### PR TITLE
Generate and commit the OpenAPI schema with enriched metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
 
       - run: uv run pytest
 
+      - run: make openapi
+
+      - run: git diff --exit-code openapi.json
+
       - uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           globs: '**/*.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - `make build` : build l'image Docker
 - `make test` : pytest
 - `make lint` / `make fmt` : ruff check+format (vérification / correction)
+- `make openapi` : régénère `openapi.json` (obligatoire après tout changement de routes ou de schémas, la CI vérifie qu'il est à jour)
 
 ## Sans Docker (fallback)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build up down logs test lint fmt
+.PHONY: build up down logs test lint fmt openapi
 
 build:
 	docker compose build
@@ -22,3 +22,6 @@ lint:
 fmt:
 	uv run ruff check --fix .
 	uv run ruff format .
+
+openapi:
+	uv run python -c "import json; from app.main import app; print(json.dumps(app.openapi(), indent=2))" > openapi.json

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ A devcontainer is provided (`.devcontainer/`) based on the compose `api` service
 - `DELETE /stufflists/{id}` — delete one
 
 Data is stored in SQLite (`tout_pris.db` by default, override with `DATABASE_URL`).
+
+## OpenAPI
+
+FastAPI generates the OpenAPI schema automatically. With the server running it is served at `/openapi.json`, with interactive docs at `/docs` (Swagger UI) and `/redoc` (ReDoc).
+
+The schema is also committed as [`openapi.json`](openapi.json) and regenerated with `make openapi`. CI fails if the committed file drifts from the code, so regenerate it whenever routes or schemas change.

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+from importlib.metadata import version
 
 from fastapi import FastAPI
 
@@ -12,10 +13,15 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="Tout Pris API", lifespan=lifespan)
+app = FastAPI(
+    title="Tout Pris API",
+    description="Backend API of the Tout Pris project: manage stufflists.",
+    version=version("tout-pris-back"),
+    lifespan=lifespan,
+)
 app.include_router(stufflists.router)
 
 
-@app.get("/health")
+@app.get("/health", summary="Health check", tags=["monitoring"])
 def health():
     return {"status": "ok"}

--- a/app/routers/stufflists.py
+++ b/app/routers/stufflists.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/stufflists", tags=["stufflists"])
 DbSession = Annotated[Session, Depends(get_db)]
 
 
-@router.post("", response_model=StuffListRead, status_code=201)
+@router.post("", response_model=StuffListRead, status_code=201, summary="Create a stufflist")
 def create_stufflist(payload: StuffListCreate, db: DbSession):
     stufflist = StuffList(name=payload.name)
     db.add(stufflist)
@@ -22,12 +22,12 @@ def create_stufflist(payload: StuffListCreate, db: DbSession):
     return stufflist
 
 
-@router.get("", response_model=list[StuffListRead])
+@router.get("", response_model=list[StuffListRead], summary="List all stufflists")
 def list_stufflists(db: DbSession):
     return db.scalars(select(StuffList)).all()
 
 
-@router.get("/{stufflist_id}", response_model=StuffListRead)
+@router.get("/{stufflist_id}", response_model=StuffListRead, summary="Get a stufflist by id")
 def get_stufflist(stufflist_id: int, db: DbSession):
     stufflist = db.get(StuffList, stufflist_id)
     if stufflist is None:
@@ -35,7 +35,7 @@ def get_stufflist(stufflist_id: int, db: DbSession):
     return stufflist
 
 
-@router.delete("/{stufflist_id}", status_code=204)
+@router.delete("/{stufflist_id}", status_code=204, summary="Delete a stufflist")
 def delete_stufflist(stufflist_id: int, db: DbSession):
     stufflist = db.get(StuffList, stufflist_id)
     if stufflist is None:

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,256 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Tout Pris API",
+    "description": "Backend API of the Tout Pris project: manage stufflists.",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/stufflists": {
+      "get": {
+        "tags": [
+          "stufflists"
+        ],
+        "summary": "List all stufflists",
+        "operationId": "list_stufflists_stufflists_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StuffListRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Stufflists Stufflists Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "stufflists"
+        ],
+        "summary": "Create a stufflist",
+        "operationId": "create_stufflist_stufflists_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StuffListCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StuffListRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/stufflists/{stufflist_id}": {
+      "get": {
+        "tags": [
+          "stufflists"
+        ],
+        "summary": "Get a stufflist by id",
+        "operationId": "get_stufflist_stufflists__stufflist_id__get",
+        "parameters": [
+          {
+            "name": "stufflist_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stufflist Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StuffListRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "stufflists"
+        ],
+        "summary": "Delete a stufflist",
+        "operationId": "delete_stufflist_stufflists__stufflist_id__delete",
+        "parameters": [
+          {
+            "name": "stufflist_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Stufflist Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "tags": [
+          "monitoring"
+        ],
+        "summary": "Health check",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "StuffListCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "StuffListCreate"
+      },
+      "StuffListRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "StuffListRead"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #5

No new library needed — FastAPI already generates the schema at runtime (`/openapi.json`, `/docs`, `/redoc`). This PR turns it into a versioned artifact and enriches it:

- **App metadata**: description added, and `version` read from the installed package via `importlib.metadata`, so it always follows `pyproject.toml`
- **Route documentation**: a `summary` on every endpoint (visible in Swagger UI and the schema), `monitoring` tag on `/health`
- **`make openapi`**: dumps `app.openapi()` to `openapi.json` without starting a server; the file is committed at the repo root
- **CI freshness check**: the Lint & Test job runs `make openapi` then `git diff --exit-code openapi.json`, so the committed schema can never drift from the code
- **Docs**: README gets an OpenAPI section (interactive docs URLs + regeneration workflow), CLAUDE.md documents the make target

Validated locally: schema generated, ruff clean, 7 tests green, markdownlint clean, workflow YAML checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_