### PR TITLE
Install project Claude skills and plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/api-designer/SKILL.md
+++ b/.claude/skills/api-designer/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: api-designer
+description: Use when designing REST or GraphQL APIs, creating OpenAPI specifications, or planning API architecture. Invoke for resource modeling, versioning strategies, pagination patterns, error handling standards.
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: api-architecture
+  triggers: API design, REST API, OpenAPI, API specification, API architecture, resource modeling, API versioning, GraphQL schema, API documentation
+  role: architect
+  scope: design
+  output-format: specification
+  related-skills: graphql-architect, fastapi-expert, nestjs-expert, spring-boot-engineer, security-reviewer
+---
+
+# API Designer
+
+Senior API architect specializing in REST and GraphQL APIs with comprehensive OpenAPI 3.1 specifications.
+
+## Core Workflow
+
+1. **Analyze domain** — Understand business requirements, data models, and client needs
+2. **Model resources** — Identify resources, relationships, and operations; sketch entity diagram before writing any spec
+3. **Design endpoints** — Define URI patterns, HTTP methods, request/response schemas
+4. **Specify contract** — Create OpenAPI 3.1 spec; validate before proceeding: `npx @redocly/cli lint openapi.yaml`
+5. **Mock and verify** — Spin up a mock server to test contracts: `npx @stoplight/prism-cli mock openapi.yaml`
+6. **Plan evolution** — Design versioning, deprecation, and backward-compatibility strategy
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| REST Patterns | `references/rest-patterns.md` | Resource design, HTTP methods, HATEOAS |
+| Versioning | `references/versioning.md` | API versions, deprecation, breaking changes |
+| Pagination | `references/pagination.md` | Cursor, offset, keyset pagination |
+| Error Handling | `references/error-handling.md` | Error responses, RFC 7807, status codes |
+| OpenAPI | `references/openapi.md` | OpenAPI 3.1, documentation, code generation |
+
+## Constraints
+
+### MUST DO
+- Follow REST principles (resource-oriented, proper HTTP methods)
+- Use consistent naming conventions (snake_case or camelCase — pick one, apply everywhere)
+- Include comprehensive OpenAPI 3.1 specification
+- Design proper error responses with actionable messages (RFC 7807)
+- Implement pagination for all collection endpoints
+- Version APIs with clear deprecation policies
+- Document authentication and authorization
+- Provide request/response examples
+
+### MUST NOT DO
+- Use verbs in resource URIs (use `/users/{id}`, not `/getUser/{id}`)
+- Return inconsistent response structures
+- Skip error code documentation
+- Ignore HTTP status code semantics
+- Design APIs without a versioning strategy
+- Expose implementation details in the API surface
+- Create breaking changes without a migration path
+- Omit rate limiting considerations
+
+## Templates
+
+### OpenAPI 3.1 Resource Endpoint (copy-paste starter)
+
+```yaml
+openapi: "3.1.0"
+info:
+  title: Example API
+  version: "1.1.0"
+paths:
+  /users:
+    get:
+      summary: List users
+      operationId: listUsers
+      tags: [Users]
+      parameters:
+        - name: cursor
+          in: query
+          schema: { type: string }
+          description: Opaque cursor for pagination
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20, maximum: 100 }
+      responses:
+        "200":
+          description: Paginated list of users
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, pagination]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: "#/components/schemas/User" }
+                  pagination:
+                    $ref: "#/components/schemas/CursorPage"
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "429": { $ref: "#/components/responses/TooManyRequests" }
+  /users/{id}:
+    get:
+      summary: Get a user
+      operationId: getUser
+      tags: [Users]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, email, created_at]
+      properties:
+        id:    { type: string, format: uuid, readOnly: true }
+        email: { type: string, format: email }
+        name:  { type: string }
+        created_at: { type: string, format: date-time, readOnly: true }
+
+    CursorPage:
+      type: object
+      required: [next_cursor, has_more]
+      properties:
+        next_cursor: { type: string, nullable: true }
+        has_more:    { type: boolean }
+
+    Problem:                       # RFC 7807 Problem Details
+      type: object
+      required: [type, title, status]
+      properties:
+        type:     { type: string, format: uri, example: "https://api.example.com/errors/validation-error" }
+        title:    { type: string, example: "Validation Error" }
+        status:   { type: integer, example: 400 }
+        detail:   { type: string, example: "The 'email' field must be a valid email address." }
+        instance: { type: string, format: uri, example: "/users/req-abc123" }
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/problem+json:
+          schema: { $ref: "#/components/schemas/Problem" }
+    Unauthorized:
+      description: Missing or invalid authentication
+      content:
+        application/problem+json:
+          schema: { $ref: "#/components/schemas/Problem" }
+    NotFound:
+      description: Resource not found
+      content:
+        application/problem+json:
+          schema: { $ref: "#/components/schemas/Problem" }
+    TooManyRequests:
+      description: Rate limit exceeded
+      headers:
+        Retry-After: { schema: { type: integer } }
+      content:
+        application/problem+json:
+          schema: { $ref: "#/components/schemas/Problem" }
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+security:
+  - BearerAuth: []
+```
+
+### RFC 7807 Error Response (copy-paste)
+
+```json
+{
+  "type": "https://api.example.com/errors/validation-error",
+  "title": "Validation Error",
+  "status": 422,
+  "detail": "The 'email' field must be a valid email address.",
+  "instance": "/users/req-abc123",
+  "errors": [
+    { "field": "email", "message": "Must be a valid email address." }
+  ]
+}
+```
+
+- Always use `Content-Type: application/problem+json` for error responses.
+- `type` must be a stable, documented URI — never a generic string.
+- `detail` must be human-readable and actionable.
+- Extend with `errors[]` for field-level validation failures.
+
+## Output Checklist
+
+When delivering an API design, provide:
+1. Resource model and relationships (diagram or table)
+2. Endpoint specifications with URIs and HTTP methods
+3. OpenAPI 3.1 specification (YAML)
+4. Authentication and authorization flows
+5. Error response catalog (all 4xx/5xx with `type` URIs)
+6. Pagination and filtering patterns
+7. Versioning and deprecation strategy
+8. Validation result: `npx @redocly/cli lint openapi.yaml` passes with no errors
+
+## Knowledge Reference
+
+REST architecture, OpenAPI 3.1, GraphQL, HTTP semantics, JSON:API, HATEOAS, OAuth 2.0, JWT, RFC 7807 Problem Details, API versioning patterns, pagination strategies, rate limiting, webhook design, SDK generation
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/api-architecture/api-designer/)

--- a/.claude/skills/api-designer/references/error-handling.md
+++ b/.claude/skills/api-designer/references/error-handling.md
@@ -1,0 +1,541 @@
+# API Error Handling
+
+## Error Response Design
+
+Consistent, informative error responses are critical for API usability.
+
+## Standard Error Format
+
+### Basic Error Response
+
+```json
+{
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "User with ID 123 not found",
+    "details": null
+  }
+}
+```
+
+### RFC 7807 Problem Details
+
+Standardized error format (application/problem+json):
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "https://api.example.com/errors/resource-not-found",
+  "title": "Resource Not Found",
+  "status": 404,
+  "detail": "User with ID 123 does not exist",
+  "instance": "/users/123"
+}
+```
+
+**Fields:**
+- `type` - URI reference identifying error type
+- `title` - Short, human-readable summary
+- `status` - HTTP status code
+- `detail` - Human-readable explanation specific to this occurrence
+- `instance` - URI reference for this specific occurrence
+
+### Extended Error Response
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "field": "email",
+        "code": "INVALID_FORMAT",
+        "message": "Email must be a valid email address"
+      },
+      {
+        "field": "age",
+        "code": "OUT_OF_RANGE",
+        "message": "Age must be between 18 and 120"
+      }
+    ],
+    "request_id": "req_123456",
+    "timestamp": "2024-01-15T10:30:00Z",
+    "documentation_url": "https://api.example.com/docs/errors#validation-error"
+  }
+}
+```
+
+## Error Categories
+
+### 1. Validation Errors (400 Bad Request)
+
+Client sent invalid data.
+
+```http
+POST /users
+Content-Type: application/json
+
+{
+  "name": "",
+  "email": "invalid-email",
+  "age": 15
+}
+
+Response: 400 Bad Request
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "field": "name",
+        "code": "REQUIRED",
+        "message": "Name is required"
+      },
+      {
+        "field": "email",
+        "code": "INVALID_FORMAT",
+        "message": "Email must be a valid email address"
+      },
+      {
+        "field": "age",
+        "code": "OUT_OF_RANGE",
+        "message": "Age must be at least 18",
+        "constraints": {
+          "min": 18,
+          "max": 120
+        }
+      }
+    ]
+  }
+}
+```
+
+### 2. Authentication Errors (401 Unauthorized)
+
+Missing or invalid authentication credentials.
+
+```http
+GET /users/123
+Authorization: Bearer invalid_token
+
+Response: 401 Unauthorized
+WWW-Authenticate: Bearer realm="api", error="invalid_token"
+
+{
+  "error": {
+    "code": "INVALID_TOKEN",
+    "message": "The access token is invalid or has expired",
+    "details": {
+      "reason": "token_expired",
+      "expired_at": "2024-01-15T10:00:00Z"
+    }
+  }
+}
+```
+
+**Common auth error codes:**
+- `MISSING_TOKEN` - No auth token provided
+- `INVALID_TOKEN` - Token is malformed or invalid
+- `EXPIRED_TOKEN` - Token has expired
+- `REVOKED_TOKEN` - Token has been revoked
+
+### 3. Authorization Errors (403 Forbidden)
+
+Authenticated but not authorized to perform action.
+
+```http
+DELETE /users/123
+Authorization: Bearer valid_token
+
+Response: 403 Forbidden
+{
+  "error": {
+    "code": "INSUFFICIENT_PERMISSIONS",
+    "message": "You do not have permission to delete this user",
+    "details": {
+      "required_permission": "users:delete",
+      "your_permissions": ["users:read", "users:update"]
+    }
+  }
+}
+```
+
+### 4. Not Found Errors (404 Not Found)
+
+Resource doesn't exist.
+
+```http
+GET /users/99999
+
+Response: 404 Not Found
+{
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "User with ID 99999 not found",
+    "details": {
+      "resource_type": "User",
+      "resource_id": "99999"
+    }
+  }
+}
+```
+
+### 5. Conflict Errors (409 Conflict)
+
+Request conflicts with current state.
+
+```http
+POST /users
+Content-Type: application/json
+
+{
+  "email": "existing@example.com",
+  "name": "John Doe"
+}
+
+Response: 409 Conflict
+{
+  "error": {
+    "code": "RESOURCE_ALREADY_EXISTS",
+    "message": "User with email 'existing@example.com' already exists",
+    "details": {
+      "field": "email",
+      "value": "existing@example.com",
+      "existing_resource": "/users/123"
+    }
+  }
+}
+```
+
+### 6. Rate Limiting (429 Too Many Requests)
+
+Client exceeded rate limit.
+
+```http
+GET /users
+
+Response: 429 Too Many Requests
+Retry-After: 60
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1705320000
+
+{
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "You have exceeded the rate limit",
+    "details": {
+      "limit": 100,
+      "window": "1 hour",
+      "retry_after": 60,
+      "reset_at": "2024-01-15T11:00:00Z"
+    }
+  }
+}
+```
+
+### 7. Server Errors (500 Internal Server Error)
+
+Unexpected server error.
+
+```http
+GET /users/123
+
+Response: 500 Internal Server Error
+{
+  "error": {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "An unexpected error occurred. Please try again later.",
+    "request_id": "req_123456",
+    "timestamp": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+**Never expose:**
+- Stack traces
+- Database errors
+- Internal paths
+- Sensitive configuration
+
+### 8. Service Unavailable (503 Service Unavailable)
+
+Service temporarily unavailable.
+
+```http
+GET /users
+
+Response: 503 Service Unavailable
+Retry-After: 300
+
+{
+  "error": {
+    "code": "SERVICE_UNAVAILABLE",
+    "message": "Service is temporarily unavailable due to maintenance",
+    "details": {
+      "retry_after": 300,
+      "maintenance_end": "2024-01-15T12:00:00Z"
+    }
+  }
+}
+```
+
+## Error Code Catalog
+
+Define standard error codes for your API:
+
+```json
+{
+  "VALIDATION_ERROR": {
+    "status": 400,
+    "description": "Request validation failed",
+    "subcodes": {
+      "REQUIRED": "Required field is missing",
+      "INVALID_FORMAT": "Field has invalid format",
+      "OUT_OF_RANGE": "Value is out of allowed range",
+      "INVALID_ENUM": "Value is not in allowed set"
+    }
+  },
+  "AUTHENTICATION_ERROR": {
+    "status": 401,
+    "description": "Authentication failed",
+    "subcodes": {
+      "MISSING_TOKEN": "No authentication token provided",
+      "INVALID_TOKEN": "Token is invalid",
+      "EXPIRED_TOKEN": "Token has expired"
+    }
+  },
+  "AUTHORIZATION_ERROR": {
+    "status": 403,
+    "description": "Insufficient permissions",
+    "subcodes": {
+      "INSUFFICIENT_PERMISSIONS": "Missing required permission",
+      "RESOURCE_FORBIDDEN": "Access to resource is forbidden"
+    }
+  },
+  "RESOURCE_NOT_FOUND": {
+    "status": 404,
+    "description": "Resource not found"
+  },
+  "CONFLICT_ERROR": {
+    "status": 409,
+    "description": "Request conflicts with current state",
+    "subcodes": {
+      "RESOURCE_ALREADY_EXISTS": "Resource already exists",
+      "CONCURRENT_MODIFICATION": "Resource was modified by another request"
+    }
+  },
+  "RATE_LIMIT_EXCEEDED": {
+    "status": 429,
+    "description": "Rate limit exceeded"
+  },
+  "INTERNAL_SERVER_ERROR": {
+    "status": 500,
+    "description": "Internal server error"
+  }
+}
+```
+
+## Validation Error Details
+
+### Field-Level Validation
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "field": "credit_card.number",
+        "code": "INVALID_FORMAT",
+        "message": "Credit card number must be 16 digits",
+        "value_provided": "1234",
+        "constraints": {
+          "pattern": "^[0-9]{16}$"
+        }
+      },
+      {
+        "field": "items[0].quantity",
+        "code": "OUT_OF_RANGE",
+        "message": "Quantity must be at least 1",
+        "value_provided": 0,
+        "constraints": {
+          "min": 1,
+          "max": 1000
+        }
+      }
+    ]
+  }
+}
+```
+
+### Cross-Field Validation
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request validation failed",
+    "details": [
+      {
+        "fields": ["start_date", "end_date"],
+        "code": "INVALID_RANGE",
+        "message": "End date must be after start date",
+        "values_provided": {
+          "start_date": "2024-01-20",
+          "end_date": "2024-01-15"
+        }
+      }
+    ]
+  }
+}
+```
+
+## Request ID Tracking
+
+Always include request ID for debugging:
+
+```http
+Response Headers:
+X-Request-ID: req_abc123
+
+Response Body:
+{
+  "error": {
+    "code": "INTERNAL_SERVER_ERROR",
+    "message": "An unexpected error occurred",
+    "request_id": "req_abc123"
+  }
+}
+```
+
+Clients can reference request ID in support tickets.
+
+## Error Documentation
+
+Document all possible errors for each endpoint:
+
+```yaml
+/users/{id}:
+  get:
+    responses:
+      '200':
+        description: Success
+      '401':
+        description: Authentication failed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error'
+            examples:
+              missing_token:
+                value:
+                  error:
+                    code: MISSING_TOKEN
+                    message: No authentication token provided
+              invalid_token:
+                value:
+                  error:
+                    code: INVALID_TOKEN
+                    message: Token is invalid or expired
+      '404':
+        description: User not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error'
+            examples:
+              not_found:
+                value:
+                  error:
+                    code: RESOURCE_NOT_FOUND
+                    message: User with ID 123 not found
+```
+
+## Retry Guidance
+
+Help clients understand if they should retry:
+
+```json
+{
+  "error": {
+    "code": "SERVICE_UNAVAILABLE",
+    "message": "Service temporarily unavailable",
+    "retry": {
+      "retryable": true,
+      "retry_after": 60,
+      "max_retries": 3,
+      "backoff": "exponential"
+    }
+  }
+}
+```
+
+### Retryable Errors
+
+- 408 Request Timeout
+- 429 Too Many Requests (with Retry-After)
+- 500 Internal Server Error (sometimes)
+- 502 Bad Gateway
+- 503 Service Unavailable
+- 504 Gateway Timeout
+
+### Non-Retryable Errors
+
+- 400 Bad Request
+- 401 Unauthorized
+- 403 Forbidden
+- 404 Not Found
+- 409 Conflict
+- 422 Unprocessable Entity
+
+## Multi-Language Support
+
+Support error messages in multiple languages:
+
+```http
+GET /users/invalid
+Accept-Language: es
+
+Response: 404 Not Found
+Content-Language: es
+{
+  "error": {
+    "code": "RESOURCE_NOT_FOUND",
+    "message": "Usuario con ID 'invalid' no encontrado"
+  }
+}
+```
+
+Always include `code` so clients can implement their own translations.
+
+## Best Practices
+
+1. **Use standard HTTP status codes** - Don't return 200 for errors
+2. **Include machine-readable codes** - Error codes for client logic
+3. **Provide human-readable messages** - Clear explanations
+4. **Be specific but safe** - Don't expose sensitive information
+5. **Include request ID** - For tracking and debugging
+6. **Document all errors** - Every possible error for each endpoint
+7. **Be consistent** - Same format across all endpoints
+8. **Help clients retry** - Indicate if error is retryable
+9. **Validate early** - Return validation errors immediately
+10. **Log errors server-side** - Track errors for monitoring
+
+## Anti-Patterns
+
+Avoid these mistakes:
+
+- **Generic error messages** - "Error occurred" without details
+- **Exposing stack traces** - Security risk
+- **Inconsistent error format** - Different structure per endpoint
+- **Missing error codes** - Only human-readable messages
+- **Wrong status codes** - Returning 200 with error in body
+- **No request ID** - Makes debugging impossible
+- **Undocumented errors** - Clients don't know what to expect
+- **Too much information** - Exposing internal implementation

--- a/.claude/skills/api-designer/references/openapi.md
+++ b/.claude/skills/api-designer/references/openapi.md
@@ -1,0 +1,824 @@
+# OpenAPI 3.1 Specification
+
+## What is OpenAPI?
+
+OpenAPI (formerly Swagger) is a standard for describing REST APIs. It enables:
+- Interactive documentation
+- Code generation (SDKs, clients, servers)
+- API testing tools
+- Contract validation
+- Mock servers
+
+## Basic Structure
+
+### Minimal OpenAPI 3.1 Spec
+
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 1.0.0
+  description: A sample API
+  contact:
+    name: API Support
+    email: support@example.com
+    url: https://example.com/support
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production server
+  - url: https://staging-api.example.com/v1
+    description: Staging server
+  - url: http://localhost:3000/v1
+    description: Local development
+
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Retrieve a paginated list of users
+      operationId: listUsers
+      tags:
+        - Users
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - email
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 123
+        email:
+          type: string
+          format: email
+          example: john@example.com
+        name:
+          type: string
+          example: John Doe
+```
+
+## Info Object
+
+Metadata about the API:
+
+```yaml
+info:
+  title: Users API
+  version: 1.0.0
+  description: |
+    # Users API
+
+    This API manages user accounts and profiles.
+
+    ## Features
+    - User CRUD operations
+    - Authentication with JWT
+    - Role-based authorization
+
+  termsOfService: https://example.com/terms
+
+  contact:
+    name: API Support Team
+    email: api-support@example.com
+    url: https://example.com/support
+
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+  x-api-id: users-api-v1
+  x-audience: external
+```
+
+## Servers
+
+Define API base URLs:
+
+```yaml
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+    variables:
+      version:
+        default: v1
+        enum:
+          - v1
+          - v2
+
+  - url: https://{environment}.example.com/v1
+    description: Dynamic environment
+    variables:
+      environment:
+        default: api
+        enum:
+          - api
+          - staging
+          - dev
+```
+
+## Paths and Operations
+
+### Complete Endpoint Example
+
+```yaml
+paths:
+  /users:
+    get:
+      summary: List users
+      description: Retrieve a paginated list of users with optional filtering
+      operationId: listUsers
+      tags:
+        - Users
+
+      parameters:
+        - name: offset
+          in: query
+          description: Number of items to skip
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+
+        - name: limit
+          in: query
+          description: Maximum number of items to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+
+        - name: status
+          in: query
+          description: Filter by user status
+          required: false
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+              - suspended
+
+      security:
+        - bearerAuth: []
+
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserListResponse'
+              examples:
+                success:
+                  $ref: '#/components/examples/UserListSuccess'
+
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
+
+    post:
+      summary: Create user
+      description: Create a new user account
+      operationId: createUser
+      tags:
+        - Users
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+            examples:
+              basic:
+                $ref: '#/components/examples/CreateUserBasic'
+
+      responses:
+        '201':
+          description: User created successfully
+          headers:
+            Location:
+              description: URL of the created user
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+        '400':
+          $ref: '#/components/responses/ValidationError'
+
+        '409':
+          description: User already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /users/{userId}:
+    parameters:
+      - name: userId
+        in: path
+        description: User ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+
+    get:
+      summary: Get user
+      description: Retrieve a specific user by ID
+      operationId: getUser
+      tags:
+        - Users
+
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    put:
+      summary: Update user
+      description: Replace user data
+      operationId: updateUser
+      tags:
+        - Users
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequest'
+
+      responses:
+        '200':
+          description: User updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      summary: Delete user
+      description: Delete a user account
+      operationId: deleteUser
+      tags:
+        - Users
+
+      responses:
+        '204':
+          description: User deleted successfully
+
+        '404':
+          $ref: '#/components/responses/NotFound'
+```
+
+## Components
+
+Reusable components for your API spec.
+
+### Schemas
+
+```yaml
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+        - email
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
+          example: 123
+        email:
+          type: string
+          format: email
+          example: john@example.com
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          example: John Doe
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+            - suspended
+          default: active
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+          example: "2024-01-15T10:30:00Z"
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    CreateUserRequest:
+      type: object
+      required:
+        - email
+        - name
+      properties:
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    UserListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    Pagination:
+      type: object
+      properties:
+        offset:
+          type: integer
+          minimum: 0
+        limit:
+          type: integer
+          minimum: 1
+        total:
+          type: integer
+          minimum: 0
+        has_more:
+          type: boolean
+
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              example: RESOURCE_NOT_FOUND
+            message:
+              type: string
+              example: User with ID 123 not found
+            details:
+              type: object
+            request_id:
+              type: string
+              example: req_abc123
+```
+
+### Security Schemes
+
+```yaml
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT access token
+
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API key for authentication
+
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/oauth/authorize
+          tokenUrl: https://auth.example.com/oauth/token
+          scopes:
+            users:read: Read user data
+            users:write: Create and update users
+            users:delete: Delete users
+```
+
+Apply security globally or per-operation:
+
+```yaml
+# Global security
+security:
+  - bearerAuth: []
+
+# Or per-operation
+paths:
+  /users:
+    get:
+      security:
+        - bearerAuth: []
+        - apiKey: []  # Alternative auth method
+```
+
+### Responses
+
+Reusable response definitions:
+
+```yaml
+components:
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: RESOURCE_NOT_FOUND
+              message: The requested resource was not found
+
+    Unauthorized:
+      description: Authentication required
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+          description: Authentication method
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    ValidationError:
+      description: Validation failed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: VALIDATION_ERROR
+              message: Request validation failed
+              details:
+                - field: email
+                  code: INVALID_FORMAT
+                  message: Email must be a valid email address
+
+    RateLimitExceeded:
+      description: Rate limit exceeded
+      headers:
+        X-RateLimit-Limit:
+          schema:
+            type: integer
+          description: Request limit per hour
+        X-RateLimit-Remaining:
+          schema:
+            type: integer
+          description: Remaining requests
+        X-RateLimit-Reset:
+          schema:
+            type: integer
+            format: int64
+          description: Time when limit resets (Unix timestamp)
+        Retry-After:
+          schema:
+            type: integer
+          description: Seconds to wait before retry
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+```
+
+### Examples
+
+```yaml
+components:
+  examples:
+    UserListSuccess:
+      summary: Successful user list response
+      value:
+        data:
+          - id: 1
+            email: john@example.com
+            name: John Doe
+            status: active
+            created_at: "2024-01-15T10:30:00Z"
+          - id: 2
+            email: jane@example.com
+            name: Jane Smith
+            status: active
+            created_at: "2024-01-16T14:20:00Z"
+        pagination:
+          offset: 0
+          limit: 20
+          total: 150
+          has_more: true
+
+    CreateUserBasic:
+      summary: Create user with minimal fields
+      value:
+        email: newuser@example.com
+        name: New User
+```
+
+## Data Types
+
+### Primitive Types
+
+```yaml
+# String
+type: string
+example: "Hello World"
+
+# String with format
+type: string
+format: email
+example: "user@example.com"
+
+# Integer
+type: integer
+format: int64
+example: 123
+
+# Number (float)
+type: number
+format: double
+example: 99.99
+
+# Boolean
+type: boolean
+example: true
+
+# Date-time
+type: string
+format: date-time
+example: "2024-01-15T10:30:00Z"
+
+# Date
+type: string
+format: date
+example: "2024-01-15"
+
+# UUID
+type: string
+format: uuid
+example: "550e8400-e29b-41d4-a716-446655440000"
+
+# URI
+type: string
+format: uri
+example: "https://example.com/users/123"
+```
+
+### Arrays
+
+```yaml
+type: array
+items:
+  type: string
+minItems: 1
+maxItems: 10
+uniqueItems: true
+example: ["tag1", "tag2", "tag3"]
+
+# Array of objects
+type: array
+items:
+  $ref: '#/components/schemas/User'
+```
+
+### Objects
+
+```yaml
+type: object
+required:
+  - name
+  - email
+properties:
+  name:
+    type: string
+  email:
+    type: string
+    format: email
+  age:
+    type: integer
+    minimum: 0
+    maximum: 120
+
+# Additional properties
+additionalProperties: false  # Strict - no extra properties
+additionalProperties: true   # Allow any extra properties
+additionalProperties:        # Extra properties must be strings
+  type: string
+```
+
+### Enums
+
+```yaml
+type: string
+enum:
+  - active
+  - inactive
+  - suspended
+default: active
+```
+
+### OneOf / AnyOf / AllOf
+
+```yaml
+# OneOf - exactly one schema matches
+oneOf:
+  - $ref: '#/components/schemas/CreditCard'
+  - $ref: '#/components/schemas/BankAccount'
+
+# AnyOf - one or more schemas match
+anyOf:
+  - $ref: '#/components/schemas/User'
+  - $ref: '#/components/schemas/Organization'
+
+# AllOf - all schemas must match (inheritance)
+allOf:
+  - $ref: '#/components/schemas/BaseUser'
+  - type: object
+    properties:
+      admin_level:
+        type: integer
+```
+
+## Validation
+
+### String Validation
+
+```yaml
+type: string
+minLength: 1
+maxLength: 100
+pattern: "^[a-zA-Z0-9_-]+$"
+format: email
+```
+
+### Number Validation
+
+```yaml
+type: integer
+minimum: 0
+maximum: 100
+exclusiveMinimum: true  # > 0 instead of >= 0
+multipleOf: 5
+```
+
+### Array Validation
+
+```yaml
+type: array
+minItems: 1
+maxItems: 10
+uniqueItems: true
+```
+
+## Tags
+
+Organize endpoints into logical groups:
+
+```yaml
+tags:
+  - name: Users
+    description: User management operations
+  - name: Orders
+    description: Order management
+  - name: Products
+    description: Product catalog
+
+paths:
+  /users:
+    get:
+      tags:
+        - Users
+```
+
+## Documentation
+
+### Markdown Support
+
+```yaml
+description: |
+  # User Management
+
+  This endpoint allows you to manage users.
+
+  ## Features
+  - Create users
+  - Update profiles
+  - Delete accounts
+
+  ## Authentication
+  Requires JWT bearer token.
+
+  ## Example
+  ```json
+  {
+    "name": "John Doe",
+    "email": "john@example.com"
+  }
+  ```
+```
+
+## Code Generation
+
+Generate SDKs from OpenAPI spec:
+
+```bash
+# Generate TypeScript client
+openapi-generator-cli generate \
+  -i openapi.yaml \
+  -g typescript-axios \
+  -o ./client
+
+# Generate Python client
+openapi-generator-cli generate \
+  -i openapi.yaml \
+  -g python \
+  -o ./python-client
+
+# Generate server stub
+openapi-generator-cli generate \
+  -i openapi.yaml \
+  -g nodejs-express-server \
+  -o ./server
+```
+
+## Validation Tools
+
+Validate OpenAPI spec:
+
+```bash
+# Using Swagger CLI
+swagger-cli validate openapi.yaml
+
+# Using Spectral (advanced linting)
+spectral lint openapi.yaml
+```
+
+## Best Practices
+
+1. **Use components** - Reuse schemas, responses, parameters
+2. **Add examples** - Include realistic examples for all schemas
+3. **Document thoroughly** - Every endpoint, parameter, response
+4. **Version your spec** - Track changes to the specification
+5. **Validate regularly** - Use tools to catch errors
+6. **Use $ref** - Reference components instead of duplicating
+7. **Include error responses** - Document all possible errors
+8. **Add operationId** - Unique ID for each operation (for code gen)
+9. **Tag endpoints** - Organize into logical groups
+10. **Provide security schemes** - Document authentication clearly

--- a/.claude/skills/api-designer/references/pagination.md
+++ b/.claude/skills/api-designer/references/pagination.md
@@ -1,0 +1,494 @@
+# Pagination Patterns
+
+## Why Paginate?
+
+Large collections can't be returned all at once due to:
+- Performance (slow queries, large payloads)
+- Memory constraints (server and client)
+- Network timeouts
+- Poor user experience
+
+Always paginate collection endpoints.
+
+## Pagination Strategies
+
+### 1. Offset-Based Pagination
+
+Most common and intuitive. Uses `offset` (skip) and `limit` (page size).
+
+**Request:**
+```http
+GET /users?offset=20&limit=10
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {"id": 21, "name": "User 21"},
+    {"id": 22, "name": "User 22"}
+  ],
+  "pagination": {
+    "offset": 20,
+    "limit": 10,
+    "total": 150,
+    "has_more": true
+  },
+  "links": {
+    "first": "/users?offset=0&limit=10",
+    "prev": "/users?offset=10&limit=10",
+    "next": "/users?offset=30&limit=10",
+    "last": "/users?offset=140&limit=10"
+  }
+}
+```
+
+**Advantages:**
+- Simple to implement
+- Easy to understand
+- Random access (jump to any page)
+- Shows total count
+
+**Disadvantages:**
+- Performance degrades with large offsets (database scans many rows)
+- Inconsistent results if data changes during pagination
+- Inefficient for real-time data
+- Database must count total rows (expensive)
+
+**Use when:**
+- Small to medium datasets
+- Data doesn't change frequently
+- Need random page access
+- Need total count
+
+### 2. Page-Based Pagination
+
+Simplified offset pagination using page numbers.
+
+**Request:**
+```http
+GET /users?page=3&per_page=10
+```
+
+**Response:**
+```json
+{
+  "data": [...],
+  "pagination": {
+    "page": 3,
+    "per_page": 10,
+    "total_pages": 15,
+    "total_count": 150
+  },
+  "links": {
+    "first": "/users?page=1&per_page=10",
+    "prev": "/users?page=2&per_page=10",
+    "next": "/users?page=4&per_page=10",
+    "last": "/users?page=15&per_page=10"
+  }
+}
+```
+
+**Calculation:**
+- `offset = (page - 1) * per_page`
+- `total_pages = ceil(total_count / per_page)`
+
+**Same pros/cons as offset-based, but:**
+- More intuitive for users (page 1, page 2)
+- Common in web applications
+
+### 3. Cursor-Based Pagination
+
+Uses an opaque cursor (pointer) to the next set of results.
+
+**Request:**
+```http
+GET /users?limit=10
+GET /users?cursor=eyJpZCI6MTIzfQ&limit=10
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {"id": 21, "name": "User 21"},
+    {"id": 22, "name": "User 22"}
+  ],
+  "pagination": {
+    "next_cursor": "eyJpZCI6MzB9",
+    "prev_cursor": "eyJpZCI6MjB9",
+    "has_more": true
+  },
+  "links": {
+    "next": "/users?cursor=eyJpZCI6MzB9&limit=10",
+    "prev": "/users?cursor=eyJpZCI6MjB9&limit=10"
+  }
+}
+```
+
+**Cursor structure (base64 encoded):**
+```json
+{"id": 30, "sort": "created_at"}
+```
+
+**Implementation:**
+```sql
+-- First page
+SELECT * FROM users ORDER BY created_at DESC LIMIT 10;
+
+-- Next page (cursor points to last item)
+SELECT * FROM users
+WHERE created_at < '2024-01-15T10:30:00Z'
+ORDER BY created_at DESC
+LIMIT 10;
+```
+
+**Advantages:**
+- Consistent results (no skipped/duplicate items)
+- Efficient for large datasets
+- Works well with real-time data
+- No expensive COUNT query
+- Better database performance
+
+**Disadvantages:**
+- No random access (can't jump to page 10)
+- No total count
+- More complex to implement
+- Cursor is opaque (users can't modify it)
+
+**Use when:**
+- Large datasets
+- Data changes frequently
+- Infinite scroll UI
+- Real-time feeds
+- Performance is critical
+
+### 4. Keyset Pagination
+
+Similar to cursor but uses actual field values instead of opaque cursor.
+
+**Request:**
+```http
+GET /users?after_id=20&limit=10
+GET /users?after_created_at=2024-01-15T10:30:00Z&limit=10
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {"id": 21, "name": "User 21", "created_at": "2024-01-15T11:00:00Z"},
+    {"id": 22, "name": "User 22", "created_at": "2024-01-15T11:30:00Z"}
+  ],
+  "pagination": {
+    "after_id": 30,
+    "limit": 10,
+    "has_more": true
+  },
+  "links": {
+    "next": "/users?after_id=30&limit=10"
+  }
+}
+```
+
+**Implementation:**
+```sql
+SELECT * FROM users
+WHERE id > 20
+ORDER BY id ASC
+LIMIT 10;
+```
+
+**Advantages:**
+- Very efficient (uses index)
+- Transparent cursor (human readable)
+- Consistent results
+- Simple implementation
+
+**Disadvantages:**
+- Requires indexed column
+- No random access
+- Sorting limited to cursor field
+- Complex for multi-field sorting
+
+**Use when:**
+- Simple ordering (by ID, timestamp)
+- Need efficient pagination
+- Want transparent cursor
+- Have proper indexes
+
+### 5. Seek Pagination (Time-Based)
+
+Specialized keyset pagination for time-series data.
+
+**Request:**
+```http
+GET /events?since=2024-01-15T10:00:00Z&until=2024-01-15T11:00:00Z&limit=100
+```
+
+**Response:**
+```json
+{
+  "data": [...],
+  "pagination": {
+    "since": "2024-01-15T10:00:00Z",
+    "until": "2024-01-15T11:00:00Z",
+    "limit": 100,
+    "has_more": true
+  },
+  "links": {
+    "next": "/events?since=2024-01-15T11:00:00Z&until=2024-01-15T12:00:00Z&limit=100"
+  }
+}
+```
+
+**Use for:**
+- Time-series data
+- Logs and events
+- Activity streams
+- Analytics data
+
+## Default Limits
+
+Always set reasonable defaults and maximum limits:
+
+```json
+{
+  "default_limit": 20,
+  "max_limit": 100,
+  "min_limit": 1
+}
+```
+
+**Validation:**
+```http
+GET /users?limit=1000
+
+Response: 400 Bad Request
+{
+  "error": {
+    "code": "INVALID_LIMIT",
+    "message": "Limit must be between 1 and 100. Default is 20."
+  }
+}
+```
+
+## Response Format
+
+### Standard Pagination Object
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "limit": 10,
+    "offset": 20,
+    "total": 150,
+    "has_more": true,
+    "has_previous": true
+  }
+}
+```
+
+### Link Header (RFC 5988)
+
+```http
+Link: </users?offset=0&limit=10>; rel="first",
+      </users?offset=10&limit=10>; rel="prev",
+      </users?offset=30&limit=10>; rel="next",
+      </users?offset=140&limit=10>; rel="last"
+```
+
+**Used by:** GitHub API
+
+### Embedded Links
+
+```json
+{
+  "data": [...],
+  "_links": {
+    "self": { "href": "/users?offset=20&limit=10" },
+    "first": { "href": "/users?offset=0&limit=10" },
+    "prev": { "href": "/users?offset=10&limit=10" },
+    "next": { "href": "/users?offset=30&limit=10" },
+    "last": { "href": "/users?offset=140&limit=10" }
+  }
+}
+```
+
+## Sorting with Pagination
+
+Always support sorting when paginating:
+
+```http
+GET /users?sort=created_at&order=desc&limit=10
+GET /users?sort=-created_at&limit=10                    # Descending
+GET /users?sort=last_name,first_name&limit=10           # Multi-field
+```
+
+**For cursor pagination, cursor must include sort fields:**
+```json
+{
+  "cursor": {
+    "id": 123,
+    "created_at": "2024-01-15T10:30:00Z",
+    "sort_fields": ["created_at", "id"]
+  }
+}
+```
+
+## Filtering with Pagination
+
+Combine filtering with pagination:
+
+```http
+GET /users?status=active&role=admin&offset=0&limit=10
+```
+
+**Important:** Apply filters before pagination:
+1. Filter records
+2. Count filtered results
+3. Apply pagination
+4. Return paginated subset
+
+## Total Count
+
+### Include Total Count
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "total": 1523,
+    "limit": 10,
+    "offset": 20
+  }
+}
+```
+
+**Pros:**
+- Clients know total results
+- Can calculate total pages
+- Better UX (show "Page 3 of 153")
+
+**Cons:**
+- COUNT query is expensive
+- Slows down response
+- Inaccurate for large/changing datasets
+
+### Omit Total Count
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "has_more": true,
+    "limit": 10
+  }
+}
+```
+
+**Use when:**
+- Large datasets (COUNT is too slow)
+- Real-time data (count changes constantly)
+- Cursor pagination
+- Infinite scroll UI
+
+### Optional Total Count
+
+Let client request total count:
+
+```http
+GET /users?limit=10&include_total=true
+```
+
+## Edge Cases
+
+### Empty Results
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "offset": 0,
+    "limit": 10,
+    "total": 0,
+    "has_more": false
+  }
+}
+```
+
+### Last Page
+
+```json
+{
+  "data": [{"id": 150, "name": "Last User"}],
+  "pagination": {
+    "offset": 140,
+    "limit": 10,
+    "total": 150,
+    "has_more": false
+  },
+  "links": {
+    "first": "/users?offset=0&limit=10",
+    "prev": "/users?offset=130&limit=10",
+    "next": null
+  }
+}
+```
+
+### Out of Range
+
+```http
+GET /users?offset=10000&limit=10
+
+Response: 200 OK (empty results)
+{
+  "data": [],
+  "pagination": {
+    "offset": 10000,
+    "limit": 10,
+    "total": 150,
+    "has_more": false
+  }
+}
+```
+
+Or return 404 for pages that don't exist:
+```http
+GET /users?page=1000&per_page=10
+
+Response: 404 Not Found
+{
+  "error": {
+    "code": "PAGE_NOT_FOUND",
+    "message": "Page 1000 does not exist. Total pages: 15"
+  }
+}
+```
+
+## Best Practices
+
+1. **Always paginate collections** - Never return unbounded lists
+2. **Set reasonable defaults** - Default limit of 20-50 items
+3. **Enforce maximum limits** - Prevent excessive loads (max 100-1000)
+4. **Include has_more flag** - Tell clients if more results exist
+5. **Provide navigation links** - Make it easy to get next/prev pages
+6. **Document pagination** - Explain cursor format, limits, defaults
+7. **Be consistent** - Use same pagination pattern across all endpoints
+8. **Consider performance** - Choose strategy based on data size/type
+9. **Support sorting** - Let clients control result order
+10. **Handle edge cases** - Empty results, last page, invalid cursors
+
+## Comparison Matrix
+
+| Feature | Offset | Page | Cursor | Keyset |
+|---------|--------|------|--------|--------|
+| Performance | Poor for large offsets | Poor | Excellent | Excellent |
+| Random access | Yes | Yes | No | No |
+| Total count | Yes | Yes | No | Optional |
+| Consistency | Poor | Poor | Excellent | Excellent |
+| Complexity | Simple | Simple | Medium | Medium |
+| Real-time data | Poor | Poor | Excellent | Excellent |
+| Database load | High | High | Low | Low |
+| Use case | Small datasets | Web UIs | Feeds/streams | Large datasets |

--- a/.claude/skills/api-designer/references/rest-patterns.md
+++ b/.claude/skills/api-designer/references/rest-patterns.md
@@ -1,0 +1,335 @@
+# REST Design Patterns
+
+## Resource-Oriented Architecture
+
+REST APIs are built around resources, not actions. Resources are the nouns of your API.
+
+### Resource Identification
+
+**Good Resource URIs:**
+```
+GET    /users                  # Collection
+GET    /users/{id}             # Individual resource
+GET    /users/{id}/orders      # Nested collection
+POST   /users                  # Create resource
+PUT    /users/{id}             # Replace resource
+PATCH  /users/{id}             # Update resource
+DELETE /users/{id}             # Delete resource
+```
+
+**Bad Resource URIs:**
+```
+POST   /getUser                # Verb in URI
+POST   /createUser             # Verb in URI
+GET    /user?action=delete     # Action as query param
+```
+
+### Resource Naming Conventions
+
+- Use plural nouns for collections: `/users`, `/orders`, `/products`
+- Use lowercase and hyphens for readability: `/shipping-addresses`
+- Avoid deep nesting (max 2-3 levels): `/users/{id}/orders/{orderId}`
+- Use query parameters for filtering: `/users?status=active&role=admin`
+
+## HTTP Method Semantics
+
+### Safe and Idempotent Methods
+
+| Method | Safe | Idempotent | Use Case |
+|--------|------|------------|----------|
+| GET | Yes | Yes | Retrieve resource(s) |
+| POST | No | No | Create resource, non-idempotent operations |
+| PUT | No | Yes | Replace entire resource |
+| PATCH | No | No | Partial update |
+| DELETE | No | Yes | Remove resource |
+| HEAD | Yes | Yes | Get metadata only |
+| OPTIONS | Yes | Yes | Get allowed methods |
+
+### Method Usage
+
+**GET - Retrieve Resources**
+```http
+GET /users/123
+Accept: application/json
+
+Response: 200 OK
+{
+  "id": 123,
+  "name": "John Doe",
+  "email": "john@example.com",
+  "created_at": "2024-01-15T10:30:00Z"
+}
+```
+
+**POST - Create Resources**
+```http
+POST /users
+Content-Type: application/json
+
+{
+  "name": "Jane Smith",
+  "email": "jane@example.com"
+}
+
+Response: 201 Created
+Location: /users/124
+{
+  "id": 124,
+  "name": "Jane Smith",
+  "email": "jane@example.com",
+  "created_at": "2024-01-16T14:20:00Z"
+}
+```
+
+**PUT - Replace Resource**
+```http
+PUT /users/123
+Content-Type: application/json
+
+{
+  "name": "John Doe Updated",
+  "email": "john.new@example.com"
+}
+
+Response: 200 OK
+{
+  "id": 123,
+  "name": "John Doe Updated",
+  "email": "john.new@example.com",
+  "updated_at": "2024-01-17T09:15:00Z"
+}
+```
+
+**PATCH - Partial Update**
+```http
+PATCH /users/123
+Content-Type: application/json
+
+{
+  "email": "john.updated@example.com"
+}
+
+Response: 200 OK
+{
+  "id": 123,
+  "name": "John Doe",
+  "email": "john.updated@example.com",
+  "updated_at": "2024-01-17T10:00:00Z"
+}
+```
+
+**DELETE - Remove Resource**
+```http
+DELETE /users/123
+
+Response: 204 No Content
+```
+
+## HTTP Status Codes
+
+### Success Codes (2xx)
+
+- **200 OK** - Request succeeded (GET, PUT, PATCH)
+- **201 Created** - Resource created (POST), include Location header
+- **202 Accepted** - Request accepted for async processing
+- **204 No Content** - Success with no response body (DELETE)
+
+### Redirection (3xx)
+
+- **301 Moved Permanently** - Resource permanently moved
+- **302 Found** - Temporary redirect
+- **304 Not Modified** - Cached version is still valid
+
+### Client Errors (4xx)
+
+- **400 Bad Request** - Invalid request syntax or validation error
+- **401 Unauthorized** - Authentication required or failed
+- **403 Forbidden** - Authenticated but not authorized
+- **404 Not Found** - Resource doesn't exist
+- **405 Method Not Allowed** - HTTP method not supported for resource
+- **409 Conflict** - Request conflicts with current state (e.g., duplicate)
+- **422 Unprocessable Entity** - Valid syntax but semantic errors
+- **429 Too Many Requests** - Rate limit exceeded
+
+### Server Errors (5xx)
+
+- **500 Internal Server Error** - Unexpected server error
+- **502 Bad Gateway** - Invalid response from upstream server
+- **503 Service Unavailable** - Server temporarily unavailable
+- **504 Gateway Timeout** - Upstream server timeout
+
+## HATEOAS (Hypermedia)
+
+### Hypermedia-Driven APIs
+
+Include links to related resources and available actions:
+
+```json
+{
+  "id": 123,
+  "name": "John Doe",
+  "email": "john@example.com",
+  "_links": {
+    "self": { "href": "/users/123" },
+    "orders": { "href": "/users/123/orders" },
+    "update": { "href": "/users/123", "method": "PATCH" },
+    "delete": { "href": "/users/123", "method": "DELETE" }
+  }
+}
+```
+
+### HAL (Hypertext Application Language)
+
+```json
+{
+  "id": 123,
+  "name": "John Doe",
+  "_links": {
+    "self": { "href": "/users/123" }
+  },
+  "_embedded": {
+    "orders": [
+      {
+        "id": 456,
+        "total": 99.99,
+        "_links": {
+          "self": { "href": "/orders/456" }
+        }
+      }
+    ]
+  }
+}
+```
+
+## Content Negotiation
+
+### Accept Headers
+
+```http
+GET /users/123
+Accept: application/json
+
+GET /users/123
+Accept: application/xml
+
+GET /users/123
+Accept: application/hal+json
+```
+
+### Response Content-Type
+
+```http
+Content-Type: application/json; charset=utf-8
+Content-Type: application/problem+json
+Content-Type: application/hal+json
+```
+
+## Idempotency
+
+### Idempotent Operations
+
+**PUT - Always idempotent:**
+Multiple identical PUT requests produce the same result as a single request.
+
+**DELETE - Idempotent:**
+First DELETE returns 204, subsequent DELETEs return 404 (same end state).
+
+**POST - Not idempotent by default:**
+Use `Idempotency-Key` header for idempotent POST:
+
+```http
+POST /payments
+Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000
+Content-Type: application/json
+
+{
+  "amount": 100.00,
+  "currency": "USD"
+}
+```
+
+Server stores idempotency key and returns same response for duplicate requests.
+
+## Cache Control
+
+### Cache Headers
+
+```http
+Cache-Control: public, max-age=3600
+Cache-Control: private, no-cache
+Cache-Control: no-store
+ETag: "33a64df551425fcc55e4d42a148795d9f25f89d4"
+Last-Modified: Wed, 15 Jan 2024 10:30:00 GMT
+```
+
+### Conditional Requests
+
+```http
+GET /users/123
+If-None-Match: "33a64df551425fcc55e4d42a148795d9f25f89d4"
+
+Response: 304 Not Modified
+```
+
+```http
+PUT /users/123
+If-Match: "33a64df551425fcc55e4d42a148795d9f25f89d4"
+Content-Type: application/json
+
+{
+  "name": "Updated Name"
+}
+
+Response: 412 Precondition Failed (if ETag doesn't match)
+```
+
+## URI Patterns
+
+### Consistent URI Structure
+
+```
+/{version}/{resource}
+/{version}/{resource}/{id}
+/{version}/{resource}/{id}/{sub-resource}
+/{version}/{resource}/{id}/{sub-resource}/{sub-id}
+```
+
+### Query Parameters
+
+**Filtering:**
+```
+GET /users?status=active&role=admin
+GET /products?category=electronics&price_min=100&price_max=500
+```
+
+**Sorting:**
+```
+GET /users?sort=created_at
+GET /users?sort=-created_at          # Descending
+GET /users?sort=name,created_at      # Multiple fields
+```
+
+**Field Selection:**
+```
+GET /users?fields=id,name,email
+GET /users?exclude=password,social_security_number
+```
+
+**Search:**
+```
+GET /users?q=john
+GET /products?search=laptop
+```
+
+## Best Practices
+
+1. **Use nouns, not verbs** - Resources are nouns, methods are verbs
+2. **Plural collections** - Use `/users` not `/user`
+3. **Consistent naming** - Choose snake_case or camelCase and stick to it
+4. **Proper status codes** - Use appropriate HTTP status codes
+5. **Include metadata** - Pagination, filtering, sorting info in responses
+6. **Version your API** - Plan for evolution from day one
+7. **Document everything** - OpenAPI specs, examples, error codes
+8. **Security by default** - HTTPS, authentication, rate limiting
+9. **Support filtering** - Enable clients to get exactly what they need
+10. **Implement HATEOAS** - Make APIs self-documenting and discoverable

--- a/.claude/skills/api-designer/references/versioning.md
+++ b/.claude/skills/api-designer/references/versioning.md
@@ -1,0 +1,391 @@
+# API Versioning Strategies
+
+## Why Version APIs?
+
+API versioning allows you to evolve your API while maintaining backward compatibility for existing clients. Breaking changes require a new version.
+
+### Breaking Changes
+
+Changes that require a new version:
+- Removing or renaming fields
+- Changing field types (string to integer)
+- Adding required fields to requests
+- Changing response structure
+- Removing endpoints
+- Changing HTTP status codes for same scenario
+- Changing authentication mechanisms
+
+### Non-Breaking Changes
+
+Safe changes that don't require a new version:
+- Adding new endpoints
+- Adding optional request fields
+- Adding new fields to responses (clients should ignore unknown fields)
+- Fixing bugs
+- Performance improvements
+- Adding new HTTP methods to existing resources
+
+## Versioning Strategies
+
+### 1. URI Versioning
+
+Most common and visible approach. Version is part of the URL path.
+
+```http
+GET /v1/users/123
+GET /v2/users/123
+```
+
+**Advantages:**
+- Clear and visible in URLs
+- Easy to understand and implement
+- Simple routing and caching
+- Can run multiple versions simultaneously
+
+**Disadvantages:**
+- Violates REST principle (same resource, different URIs)
+- Requires updating client code to change version
+- Can lead to URI proliferation
+
+**Implementation:**
+```
+/v1/users
+/v1/products
+/v2/users      # New version with breaking changes
+/v2/products
+```
+
+### 2. Header Versioning
+
+Version specified in HTTP headers (Accept header or custom header).
+
+**Accept Header:**
+```http
+GET /users/123
+Accept: application/vnd.myapi.v1+json
+
+GET /users/123
+Accept: application/vnd.myapi.v2+json
+```
+
+**Custom Header:**
+```http
+GET /users/123
+API-Version: 1
+
+GET /users/123
+API-Version: 2
+```
+
+**Advantages:**
+- URIs remain stable
+- More RESTful (same resource, same URI)
+- Separates versioning from resource identification
+
+**Disadvantages:**
+- Less visible (harder to debug)
+- More complex routing
+- Difficult to test in browser
+- Cache complexity
+
+### 3. Query Parameter Versioning
+
+Version specified as query parameter.
+
+```http
+GET /users/123?version=1
+GET /users/123?version=2
+
+# or
+GET /users/123?api-version=1
+GET /users/123?api-version=2
+```
+
+**Advantages:**
+- Simple to implement
+- Easy to test
+- Visible in URLs
+
+**Disadvantages:**
+- Pollutes query string
+- Not semantic (version not a filter)
+- Can interfere with other query params
+
+### 4. Content Negotiation
+
+Client specifies desired version through content negotiation.
+
+```http
+GET /users/123
+Accept: application/vnd.myapi+json; version=1
+
+GET /users/123
+Accept: application/vnd.myapi+json; version=2
+```
+
+**Advantages:**
+- Very RESTful
+- Flexible content type negotiation
+- Stable URIs
+
+**Disadvantages:**
+- Complex implementation
+- Less intuitive for developers
+- Harder to test
+
+## Recommended Approach
+
+**URI versioning is recommended for most APIs** because:
+- It's the most explicit and discoverable
+- Easy to understand and debug
+- Simple to implement and maintain
+- Clear separation between versions
+
+```
+/v1/users
+/v2/users
+/v3/users
+```
+
+## Version Format
+
+### Major Versions Only
+
+Use simple major versions (v1, v2, v3) for public APIs:
+```
+/v1/users
+/v2/users
+```
+
+**Advantages:**
+- Simple and clear
+- Easy to communicate
+- Forces thoughtful breaking changes
+
+### Date-Based Versions
+
+Some APIs use dates for versions:
+```
+/2024-01-01/users
+/2024-06-15/users
+```
+
+**Used by:** Stripe, GitHub API
+
+**Advantages:**
+- Clear when version was released
+- Easy to understand timeline
+- No confusion about major/minor
+
+**Disadvantages:**
+- Less intuitive for clients
+- Harder to understand what changed
+
+## Version Lifecycle
+
+### 1. Introduction Phase
+
+New version is released alongside existing version:
+```
+/v1/users  # Still supported
+/v2/users  # New version available
+```
+
+Announce new version:
+- Blog post explaining changes
+- Migration guide
+- Breaking changes list
+- Timeline for v1 deprecation
+
+### 2. Deprecation Phase
+
+Mark old version as deprecated but keep it running:
+
+```http
+GET /v1/users/123
+
+Response:
+Deprecation: true
+Sunset: Wed, 15 Jan 2025 00:00:00 GMT
+Link: </v2/users/123>; rel="successor-version"
+
+{
+  "id": 123,
+  "name": "John Doe"
+}
+```
+
+**Deprecation Headers:**
+- `Deprecation: true` - Indicates version is deprecated
+- `Sunset: <date>` - When version will be removed (RFC 8594)
+- `Link: <url>; rel="successor-version"` - Points to new version
+
+### 3. Sunset Phase
+
+Old version is shut down on announced date.
+
+Return 410 Gone for deprecated endpoints:
+```http
+GET /v1/users/123
+
+Response: 410 Gone
+{
+  "error": {
+    "code": "VERSION_SUNSET",
+    "message": "API v1 was sunset on 2025-01-15. Please use v2.",
+    "documentation_url": "https://api.example.com/docs/migration-v1-to-v2"
+  }
+}
+```
+
+## Deprecation Policy
+
+### Recommended Timeline
+
+1. **Announce deprecation** - At least 6 months before sunset
+2. **Support period** - Run both versions for 6-12 months
+3. **Sunset date** - Clear date communicated in advance
+4. **Grace period** - 30 days of 410 Gone responses before complete shutdown
+
+### Communication Channels
+
+- API response headers
+- Email to registered developers
+- Blog posts and changelog
+- Dashboard notifications
+- Documentation updates
+- Status page announcements
+
+## Migration Strategy
+
+### Provide Migration Guide
+
+```markdown
+# Migrating from v1 to v2
+
+## Breaking Changes
+
+### User Resource Changes
+
+**v1:**
+```json
+{
+  "id": 123,
+  "name": "John Doe",
+  "email": "john@example.com"
+}
+```
+
+**v2:**
+```json
+{
+  "id": 123,
+  "first_name": "John",
+  "last_name": "Doe",
+  "email": "john@example.com"
+}
+```
+
+**Migration:**
+- Split `name` field into `first_name` and `last_name`
+- Update client code to use new fields
+```
+
+### Offer Tools
+
+- Migration scripts
+- SDK updates
+- API diff viewer
+- Compatibility layer (temporary)
+
+## Version Discovery
+
+### Root Endpoint
+
+```http
+GET /
+
+Response:
+{
+  "versions": {
+    "v1": {
+      "status": "deprecated",
+      "sunset_date": "2025-01-15",
+      "documentation_url": "https://api.example.com/docs/v1"
+    },
+    "v2": {
+      "status": "current",
+      "documentation_url": "https://api.example.com/docs/v2"
+    },
+    "v3": {
+      "status": "beta",
+      "documentation_url": "https://api.example.com/docs/v3"
+    }
+  }
+}
+```
+
+### Version Info Endpoint
+
+```http
+GET /v2/version
+
+Response:
+{
+  "version": "v2",
+  "released": "2024-01-15",
+  "status": "stable",
+  "sunset_date": null
+}
+```
+
+## OpenAPI Versioning
+
+### Separate Specs per Version
+
+```
+openapi-v1.yaml
+openapi-v2.yaml
+openapi-v3.yaml
+```
+
+Each spec is complete and independent.
+
+### Single Spec with Servers
+
+```yaml
+openapi: 3.1.0
+info:
+  title: My API
+  version: 2.0.0
+servers:
+  - url: https://api.example.com/v1
+    description: Version 1 (deprecated)
+  - url: https://api.example.com/v2
+    description: Version 2 (current)
+```
+
+## Best Practices
+
+1. **Version from day one** - Start with /v1, not /api
+2. **Major versions only** - Use v1, v2, v3 (not v1.1, v1.2)
+3. **Long deprecation periods** - Give clients time to migrate (6-12 months)
+4. **Clear communication** - Use headers, docs, emails
+5. **Maintain old versions** - Support at least 2 versions simultaneously
+6. **Document changes** - Provide detailed migration guides
+7. **Use semantic versioning** - For internal/SDK versioning
+8. **Never break without warning** - Always announce breaking changes
+9. **Provide tools** - Migration scripts, updated SDKs
+10. **Monitor usage** - Track which versions are being used
+
+## Anti-Patterns
+
+Avoid these mistakes:
+
+- **Breaking changes without version bump** - Breaks existing clients
+- **Too many versions** - Maintenance nightmare (max 2-3 active versions)
+- **Short deprecation periods** - Frustrates developers
+- **No migration path** - Makes upgrades painful
+- **Surprise sunsets** - Breaks production apps without warning
+- **Inconsistent versioning** - Different strategies for different endpoints
+- **Versioning individual endpoints** - Use consistent version across API

--- a/.claude/skills/code-reviewer/SKILL.md
+++ b/.claude/skills/code-reviewer/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: code-reviewer
+description: Analyzes code diffs and files to identify bugs, security vulnerabilities (SQL injection, XSS, insecure deserialization), code smells, N+1 queries, naming issues, and architectural concerns, then produces a structured review report with prioritized, actionable feedback. Use when reviewing pull requests, conducting code quality audits, identifying refactoring opportunities, or checking for security issues. Invoke for PR reviews, code quality checks, refactoring suggestions, review code, code quality. Complements specialized skills (security-reviewer, test-master) by providing broad-scope review across correctness, performance, maintainability, and test coverage in a single pass.
+license: MIT
+allowed-tools: Read, Grep, Glob
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: quality
+  triggers: code review, PR review, pull request, review code, code quality
+  role: specialist
+  scope: review
+  output-format: report
+  related-skills: security-reviewer, test-master, architecture-designer
+---
+
+# Code Reviewer
+
+Senior engineer conducting thorough, constructive code reviews that improve quality and share knowledge.
+
+## When to Use This Skill
+
+- Reviewing pull requests
+- Conducting code quality audits
+- Identifying refactoring opportunities
+- Checking for security vulnerabilities
+- Validating architectural decisions
+
+## Core Workflow
+
+1. **Context** — Read PR description, understand the problem being solved. **Checkpoint:** Summarize the PR's intent in one sentence before proceeding. If you cannot, ask the author to clarify.
+2. **Structure** — Review architecture and design decisions. Ask: Does this follow existing patterns in the codebase? Are new abstractions justified?
+3. **Details** — Check code quality, security, and performance. Apply the checks in the Reference Guide below. Ask: Are there N+1 queries, hardcoded secrets, or injection risks?
+4. **Tests** — Validate test coverage and quality. Ask: Are edge cases covered? Do tests assert behavior, not implementation?
+5. **Feedback** — Produce a categorized report using the Output Template. If critical issues are found in step 3, note them immediately and do not wait until the end.
+
+> **Disagreement handling:** If the author has left comments explaining a non-obvious choice, acknowledge their reasoning before suggesting an alternative. Never block on style preferences when a linter or formatter is configured.
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+<!-- Spec Compliance and Receiving Feedback rows adapted from obra/superpowers by Jesse Vincent (@obra), MIT License -->
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Review Checklist | `references/review-checklist.md` | Starting a review, categories |
+| Common Issues | `references/common-issues.md` | N+1 queries, magic numbers, patterns |
+| Feedback Examples | `references/feedback-examples.md` | Writing good feedback |
+| Report Template | `references/report-template.md` | Writing final review report |
+| Spec Compliance | `references/spec-compliance-review.md` | Reviewing implementations, PR review, spec verification |
+| Receiving Feedback | `references/receiving-feedback.md` | Responding to review comments, handling feedback |
+
+## Review Patterns (Quick Reference)
+
+### N+1 Query — Bad vs Good
+```python
+# BAD: query inside loop
+for user in users:
+    orders = Order.objects.filter(user=user)  # N+1
+
+# GOOD: prefetch in bulk
+users = User.objects.prefetch_related('orders').all()
+```
+
+### Magic Number — Bad vs Good
+```python
+# BAD
+if status == 3:
+    ...
+
+# GOOD
+ORDER_STATUS_SHIPPED = 3
+if status == ORDER_STATUS_SHIPPED:
+    ...
+```
+
+### Security: SQL Injection — Bad vs Good
+```python
+# BAD: string interpolation in query
+cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
+
+# GOOD: parameterized query
+cursor.execute("SELECT * FROM users WHERE id = %s", [user_id])
+```
+
+## Constraints
+
+### MUST DO
+- Summarize PR intent before reviewing (see Workflow step 1)
+- Provide specific, actionable feedback
+- Include code examples in suggestions
+- Praise good patterns
+- Prioritize feedback (critical → minor)
+- Review tests as thoroughly as code
+- Check for security issues (OWASP Top 10 as baseline)
+
+### MUST NOT DO
+- Be condescending or rude
+- Nitpick style when linters exist
+- Block on personal preferences
+- Demand perfection
+- Review without understanding the why
+- Skip praising good work
+
+## Output Template
+
+Code review report must include:
+1. **Summary** — One-sentence intent recap + overall assessment
+2. **Critical issues** — Must fix before merge (bugs, security, data loss)
+3. **Major issues** — Should fix (performance, design, maintainability)
+4. **Minor issues** — Nice to have (naming, readability)
+5. **Positive feedback** — Specific patterns done well
+6. **Questions for author** — Clarifications needed
+7. **Verdict** — Approve / Request Changes / Comment
+
+## Knowledge Reference
+
+SOLID, DRY, KISS, YAGNI, design patterns, OWASP Top 10, language idioms, testing patterns
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/code-reviewer/)

--- a/.claude/skills/code-reviewer/references/common-issues.md
+++ b/.claude/skills/code-reviewer/references/common-issues.md
@@ -1,0 +1,142 @@
+# Common Issues
+
+## N+1 Query Problem
+
+```typescript
+// N+1 queries - BAD
+const posts = await Post.findAll();
+for (const post of posts) {
+  post.author = await User.findById(post.authorId); // N queries!
+}
+
+// Single query with join - GOOD
+const posts = await Post.findAll({ include: [User] });
+
+// Or batch load
+const posts = await Post.findAll();
+const authorIds = posts.map(p => p.authorId);
+const authors = await User.findByIds(authorIds);
+```
+
+## Missing Error Handling
+
+```typescript
+// Unhandled rejection - BAD
+const data = await fetch('/api/data').then(r => r.json());
+
+// Proper error handling - GOOD
+try {
+  const response = await fetch('/api/data');
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const data = await response.json();
+} catch (error) {
+  logger.error('Failed to fetch data', { error });
+  throw new DataFetchError('Could not load data');
+}
+```
+
+## Magic Numbers/Strings
+
+```typescript
+// Magic number - BAD
+if (user.age >= 18) { ... }
+setTimeout(fn, 86400000);
+
+// Named constant - GOOD
+const MINIMUM_AGE = 18;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+if (user.age >= MINIMUM_AGE) { ... }
+setTimeout(fn, ONE_DAY_MS);
+```
+
+## Deep Nesting
+
+```typescript
+// Deep nesting - BAD
+if (user) {
+  if (user.isActive) {
+    if (user.hasPermission) {
+      doSomething();
+    }
+  }
+}
+
+// Early returns - GOOD
+if (!user || !user.isActive || !user.hasPermission) {
+  return;
+}
+doSomething();
+```
+
+## God Functions
+
+```typescript
+// Does too much - BAD
+async function processOrder(order) {
+  // validate
+  // check inventory
+  // process payment
+  // send email
+  // update database
+  // log analytics
+}
+
+// Single responsibility - GOOD
+async function processOrder(order) {
+  await validateOrder(order);
+  await reserveInventory(order);
+  await chargePayment(order);
+  await sendConfirmation(order);
+}
+```
+
+## Mutable Shared State
+
+```typescript
+// Shared mutable - BAD
+const config = { debug: false };
+function enableDebug() {
+  config.debug = true;
+}
+
+// Immutable pattern - GOOD
+function createConfig(overrides = {}) {
+  return Object.freeze({ debug: false, ...overrides });
+}
+```
+
+## Missing Null Checks
+
+```typescript
+// Unsafe access - BAD
+const name = user.profile.name;
+
+// Safe access - GOOD
+const name = user?.profile?.name ?? 'Unknown';
+```
+
+## Synchronous File Operations
+
+```typescript
+// Blocks event loop - BAD
+const data = fs.readFileSync('file.txt');
+
+// Non-blocking - GOOD
+const data = await fs.promises.readFile('file.txt');
+```
+
+## Quick Reference
+
+| Issue | Impact | Fix |
+|-------|--------|-----|
+| N+1 queries | Performance | Eager load or batch |
+| Missing error handling | Reliability | Try/catch + logging |
+| Magic numbers | Maintainability | Named constants |
+| Deep nesting | Readability | Early returns |
+| God functions | Testability | Single responsibility |
+| Mutable shared state | Bugs | Immutable patterns |
+| Missing null checks | Crashes | Optional chaining |
+| Sync file operations | Performance | Async operations |

--- a/.claude/skills/code-reviewer/references/feedback-examples.md
+++ b/.claude/skills/code-reviewer/references/feedback-examples.md
@@ -1,0 +1,144 @@
+# Feedback Examples
+
+## Good vs Bad Feedback
+
+### Be Specific, Not Vague
+
+```markdown
+BAD: "This is confusing"
+
+GOOD: "This function handles both validation and persistence. Consider
+      splitting into `validateUser()` and `saveUser()` for single
+      responsibility and easier testing."
+```
+
+### Be Actionable, Not Just Critical
+
+```markdown
+BAD: "Fix the query"
+
+GOOD: "This will cause N+1 queries - one per post. Use `include: [Author]`
+      to eager load authors in a single query. See: [link to docs]"
+```
+
+### Be Constructive, Not Demanding
+
+```markdown
+BAD: "Add tests"
+
+GOOD: "Missing test for the case when `email` is already taken. Add a test
+      that verifies 409 is returned with appropriate error message."
+```
+
+### Ask Questions, Don't Assume
+
+```markdown
+BAD: "This is wrong"
+
+GOOD: "I notice this returns null instead of throwing. Is that intentional?
+      The other methods throw on not-found. Should this be consistent?"
+```
+
+## Praise Examples
+
+Reinforce good patterns with specific praise:
+
+```markdown
+"Great use of early returns here - much more readable than nested ifs!"
+
+"Nice extraction of this validation logic into a reusable function."
+
+"Excellent error messages - they'll help debugging in production."
+
+"Good choice using a discriminated union here instead of optional fields."
+
+"Appreciate the comprehensive test coverage, especially the edge cases."
+```
+
+## Feedback by Category
+
+### Critical (Must Fix)
+
+```markdown
+**[CRITICAL] Security: SQL Injection**
+Location: `src/users/service.ts:45`
+
+The query uses string interpolation:
+`SELECT * FROM users WHERE id = ${id}`
+
+This is vulnerable to SQL injection. Use parameterized query:
+`db.query('SELECT * FROM users WHERE id = $1', [id])`
+```
+
+### Major (Should Fix)
+
+```markdown
+**[MAJOR] Performance: N+1 Query**
+Location: `src/posts/service.ts:23`
+
+Current code fetches users in a loop (N+1 problem):
+```typescript
+for (const post of posts) {
+  post.author = await User.findById(post.authorId);
+}
+```
+
+Suggestion: Use eager loading:
+```typescript
+const posts = await Post.findAll({ include: [User] });
+```
+
+Impact: ~100 extra DB queries per request with current approach.
+```
+
+### Minor (Nice to Have)
+
+```markdown
+**[MINOR] Naming: Unclear variable**
+Location: `src/utils/date.ts:12`
+
+`d` is unclear. Consider `createdDate` or `timestamp` for better readability.
+
+**[MINOR] Style: Prefer const**
+Location: `src/config/index.ts:8`
+
+`let config` is never reassigned. Use `const` for immutability.
+```
+
+## Question Format
+
+```markdown
+**[QUESTION]**
+Location: `src/orders/service.ts:67`
+
+What's the expected behavior when the user has an existing pending order?
+Should this:
+- Return the existing order?
+- Create a new one anyway?
+- Return an error?
+```
+
+## Summary Format
+
+```markdown
+## Summary
+
+Overall this is a solid implementation of the user registration flow.
+The validation logic is clean and the error handling is comprehensive.
+
+**Blocking Issues**: 1 critical (SQL injection)
+**Suggestions**: 2 major, 3 minor
+
+Once the SQL injection is fixed, this is ready to merge. The major
+suggestions are performance improvements worth considering.
+```
+
+## Quick Reference
+
+| Feedback Type | Tone | Required Action |
+|---------------|------|-----------------|
+| Critical | Firm, clear | Must fix before merge |
+| Major | Suggestive | Should fix |
+| Minor | Optional | Nice to have |
+| Praise | Positive | None - reinforcement |
+| Question | Curious | Response needed |

--- a/.claude/skills/code-reviewer/references/receiving-feedback.md
+++ b/.claude/skills/code-reviewer/references/receiving-feedback.md
@@ -1,0 +1,238 @@
+# Receiving Feedback
+
+---
+
+## Core Mindset
+
+> "Verify before implementing. Ask before assuming. Technical correctness over social comfort."
+
+Code review feedback is a technical discussion, not a social one. Focus on the code, not on feelings.
+
+---
+
+## The Six-Step Process
+
+### Step 1: Read Completely
+
+**Without reacting.** Read the entire comment before forming any response.
+
+```markdown
+❌ BAD: Read first sentence → start typing defense
+✅ GOOD: Read entire comment → understand full context → then respond
+```
+
+### Step 2: Restate Requirements
+
+Rephrase the reviewer's feedback in your own words to confirm understanding.
+
+```markdown
+Reviewer: "This function is doing too much. It handles validation,
+transformation, and persistence all in one place."
+
+Your restatement: "You're suggesting I split this into three separate
+functions: validate(), transform(), and persist()?"
+```
+
+### Step 3: Check Against Codebase
+
+Verify the feedback against actual code conditions before responding.
+
+```typescript
+// Reviewer says: "This will throw if user is null"
+
+// Check the code:
+function getUsername(user: User): string {
+  return user.name;  // No null check - reviewer is correct
+}
+
+// Or discover context:
+function getUsername(user: User): string {
+  return user.name;  // TypeScript enforces User, null not possible
+}
+```
+
+### Step 4: Evaluate Technical Soundness
+
+Consider whether the feedback applies to your specific stack and context.
+
+```markdown
+Reviewer: "You should use useMemo here for performance"
+
+Evaluate:
+- Is this component re-rendering frequently? → Check React DevTools
+- Is the computation expensive? → Profile it
+- Does React 19's compiler auto-optimize this? → Check version
+```
+
+### Step 5: Respond with Substance
+
+Provide technical acknowledgment or reasoned objection.
+
+```markdown
+✅ GOOD: "Fixed. Split into validate(), transform(), persist()
+         at lines 24, 45, 67."
+
+✅ GOOD: "Respectfully disagree. This list has max 5 items
+         (see schema.ts:12), so filter performance is O(5)."
+
+❌ BAD: "You're absolutely right! Great catch!"
+❌ BAD: "I don't think that's necessary."
+```
+
+### Step 6: Implement One at a Time
+
+Address each piece of feedback individually with verification.
+
+```markdown
+Feedback item 1: Add null check
+→ Implement → Test → Commit → Verify → Move to next
+
+Feedback item 2: Extract helper function
+→ Implement → Test → Commit → Verify → Move to next
+
+NOT: Try to address all feedback in one massive commit
+```
+
+---
+
+## Avoiding Agreement Theater
+
+### The Problem
+
+Performative agreement wastes time and provides no information. When you write "Great point!" you're adding noise, not signal.
+
+### Forbidden Phrases
+
+| Phrase | Why It's Wrong |
+|--------|----------------|
+| "You're absolutely right!" | Sycophantic, adds no information |
+| "Great point!" | Empty praise, not a response |
+| "Excellent feedback!" | Flattery, not engagement |
+| "Thanks for catching this!" | Unnecessary, just fix it |
+| "I really appreciate..." | Social fluff, not technical |
+
+### Actions Demonstrate Understanding
+
+```markdown
+❌ "You're absolutely right! Great catch on that null check!
+    Thanks so much for pointing this out!"
+
+✅ "Fixed. Added null check at line 42."
+```
+
+The code change shows you understood. Words are redundant.
+
+### When Acknowledgment IS Appropriate
+
+Brief, technical acknowledgment when learning something new:
+
+```markdown
+✅ "I wasn't aware of that edge case. Added handling at line 42."
+✅ "Good point about thread safety. Added mutex at line 67."
+```
+
+---
+
+## When to Push Back
+
+### Valid Reasons to Disagree
+
+Push back with technical reasoning when feedback:
+
+| Situation | How to Respond |
+|-----------|----------------|
+| Breaks existing functionality | "This change would break Feature X (see test at tests/feature-x.spec.ts:34)" |
+| Lacks full codebase context | "This pattern exists because of Y (see architecture.md#constraints)" |
+| Violates YAGNI | "This flexibility isn't needed yet - only one caller exists" |
+| Is technically incorrect | "This actually works because of Z (link to docs)" |
+| Conflicts with established architecture | "This conflicts with our JWT approach (see auth/README.md)" |
+
+### Good Pushback Format
+
+```markdown
+## Template
+This conflicts with [X]. [Evidence]. Was that the intent, or should we [alternative]?
+
+## Example
+This conflicts with our JWT authentication architecture (see auth/token.js:45).
+Switching to sessions would require restructuring the API middleware.
+Was that the intent, or should we keep JWT?
+```
+
+### Bad Pushback
+
+```markdown
+❌ "I don't think that's right."
+❌ "That won't work."
+❌ "We've always done it this way."
+❌ "That's too much work."
+```
+
+---
+
+## Verification Before Claiming Fixed
+
+### The Checklist
+
+Before writing "Fixed" or "Done":
+
+- [ ] Change is implemented
+- [ ] Tests pass (full suite, not just changed files)
+- [ ] Specific behavior mentioned in feedback is verified
+- [ ] Edge cases are tested
+- [ ] No unintended side effects introduced
+
+### Acceptable Responses
+
+```markdown
+✅ "Fixed. Added null check. Tests pass."
+✅ "Fixed at line 42. Verified with test case X."
+✅ "Implemented. All 47 tests pass."
+```
+
+### Unacceptable Responses
+
+```markdown
+❌ "I think this addresses your concern."
+❌ "Should be fixed now."
+❌ "Done, I believe."
+❌ "Fixed (probably)."
+```
+
+### When You Can't Verify
+
+If you cannot verify a fix:
+
+```markdown
+✅ "Implemented the change, but I'm unable to verify because
+    [specific reason]. Can you confirm on your end?"
+```
+
+---
+
+## Quick Reference
+
+| Situation | Response |
+|-----------|----------|
+| Reviewer is correct | "Fixed. [What you changed]." |
+| You need clarification | "To confirm: you're suggesting [restatement]?" |
+| Reviewer is incorrect | "This works because [evidence]. [Link to proof]." |
+| You disagree on approach | "This conflicts with [X]. Should we [alternative]?" |
+| You learned something | "I wasn't aware of [X]. Fixed at line [N]." |
+| You can't verify | "Implemented. Unable to verify because [reason]." |
+
+---
+
+## Anti-Patterns
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| Defensive responses | Creates conflict, wastes time | Assume good faith, respond technically |
+| Apologetic responses | Unprofessional, adds noise | Just fix it |
+| Delayed responses | Blocks review cycle | Respond within hours, not days |
+| Vague responses | Leaves reviewer uncertain | Be specific about changes |
+| Ignoring feedback | Disrespectful, creates friction | Address every point |
+
+---
+
+*Content adapted from [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (@obra), MIT License.*

--- a/.claude/skills/code-reviewer/references/report-template.md
+++ b/.claude/skills/code-reviewer/references/report-template.md
@@ -1,0 +1,109 @@
+# Report Template
+
+## Full Review Report Template
+
+```markdown
+# Code Review: [PR Title]
+
+## Summary
+[1-2 sentence overview of the changes and overall assessment]
+
+**Verdict**: [ ] Approve | [x] Request Changes | [ ] Comment
+
+## Critical Issues (Must Fix)
+
+### 1. [File:Line] Security: SQL Injection Risk
+- **Current**: String interpolation in query
+- **Suggested**: Use parameterized query
+- **Impact**: Potential data breach
+
+```typescript
+// Current (vulnerable)
+const query = `SELECT * FROM users WHERE id = ${id}`;
+
+// Suggested (secure)
+const query = 'SELECT * FROM users WHERE id = $1';
+db.query(query, [id]);
+```
+
+## Major Issues (Should Fix)
+
+### 1. [File:Line] Performance: N+1 Query
+- **Current**: Fetching users in loop
+- **Suggested**: Use eager loading with include
+- **Impact**: ~100 extra DB queries per request
+
+### 2. [File:Line] Logic: Missing edge case
+- **Current**: No handling for empty array
+- **Suggested**: Add guard clause
+- **Impact**: Potential runtime error
+
+## Minor Issues (Nice to Have)
+
+### 1. [File:Line] Naming: Unclear variable name
+- **Current**: `d`
+- **Suggested**: `createdDate`
+
+### 2. [File:Line] Style: Inconsistent formatting
+- **Current**: Mixed quotes
+- **Suggested**: Use single quotes consistently
+
+## Positive Feedback
+- Clean separation of concerns in service layer
+- Comprehensive input validation on DTOs
+- Good test coverage for edge cases
+- Excellent error messages
+
+## Questions for Author
+- What's the expected behavior when X happens?
+- Should this support pagination for large datasets?
+- Is the retry logic intentional or accidental?
+
+## Test Coverage Assessment
+- [ ] Happy path tested
+- [x] Error cases tested
+- [ ] Edge cases tested (missing empty array test)
+- [x] Integration tests present
+
+## Checklist
+- [x] No security vulnerabilities
+- [ ] Performance is acceptable (N+1 issue)
+- [x] Code is readable
+- [x] Tests are adequate
+- [x] Documentation is present
+```
+
+## Verdict Guidelines
+
+| Verdict | When to Use |
+|---------|-------------|
+| **Approve** | No blocking issues, minor suggestions only |
+| **Request Changes** | Critical or major issues must be fixed |
+| **Comment** | Questions need answers, no blocking issues |
+
+## Severity Definitions
+
+| Severity | Definition | Examples |
+|----------|------------|----------|
+| **Critical** | Security risk, data loss, crashes | SQL injection, auth bypass |
+| **Major** | Significant performance, maintainability | N+1 queries, god functions |
+| **Minor** | Style, naming, small improvements | Variable names, formatting |
+
+## Time Boxing
+
+| Section | Suggested Time |
+|---------|----------------|
+| Context & understanding | 5 minutes |
+| Critical/security review | 10 minutes |
+| Logic & performance | 15 minutes |
+| Tests review | 10 minutes |
+| Writing report | 10 minutes |
+| **Total** | ~50 minutes |
+
+## Quick Checks Before Submitting
+
+- [ ] All critical issues have clear remediation
+- [ ] Major issues explain the impact
+- [ ] At least one positive comment included
+- [ ] Questions are specific and answerable
+- [ ] Verdict matches the issues found

--- a/.claude/skills/code-reviewer/references/review-checklist.md
+++ b/.claude/skills/code-reviewer/references/review-checklist.md
@@ -1,0 +1,88 @@
+# Review Checklist
+
+## Comprehensive Review Checklist
+
+| Category | Key Questions |
+|----------|---------------|
+| **Design** | Does it fit existing patterns? Right abstraction level? |
+| **Logic** | Edge cases handled? Race conditions? Null checks? |
+| **Security** | Input validated? Auth checked? Secrets safe? |
+| **Performance** | N+1 queries? Memory leaks? Caching needed? |
+| **Tests** | Adequate coverage? Edge cases tested? Mocks appropriate? |
+| **Naming** | Clear, consistent, intention-revealing? |
+| **Error Handling** | Errors caught? Meaningful messages? Logged? |
+| **Documentation** | Public APIs documented? Complex logic explained? |
+
+## Review Process
+
+### 1. Context (5 min)
+- [ ] Read PR description
+- [ ] Understand the problem being solved
+- [ ] Check linked issues/tickets
+- [ ] Note expected changes
+
+### 2. Structure (10 min)
+- [ ] Review file organization
+- [ ] Check architectural fit
+- [ ] Verify design patterns used
+- [ ] Note any breaking changes
+
+### 3. Code Details (20 min)
+- [ ] Review logic correctness
+- [ ] Check edge cases
+- [ ] Verify error handling
+- [ ] Look for security issues
+- [ ] Check performance concerns
+- [ ] Review naming clarity
+
+### 4. Tests (10 min)
+- [ ] Verify test coverage
+- [ ] Check test quality
+- [ ] Look for edge case tests
+- [ ] Ensure mocks are appropriate
+
+### 5. Final Pass (5 min)
+- [ ] Note positive patterns
+- [ ] Prioritize feedback
+- [ ] Write summary
+
+## Category Deep Dive
+
+### Design Questions
+- Does this change belong in this file/module?
+- Is the abstraction level appropriate?
+- Could this be simpler?
+- Does it follow existing patterns?
+- Is it extensible without modification?
+
+### Logic Questions
+- What happens with null/undefined inputs?
+- Are boundary conditions handled?
+- Could there be race conditions?
+- Is the order of operations correct?
+- Are all code paths tested?
+
+### Security Questions
+- Is all user input validated?
+- Are SQL queries parameterized?
+- Is output properly encoded?
+- Are secrets handled safely?
+- Is authentication checked?
+- Is authorization enforced?
+
+### Performance Questions
+- Are there N+1 query patterns?
+- Is data fetched efficiently?
+- Are expensive operations cached?
+- Could this cause memory leaks?
+- Is pagination implemented?
+
+## Quick Reference
+
+| Review Focus | Time % |
+|--------------|--------|
+| Context & PR description | 10% |
+| Architecture & design | 20% |
+| Code logic & details | 40% |
+| Tests & coverage | 20% |
+| Final review & summary | 10% |

--- a/.claude/skills/code-reviewer/references/spec-compliance-review.md
+++ b/.claude/skills/code-reviewer/references/spec-compliance-review.md
@@ -1,0 +1,258 @@
+# Spec Compliance Review
+
+---
+
+## Two-Stage Review Architecture
+
+```
+                    ┌─────────────────────┐
+                    │   Implementation    │
+                    └──────────┬──────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │  STAGE 1: Spec      │
+                    │  Compliance Review  │
+                    └──────────┬──────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              │                                  │
+      ┌───────▼───────┐                ┌────────▼────────┐
+      │   ✗ Issues    │                │   ✓ Compliant   │
+      │     Found     │                │                 │
+      └───────┬───────┘                └────────┬────────┘
+              │                                  │
+              │                        ┌────────▼────────┐
+              │                        │  STAGE 2: Code  │
+              │                        │  Quality Review │
+              │                        └────────┬────────┘
+              │                                  │
+              │                    ┌─────────────┴─────────────┐
+              │                    │                           │
+              │            ┌───────▼───────┐         ┌────────▼────────┐
+              │            │   ✗ Issues    │         │   ✓ Approved    │
+              │            │     Found     │         │                 │
+              │            └───────┬───────┘         └─────────────────┘
+              │                    │
+              └────────────────────┴────────────────────┐
+                                                        │
+                                              ┌─────────▼─────────┐
+                                              │ Return to Author  │
+                                              └───────────────────┘
+```
+
+**Critical:** Complete Stage 1 (spec compliance) BEFORE Stage 2 (code quality). Never review code quality for functionality that doesn't meet the specification.
+
+---
+
+## Stage 1: Spec Compliance Review
+
+### Core Directive
+
+> "The implementer finished suspiciously quickly. Their report may be incomplete, inaccurate, or optimistic."
+
+Approach every review with professional skepticism. Verify claims independently.
+
+### The Three Verification Categories
+
+#### Category 1: Missing Requirements
+
+**Check for features that were requested but not implemented.**
+
+| Question | How to Verify |
+|----------|---------------|
+| Did they skip requested features? | Compare PR to original requirements line by line |
+| Are edge cases handled? | Check error paths, empty states, boundaries |
+| Were error scenarios addressed? | Look for try/catch, error boundaries, validation |
+| Is the happy path complete? | Trace through primary use case manually |
+
+```markdown
+## Example Review Finding
+
+**Missing Requirement:** Issue #42 requested "password must be at least 8 characters"
+
+**Found in code:**
+```typescript
+// No length validation present
+function validatePassword(password: string) {
+  return password.length > 0;  // Only checks non-empty
+}
+```
+
+**Status:** ❌ Incomplete - minimum length validation missing
+```
+
+#### Category 2: Unnecessary Additions
+
+**Check for scope creep and over-engineering.**
+
+| Question | How to Verify |
+|----------|---------------|
+| Features beyond specification? | Compare to original requirements |
+| Over-engineering? | Is complexity justified by requirements? |
+| Premature optimization? | Is performance cited without measurements? |
+| Unrequested abstractions? | Are there helpers/utils for one-time use? |
+
+```markdown
+## Example Review Finding
+
+**Unnecessary Addition:** Added caching layer not in requirements
+
+**Found in code:**
+```typescript
+// Original requirement: "Fetch user by ID"
+// Actual implementation:
+class CachedUserRepository {  // Not requested
+  private cache = new Map();
+  private ttl = 60000;
+
+  async getUser(id: string) {
+    if (this.cache.has(id)) { ... }
+    // 50 lines of cache logic
+  }
+}
+```
+
+**Status:** ⚠️ Scope creep - discuss before merging
+```
+
+#### Category 3: Interpretation Gaps
+
+**Check for misunderstandings of requirements.**
+
+| Question | How to Verify |
+|----------|---------------|
+| Different understanding of requirements? | Ask author to explain their interpretation |
+| Unclarified assumptions? | Look for comments like "assuming..." |
+| Ambiguous specs resolved incorrectly? | Compare to similar existing features |
+
+```markdown
+## Example Review Finding
+
+**Interpretation Gap:** "Sort by date" implemented as ascending
+
+**Requirement stated:** "Sort by date" (ambiguous)
+
+**Author implemented:** Oldest first (ascending)
+
+**Expected:** Most recent first is typical UX pattern
+
+**Status:** ❓ Clarify - which sort order was intended?
+```
+
+---
+
+## Why Order Matters
+
+### Stage 1 Must Come First
+
+| Scenario | Waste from Wrong Order |
+|----------|------------------------|
+| Skip Stage 1 | Review 500 lines of code quality, then discover wrong feature was built |
+| Stage 2 First | Suggest refactoring, then realize the code shouldn't exist |
+| Combined | Mix concerns, miss systematic issues |
+
+### Separation of Concerns
+
+- **Stage 1 (Spec):** Does it do the right thing?
+- **Stage 2 (Quality):** Does it do the thing right?
+
+Code quality review is meaningless if the code doesn't implement the correct functionality.
+
+---
+
+## Spec Compliance Checklist
+
+### Before You Start
+
+- [ ] Read the original issue/ticket completely
+- [ ] Identify all explicit requirements
+- [ ] Identify implicit requirements from context
+- [ ] Note any acceptance criteria listed
+
+### During Review
+
+**Missing Requirements:**
+- [ ] All required features present
+- [ ] Edge cases covered (empty, null, max values)
+- [ ] Error handling as specified
+- [ ] Happy path fully functional
+- [ ] UI matches mockups/specs if provided
+
+**Unnecessary Additions:**
+- [ ] No unrequested features
+- [ ] No speculative abstractions
+- [ ] No premature optimizations
+- [ ] Scope matches requirements exactly
+
+**Interpretation Gaps:**
+- [ ] Author's understanding matches spec
+- [ ] Ambiguities resolved correctly
+- [ ] Assumptions are documented and valid
+- [ ] Behavior matches similar existing features
+
+### After Review
+
+- [ ] Document all findings with file:line references
+- [ ] Categorize as missing/unnecessary/interpretation
+- [ ] Prioritize: blocking vs. non-blocking issues
+
+---
+
+## Output Format
+
+### Compliant Result
+
+```markdown
+## Spec Compliance Review: ✅ PASS
+
+All requirements verified:
+- ✅ User can upload profile image (req #1)
+- ✅ Image resized to 200x200 (req #2)
+- ✅ Invalid formats rejected with error message (req #3)
+- ✅ Progress indicator during upload (req #4)
+
+**Proceed to:** Code Quality Review
+```
+
+### Issues Found
+
+```markdown
+## Spec Compliance Review: ❌ ISSUES FOUND
+
+### Missing Requirements
+
+1. **Progress indicator not implemented** (req #4)
+   - File: `ProfileUpload.tsx`
+   - Expected: Progress bar during upload
+   - Found: No progress indication
+
+2. **Error messages not user-friendly** (req #3)
+   - File: `ProfileUpload.tsx:45`
+   - Expected: "Please upload a JPG or PNG file"
+   - Found: "Error: INVALID_FORMAT"
+
+### Unnecessary Additions
+
+1. **Image cropping feature not requested**
+   - File: `ImageCropper.tsx` (new file, 150 lines)
+   - Impact: Adds complexity, delays delivery
+   - Recommendation: Remove or create separate PR
+
+**Action Required:** Address missing requirements before code quality review
+```
+
+---
+
+## Common Mistakes to Avoid
+
+| Mistake | Why It's Wrong |
+|---------|----------------|
+| Reviewing code style before spec compliance | Wasted effort if wrong thing was built |
+| Assuming spec was followed | Verify independently |
+| Skipping edge cases | Bugs hide in boundaries |
+| Accepting "we can add it later" | Technical debt accumulates |
+| Missing scope creep | Unreviewed code enters codebase |
+
+---
+
+*Content adapted from [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (@obra), MIT License.*

--- a/.claude/skills/debugging-wizard/SKILL.md
+++ b/.claude/skills/debugging-wizard/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: debugging-wizard
+description: Parses error messages, traces execution flow through stack traces, correlates log entries to identify failure points, and applies systematic hypothesis-driven methodology to isolate and resolve bugs. Use when investigating errors, analyzing stack traces, finding root causes of unexpected behavior, troubleshooting crashes, or performing log analysis, error investigation, or root cause analysis.
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: quality
+  triggers: debug, error, bug, exception, traceback, stack trace, troubleshoot, not working, crash, fix issue
+  role: specialist
+  scope: analysis
+  output-format: analysis
+  related-skills: test-master, fullstack-guardian, monitoring-expert
+---
+
+# Debugging Wizard
+
+Expert debugger applying systematic methodology to isolate and resolve issues in any codebase.
+
+## Core Workflow
+
+1. **Reproduce** - Establish consistent reproduction steps
+2. **Isolate** - Narrow down to smallest failing case
+3. **Hypothesize and test** - Form testable theories, verify/disprove each one
+4. **Fix** - Implement and verify solution
+5. **Prevent** - Add tests/safeguards against regression
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+<!-- Systematic Debugging row adapted from obra/superpowers by Jesse Vincent (@obra), MIT License -->
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Debugging Tools | `references/debugging-tools.md` | Setting up debuggers by language |
+| Common Patterns | `references/common-patterns.md` | Recognizing bug patterns |
+| Strategies | `references/strategies.md` | Binary search, git bisect, time travel |
+| Quick Fixes | `references/quick-fixes.md` | Common error solutions |
+| Systematic Debugging | `references/systematic-debugging.md` | Complex bugs, multiple failed fixes, root cause analysis |
+
+## Constraints
+
+### MUST DO
+- Reproduce the issue first
+- Gather complete error messages and stack traces
+- Test one hypothesis at a time
+- Document findings for future reference
+- Add regression tests after fixing
+- Remove all debug code before committing
+
+### MUST NOT DO
+- Guess without testing
+- Make multiple changes at once
+- Skip reproduction steps
+- Assume you know the cause
+- Debug in production without safeguards
+- Leave console.log/debugger statements in code
+
+## Common Debugging Commands
+
+**Python (pdb)**
+```bash
+python -m pdb script.py          # launch debugger
+# inside pdb:
+# b 42          — set breakpoint at line 42
+# n             — step over
+# s             — step into
+# p some_var    — print variable
+# bt            — print full traceback
+```
+
+**JavaScript (Node.js)**
+```bash
+node --inspect-brk script.js     # pause at first line, attach Chrome DevTools
+# In Chrome: open chrome://inspect → click "inspect"
+# Sources panel: add breakpoints, watch expressions, step through
+```
+
+**Git bisect (regression hunting)**
+```bash
+git bisect start
+git bisect bad                   # current commit is broken
+git bisect good v1.2.0           # last known good tag/commit
+# Git checks out midpoint — test, then:
+git bisect good   # or: git bisect bad
+# Repeat until git identifies the first bad commit
+git bisect reset
+```
+
+**Go (delve)**
+```bash
+dlv debug ./cmd/server           # build & attach
+# (dlv) break main.go:55
+# (dlv) continue
+# (dlv) print myVar
+```
+
+## Output Templates
+
+When debugging, provide:
+1. **Root Cause**: What specifically caused the issue
+2. **Evidence**: Stack trace, logs, or test that proves it
+3. **Fix**: Code change that resolves it
+4. **Prevention**: Test or safeguard to prevent recurrence
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/debugging-wizard/)

--- a/.claude/skills/debugging-wizard/references/common-patterns.md
+++ b/.claude/skills/debugging-wizard/references/common-patterns.md
@@ -1,0 +1,132 @@
+# Common Bug Patterns
+
+## Pattern Recognition
+
+| Pattern | Symptom | Likely Cause |
+|---------|---------|--------------|
+| Race condition | Intermittent failures | Missing await, async timing |
+| Off-by-one | Missing first/last item | `<` vs `<=`, array bounds |
+| Null reference | "undefined is not..." | Missing null check |
+| Memory leak | Growing memory | Uncleaned listeners/intervals |
+| N+1 queries | Slow with more data | Fetching in loop |
+| Type coercion | Unexpected behavior | `==` instead of `===` |
+| Closure issue | Wrong variable value | Loop variable capture |
+| Stale state | Old value used | React state closure |
+
+## Race Condition
+
+```typescript
+// BUG: Race condition
+let data;
+fetchData().then(result => { data = result; });
+console.log(data); // undefined!
+
+// FIX: Await the result
+const data = await fetchData();
+console.log(data);
+```
+
+## Off-by-One
+
+```typescript
+// BUG: Skips last element
+for (let i = 0; i < array.length - 1; i++) { }
+
+// FIX: Include last element
+for (let i = 0; i < array.length; i++) { }
+
+// BUG: Array index out of bounds
+const last = array[array.length]; // undefined
+
+// FIX: Correct index
+const last = array[array.length - 1];
+```
+
+## Null Reference
+
+```typescript
+// BUG: Crashes if user is null
+const name = user.profile.name;
+
+// FIX: Optional chaining
+const name = user?.profile?.name ?? 'Unknown';
+
+// FIX: Guard clause
+if (!user?.profile) {
+  return 'Unknown';
+}
+return user.profile.name;
+```
+
+## Memory Leak
+
+```typescript
+// BUG: Listener never removed
+useEffect(() => {
+  window.addEventListener('resize', handleResize);
+}, []);
+
+// FIX: Cleanup function
+useEffect(() => {
+  window.addEventListener('resize', handleResize);
+  return () => window.removeEventListener('resize', handleResize);
+}, []);
+
+// BUG: Interval never cleared
+setInterval(pollData, 1000);
+
+// FIX: Store and clear
+const intervalId = setInterval(pollData, 1000);
+return () => clearInterval(intervalId);
+```
+
+## Closure in Loop
+
+```typescript
+// BUG: All callbacks use i = 5
+for (var i = 0; i < 5; i++) {
+  setTimeout(() => console.log(i), 100);
+}
+
+// FIX: Use let (block scoped)
+for (let i = 0; i < 5; i++) {
+  setTimeout(() => console.log(i), 100);
+}
+
+// FIX: Capture in closure
+for (var i = 0; i < 5; i++) {
+  ((j) => setTimeout(() => console.log(j), 100))(i);
+}
+```
+
+## React Stale State
+
+```typescript
+// BUG: count is stale in closure
+const [count, setCount] = useState(0);
+useEffect(() => {
+  setInterval(() => {
+    setCount(count + 1); // Always uses initial count
+  }, 1000);
+}, []);
+
+// FIX: Use functional update
+setCount(prev => prev + 1);
+
+// FIX: Include in dependency array with cleanup
+useEffect(() => {
+  const id = setInterval(() => setCount(c => c + 1), 1000);
+  return () => clearInterval(id);
+}, []);
+```
+
+## Quick Reference
+
+| Symptom | First Check |
+|---------|-------------|
+| "undefined is not..." | Null check missing |
+| Works sometimes | Race condition |
+| Wrong value in callback | Closure/stale state |
+| Gets slower over time | Memory leak, N+1 |
+| Off by one item | Loop bounds, array index |
+| Type mismatch | `==` vs `===`, coercion |

--- a/.claude/skills/debugging-wizard/references/debugging-tools.md
+++ b/.claude/skills/debugging-wizard/references/debugging-tools.md
@@ -1,0 +1,140 @@
+# Debugging Tools
+
+## Debuggers by Language
+
+| Language | Debugger | Start Command |
+|----------|----------|---------------|
+| TypeScript/JS | Node Inspector | `node --inspect` |
+| Python | pdb/ipdb | `python -m pdb` |
+| Go | Delve | `dlv debug` |
+| Rust | rust-gdb/lldb | `rust-gdb ./target/debug/app` |
+| Java | JDB/IDE | IDE debugger |
+
+## Node.js / TypeScript
+
+```bash
+# Start with inspector
+node --inspect dist/main.js
+
+# Break on first line
+node --inspect-brk dist/main.js
+
+# With ts-node
+node --inspect -r ts-node/register src/main.ts
+```
+
+```typescript
+// In code
+debugger; // Breakpoint
+
+// Quick print
+console.log({ variable }); // Shows name and value
+console.table(arrayOfObjects); // Table format
+console.trace('Called from'); // Stack trace
+```
+
+## Python
+
+```bash
+# Start debugger
+python -m pdb script.py
+
+# Post-mortem on exception
+python -m pdb -c continue script.py
+```
+
+```python
+# In code
+breakpoint()  # Python 3.7+
+import pdb; pdb.set_trace()  # Older Python
+
+# Quick print
+print(f"{variable=}")  # Python 3.8+ shows name and value
+
+# Rich debugging
+from rich import inspect
+inspect(object, methods=True)
+```
+
+### pdb Commands
+
+| Command | Action |
+|---------|--------|
+| `n` | Next line |
+| `s` | Step into |
+| `c` | Continue |
+| `l` | List code |
+| `p expr` | Print expression |
+| `pp expr` | Pretty print |
+| `w` | Where (stack) |
+| `q` | Quit |
+
+## Go
+
+```bash
+# Start delve
+dlv debug ./cmd/app
+
+# Attach to running process
+dlv attach <pid>
+
+# Debug test
+dlv test ./pkg/...
+```
+
+```go
+// Quick print
+log.Printf("%+v", variable) // With field names
+fmt.Printf("%#v\n", variable) // Go syntax representation
+
+// Spew for complex structures
+import "github.com/davecgh/go-spew/spew"
+spew.Dump(variable)
+```
+
+### Delve Commands
+
+| Command | Action |
+|---------|--------|
+| `break main.go:42` | Set breakpoint |
+| `continue` | Continue |
+| `next` | Next line |
+| `step` | Step into |
+| `print var` | Print variable |
+| `goroutines` | List goroutines |
+
+## VS Code Debug Config
+
+```json
+// .vscode/launch.json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug TypeScript",
+      "program": "${workspaceFolder}/src/main.ts",
+      "preLaunchTask": "tsc: build",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
+      "type": "python",
+      "request": "launch",
+      "name": "Debug Python",
+      "program": "${workspaceFolder}/main.py",
+      "console": "integratedTerminal"
+    }
+  ]
+}
+```
+
+## Quick Reference
+
+| Need | Tool |
+|------|------|
+| Breakpoint in code | `debugger;` / `breakpoint()` |
+| Print with name | `console.log({x})` / `print(f"{x=}")` |
+| Stack trace | `console.trace()` / `traceback.print_stack()` |
+| Inspect object | `console.dir(obj)` / `dir(obj)` |
+| Step through | IDE debugger or CLI debugger |

--- a/.claude/skills/debugging-wizard/references/quick-fixes.md
+++ b/.claude/skills/debugging-wizard/references/quick-fixes.md
@@ -1,0 +1,177 @@
+# Quick Fixes
+
+## TypeError: Cannot read property 'x' of undefined
+
+```typescript
+// Error
+user.profile.name
+// user or profile is undefined
+
+// Fix: Optional chaining
+user?.profile?.name
+
+// Fix: Default value
+user?.profile?.name ?? 'Unknown'
+
+// Fix: Guard clause
+if (!user?.profile) {
+  return null;
+}
+return user.profile.name;
+```
+
+## Unhandled Promise Rejection
+
+```typescript
+// Error
+fetchData().then(process);
+// What if fetchData rejects?
+
+// Fix: Add catch
+fetchData()
+  .then(process)
+  .catch(error => {
+    console.error('Fetch failed:', error);
+  });
+
+// Fix: try/catch with await
+try {
+  const data = await fetchData();
+  await process(data);
+} catch (error) {
+  console.error('Operation failed:', error);
+}
+```
+
+## React: Too Many Re-renders
+
+```typescript
+// Error: Calling setState during render
+function Component() {
+  const [count, setCount] = useState(0);
+  setCount(count + 1); // Infinite loop!
+}
+
+// Fix: Use useEffect for side effects
+function Component() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    setCount(c => c + 1);
+  }, []); // Only on mount
+}
+
+// Error: Object/array in dependency array
+useEffect(() => {}, [{ a: 1 }]); // New object every render!
+
+// Fix: Memoize or use primitives
+const config = useMemo(() => ({ a: 1 }), []);
+useEffect(() => {}, [config]);
+```
+
+## CORS Error
+
+```typescript
+// Browser blocks cross-origin request
+
+// Fix 1: Server - Add CORS headers
+app.use(cors({
+  origin: 'http://localhost:3000',
+  credentials: true,
+}));
+
+// Fix 2: Proxy in development (Vite)
+// vite.config.ts
+export default {
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
+  },
+};
+```
+
+## Maximum Call Stack Size Exceeded
+
+```typescript
+// Error: Infinite recursion
+function factorial(n) {
+  return n * factorial(n - 1); // No base case!
+}
+
+// Fix: Add base case
+function factorial(n) {
+  if (n <= 1) return 1;
+  return n * factorial(n - 1);
+}
+
+// Error: Circular dependency in objects
+const a = {};
+const b = { ref: a };
+a.ref = b;
+JSON.stringify(a); // Fails!
+
+// Fix: Break circular reference
+JSON.stringify(a, (key, value) => {
+  if (key === 'ref') return '[Circular]';
+  return value;
+});
+```
+
+## Module Not Found
+
+```bash
+# Error: Cannot find module 'x'
+
+# Fix 1: Install the package
+npm install x
+
+# Fix 2: Check import path
+import x from './x';     # Relative - needs ./
+import x from 'x';       # Package - no ./
+
+# Fix 3: Check file extension
+import x from './x.js';  # ESM may need extension
+
+# Fix 4: Clear cache
+rm -rf node_modules package-lock.json
+npm install
+```
+
+## Async/Await Issues
+
+```typescript
+// Error: await in non-async function
+function getData() {
+  const data = await fetch('/api'); // SyntaxError!
+}
+
+// Fix: Mark function as async
+async function getData() {
+  const data = await fetch('/api');
+}
+
+// Error: forEach doesn't await
+items.forEach(async item => {
+  await process(item); // Doesn't wait!
+});
+
+// Fix: Use for...of
+for (const item of items) {
+  await process(item);
+}
+
+// Fix: Use Promise.all for parallel
+await Promise.all(items.map(item => process(item)));
+```
+
+## Quick Reference
+
+| Error Message | Likely Fix |
+|--------------|------------|
+| Cannot read property of undefined | Optional chaining `?.` |
+| Unhandled promise rejection | Add `.catch()` or try/catch |
+| Too many re-renders | Remove setState from render |
+| CORS error | Add CORS headers on server |
+| Maximum call stack | Add recursion base case |
+| Module not found | Check path, install package |
+| await in non-async | Add `async` keyword |

--- a/.claude/skills/debugging-wizard/references/strategies.md
+++ b/.claude/skills/debugging-wizard/references/strategies.md
@@ -1,0 +1,142 @@
+# Debugging Strategies
+
+## Binary Search
+
+Divide and conquer to find the bug location.
+
+```markdown
+1. Comment out/disable half the code
+2. Test if bug still occurs
+3. If yes: bug is in remaining half
+4. If no: bug is in disabled half
+5. Repeat until isolated
+```
+
+```typescript
+// Example: Bug in data processing pipeline
+async function process(data) {
+  const step1 = await transform(data);
+  // Bug somewhere below?
+
+  const step2 = await validate(step1);
+  console.log('After step2:', step2); // Check here
+
+  const step3 = await enrich(step2);
+  const step4 = await save(step3);
+  return step4;
+}
+```
+
+## Minimal Reproduction
+
+Strip away everything until only the bug remains.
+
+```markdown
+1. Create new minimal project
+2. Add only code needed to reproduce
+3. Remove dependencies one by one
+4. Simplify inputs to smallest failing case
+5. Document exact reproduction steps
+```
+
+```typescript
+// Instead of debugging full app
+// Create minimal test case:
+const input = { id: null }; // Minimal failing input
+const result = processUser(input);
+console.log(result); // Isolate the exact failure
+```
+
+## Git Bisect
+
+Find the commit that introduced the bug.
+
+```bash
+# Start bisect
+git bisect start
+
+# Mark current commit as bad
+git bisect bad
+
+# Mark known good commit
+git bisect good v1.0.0
+
+# Git checks out middle commit
+# Test and mark:
+git bisect good  # or
+git bisect bad
+
+# Repeat until found
+# Git will say: "abc123 is the first bad commit"
+
+# End bisect
+git bisect reset
+```
+
+```bash
+# Automated bisect with test script
+git bisect start HEAD v1.0.0
+git bisect run npm test
+```
+
+## Time Travel Debugging
+
+Work backwards from the failure.
+
+```markdown
+1. Start at the error/failure point
+2. What value caused it? Where did that come from?
+3. Trace backwards through the code
+4. Find where the value diverged from expected
+```
+
+```typescript
+// Error: Cannot read 'name' of undefined at line 45
+
+// Line 45: const name = user.name;
+// Q: Why is user undefined?
+
+// Line 40: const user = users.find(u => u.id === id);
+// Q: Why didn't find() return a user?
+
+// Check: Is the id correct? Are users populated?
+console.log({ id, users, user });
+```
+
+## Rubber Duck Debugging
+
+Explain the problem step by step.
+
+```markdown
+1. State what the code should do
+2. Explain what it actually does
+3. Walk through the code line by line
+4. Describe what each line does
+5. The discrepancy often becomes obvious
+```
+
+## Delta Debugging
+
+When something recently broke.
+
+```bash
+# Check what changed
+git diff HEAD~5..HEAD
+
+# Check specific file history
+git log -p --follow -- src/problematic-file.ts
+
+# Find when file last worked
+git log --oneline -- src/problematic-file.ts
+```
+
+## Quick Reference
+
+| Strategy | Best For |
+|----------|----------|
+| Binary Search | Unknown bug location |
+| Minimal Repro | Complex bugs, reporting |
+| Git Bisect | Regression bugs |
+| Time Travel | Known error location |
+| Rubber Duck | Logic errors |
+| Delta Debug | Recent breakage |

--- a/.claude/skills/debugging-wizard/references/systematic-debugging.md
+++ b/.claude/skills/debugging-wizard/references/systematic-debugging.md
@@ -1,0 +1,367 @@
+# Systematic Debugging
+
+---
+
+## Core Principle
+
+> **NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+Jumping to fixes without understanding causes creates more bugs. Systematic debugging prevents the "fix one thing, break two more" cycle.
+
+---
+
+## The Four Mandatory Phases
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    SYSTEMATIC DEBUGGING                      │
+├─────────────────────────────────────────────────────────────┤
+│  Phase 1: ROOT CAUSE INVESTIGATION                          │
+│  ├── Read error messages thoroughly                         │
+│  ├── Reproduce reliably with documented steps               │
+│  ├── Examine recent changes                                 │
+│  └── Trace data flow backward                               │
+├─────────────────────────────────────────────────────────────┤
+│  Phase 2: PATTERN ANALYSIS                                   │
+│  ├── Find similar working implementations                   │
+│  ├── Study reference implementations completely             │
+│  └── Document all differences                               │
+├─────────────────────────────────────────────────────────────┤
+│  Phase 3: HYPOTHESIS TESTING                                 │
+│  ├── Form specific, written hypothesis                      │
+│  ├── Test with minimal, isolated changes                    │
+│  └── One variable at a time                                 │
+├─────────────────────────────────────────────────────────────┤
+│  Phase 4: IMPLEMENTATION                                     │
+│  ├── Create failing test case                               │
+│  ├── Implement single fix addressing root cause             │
+│  └── Verify no new breakage                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 1: Root Cause Investigation
+
+**Objective:** Understand exactly what is failing and why before attempting any fix.
+
+### Step 1.1: Read Error Messages Thoroughly
+
+```bash
+# Don't just read the first line
+TypeError: Cannot read property 'map' of undefined
+    at UserList.render (UserList.tsx:24)
+    at renderWithHooks (react-dom.js:14985)
+    at mountIndeterminateComponent (react-dom.js:17811)
+```
+
+**Key questions:**
+- What exact operation failed?
+- Where in the code (file, line)?
+- What was the call stack?
+- Are there multiple errors or just one?
+
+### Step 1.2: Reproduce Reliably
+
+```markdown
+## Reproduction Steps
+1. Navigate to /users
+2. Click "Load More" button
+3. Wait for loading spinner
+4. **ERROR: "Cannot read property 'map' of undefined"**
+
+## Environment
+- Browser: Chrome 120
+- User: Admin role
+- Data state: 50+ users in database
+```
+
+**Requirement:** Document exact steps that reproduce the bug 100% of the time.
+
+### Step 1.3: Examine Recent Changes
+
+```bash
+# What changed recently?
+git log --oneline -10
+
+# What specifically changed in the failing file?
+git log -p UserList.tsx
+
+# When did this start failing?
+git bisect start
+git bisect bad HEAD
+git bisect good v1.2.0
+```
+
+### Step 1.4: Trace Data Flow Backward
+
+```typescript
+// Error happens here:
+users.map(u => u.name)  // users is undefined
+
+// Trace backward:
+// Where does 'users' come from?
+const users = props.users;
+
+// Where do props come from?
+<UserList users={data.users} />
+
+// Where does data come from?
+const { data } = useQuery(GET_USERS);
+
+// ROOT CAUSE: Query returns { users: null } when loading
+```
+
+### Step 1.5: Add Diagnostic Instrumentation
+
+```typescript
+// Add temporary logging at boundaries
+console.log('[UserList] props:', JSON.stringify(props));
+console.log('[UserList] users type:', typeof props.users);
+console.log('[UserList] users value:', props.users);
+
+// Check at data source
+console.log('[API] Response:', response);
+console.log('[API] Response.data:', response.data);
+```
+
+---
+
+## Phase 2: Pattern Analysis
+
+**Objective:** Find working examples to understand what correct behavior looks like.
+
+### Step 2.1: Locate Similar Working Implementations
+
+```bash
+# Find similar components that work correctly
+grep -r "useQuery" src/components/ --include="*.tsx"
+
+# Find how other lists handle loading states
+grep -r "loading" src/components/*List* --include="*.tsx"
+```
+
+### Step 2.2: Study Reference Implementations Completely
+
+```typescript
+// WORKING: ProductList.tsx
+function ProductList({ products, loading }) {
+  if (loading) return <Spinner />;
+  if (!products) return null;  // ← Handles undefined case
+
+  return products.map(p => <ProductItem key={p.id} {...p} />);
+}
+
+// BROKEN: UserList.tsx
+function UserList({ users, loading }) {
+  if (loading) return <Spinner />;
+  // Missing: !users check
+
+  return users.map(u => <UserItem key={u.id} {...u} />);  // 💥 Crashes
+}
+```
+
+### Step 2.3: Document All Differences
+
+| Aspect | Working (ProductList) | Broken (UserList) |
+|--------|----------------------|-------------------|
+| Null check | `if (!products)` | Missing |
+| Default value | `products ?? []` | None |
+| Loading handled | Before render | Before render |
+| Error handled | Returns ErrorState | Missing |
+
+---
+
+## Phase 3: Hypothesis Testing
+
+**Objective:** Verify your understanding with controlled experiments.
+
+### Step 3.1: Form Specific, Written Hypothesis
+
+```markdown
+## Hypothesis #1
+**Statement:** The crash occurs because `users` is undefined when the
+query is complete but returns no data.
+
+**Prediction:** Adding a null check before `.map()` will prevent the crash.
+
+**Test:** Add `if (!users) return null;` before the map call.
+```
+
+### Step 3.2: Test with Minimal Changes
+
+```typescript
+// Change ONLY one thing
+function UserList({ users, loading }) {
+  if (loading) return <Spinner />;
+  if (!users) return null;  // ← Single change
+
+  return users.map(u => <UserItem key={u.id} {...u} />);
+}
+```
+
+### Step 3.3: One Variable at a Time
+
+```markdown
+## Test Results
+
+| Hypothesis | Change | Result | Conclusion |
+|------------|--------|--------|------------|
+| #1: Null check | Add `if (!users)` | ✓ Pass | Confirmed |
+
+Do NOT test multiple hypotheses simultaneously.
+```
+
+---
+
+## Phase 4: Implementation
+
+**Objective:** Fix the bug permanently with proper safeguards.
+
+### Step 4.1: Create Failing Test Case First
+
+```typescript
+describe('UserList', () => {
+  it('should handle undefined users gracefully', () => {
+    // This test should FAIL before the fix
+    const { container } = render(<UserList users={undefined} loading={false} />);
+    expect(container).not.toThrow();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+});
+```
+
+### Step 4.2: Implement Single Fix
+
+```typescript
+function UserList({ users, loading }: UserListProps) {
+  if (loading) return <Spinner />;
+  if (!users || users.length === 0) {
+    return <EmptyState message="No users found" />;
+  }
+
+  return (
+    <ul role="list">
+      {users.map(u => <UserItem key={u.id} {...u} />)}
+    </ul>
+  );
+}
+```
+
+### Step 4.3: Verify No New Breakage
+
+```bash
+# Run full test suite
+npm test
+
+# Run specific component tests
+npm test UserList
+
+# Run integration tests
+npm run test:integration
+
+# Verify in browser
+# 1. Normal case: 50 users
+# 2. Empty case: 0 users
+# 3. Loading case: spinner shows
+# 4. Error case: error message shows
+```
+
+---
+
+## The Three-Fix Threshold
+
+> **After 3 failed fix attempts → STOP.**
+
+Three failures in different locations signals architectural problems, not isolated bugs.
+
+### What Three Failures Means
+
+```
+Fix Attempt 1: Added null check → New error in child component
+Fix Attempt 2: Fixed child component → New error in parent
+Fix Attempt 3: Fixed parent → Original error returns
+                              ↓
+                    STOP. QUESTION ARCHITECTURE.
+```
+
+### At the Threshold, Do This
+
+1. **Stop fixing symptoms**
+2. **Document the pattern** of failures
+3. **Identify architectural assumptions** being violated
+4. **Propose structural change** rather than patch
+5. **Discuss with team** before proceeding
+
+---
+
+## Red Flags Requiring Process Reset
+
+When you notice these, stop and restart from Phase 1:
+
+| Red Flag | Why It's Wrong |
+|----------|----------------|
+| Proposing solutions before tracing data flow | Guessing, not debugging |
+| Making multiple simultaneous changes | Can't identify which change worked |
+| Skipping test creation | Bug will recur |
+| "Let's try this and see if it works" | Shotgun debugging |
+| Fixing without understanding the cause | Band-aid, not cure |
+
+---
+
+## Decision Flowchart
+
+```
+                    ┌──────────────────┐
+                    │   Bug Reported   │
+                    └────────┬─────────┘
+                             │
+              ┌──────────────▼──────────────┐
+              │   Can you reproduce it?      │
+              └──────────────┬──────────────┘
+                    No       │       Yes
+            ┌────────────────┴────────────────┐
+            ▼                                  ▼
+    ┌───────────────┐               ┌─────────────────┐
+    │ Get more info │               │ Trace data flow │
+    └───────────────┘               └────────┬────────┘
+                                             │
+                              ┌──────────────▼──────────────┐
+                              │ Do you understand the cause? │
+                              └──────────────┬──────────────┘
+                                    No       │       Yes
+                    ┌────────────────────────┴─────────┐
+                    ▼                                   ▼
+            ┌───────────────┐               ┌─────────────────┐
+            │ Study working │               │ Write hypothesis│
+            │   examples    │               └────────┬────────┘
+            └───────────────┘                        │
+                                             ┌───────▼───────┐
+                                             │  Write test   │
+                                             └───────┬───────┘
+                                                     │
+                                             ┌───────▼───────┐
+                                             │  Implement    │
+                                             └───────┬───────┘
+                                                     │
+                                  ┌──────────────────▼──────────────────┐
+                                  │          Does test pass?            │
+                                  └──────────────────┬──────────────────┘
+                                            No       │       Yes
+                            ┌────────────────────────┴──────────┐
+                            ▼                                    ▼
+                    ┌───────────────┐                  ┌─────────────────┐
+                    │ Attempt < 3?  │                  │      Done       │
+                    └───────┬───────┘                  └─────────────────┘
+                    No      │      Yes
+            ┌───────────────┴─────────────────┐
+            ▼                                  ▼
+    ┌───────────────────┐          ┌─────────────────────┐
+    │ Question          │          │ Return to Phase 1   │
+    │ architecture      │          └─────────────────────┘
+    └───────────────────┘
+```
+
+---
+
+*Content adapted from [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (@obra), MIT License.*

--- a/.claude/skills/fastapi-expert/SKILL.md
+++ b/.claude/skills/fastapi-expert/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: fastapi-expert
+description: "Use when building high-performance async Python APIs with FastAPI and Pydantic V2. Invoke to create REST endpoints, define Pydantic models, implement authentication flows, set up async SQLAlchemy database operations, add JWT authentication, build WebSocket endpoints, or generate OpenAPI documentation. Trigger terms: FastAPI, Pydantic, async Python, Python API, REST API Python, SQLAlchemy async, JWT authentication, OpenAPI, Swagger Python."
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: backend
+  triggers: FastAPI, Pydantic, async Python, Python API, REST API Python, SQLAlchemy async, JWT authentication, OpenAPI, Swagger Python
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: fullstack-guardian, django-expert, test-master
+---
+
+# FastAPI Expert
+
+Deep expertise in async Python, Pydantic V2, and production-grade API development with FastAPI.
+
+## When to Use This Skill
+
+- Building REST APIs with FastAPI
+- Implementing Pydantic V2 validation schemas
+- Setting up async database operations
+- Implementing JWT authentication/authorization
+- Creating WebSocket endpoints
+- Optimizing API performance
+
+## Core Workflow
+
+1. **Analyze requirements** — Identify endpoints, data models, auth needs
+2. **Design schemas** — Create Pydantic V2 models for validation
+3. **Implement** — Write async endpoints with proper dependency injection
+4. **Secure** — Add authentication, authorization, rate limiting
+5. **Test** — Write async tests with pytest and httpx; run `pytest` after each endpoint group and verify OpenAPI docs at `/docs`
+
+> **Checkpoint after each step:** confirm schemas validate correctly, endpoints return expected HTTP status codes, and `/docs` reflects the intended API surface before proceeding.
+
+## Minimal Complete Example
+
+Schema + endpoint + dependency injection in one cohesive unit:
+
+```python
+# schemas.py
+from pydantic import BaseModel, EmailStr, field_validator, model_config
+
+class UserCreate(BaseModel):
+    model_config = model_config(str_strip_whitespace=True)
+
+    email: EmailStr
+    password: str
+    name: str | None = None
+
+    @field_validator("password")
+    @classmethod
+    def password_strength(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters")
+        return v
+
+class UserResponse(BaseModel):
+    model_config = model_config(from_attributes=True)
+
+    id: int
+    email: EmailStr
+    name: str | None = None
+```
+
+```python
+# routers/users.py
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Annotated
+
+from app.database import get_db
+from app.schemas import UserCreate, UserResponse
+from app import crud
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+DbDep = Annotated[AsyncSession, Depends(get_db)]
+
+@router.post("/", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def create_user(payload: UserCreate, db: DbDep) -> UserResponse:
+    existing = await crud.get_user_by_email(db, payload.email)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
+    return await crud.create_user(db, payload)
+```
+
+```python
+# crud.py
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models import User
+from app.schemas import UserCreate
+from app.security import hash_password
+
+async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
+    result = await db.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()
+
+async def create_user(db: AsyncSession, payload: UserCreate) -> User:
+    user = User(email=payload.email, hashed_password=hash_password(payload.password), name=payload.name)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+```
+
+## JWT Authentication Snippet
+
+```python
+# security.py
+from datetime import datetime, timedelta, timezone
+from jose import JWTError, jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from typing import Annotated
+
+SECRET_KEY = "read-from-env"  # use os.environ / settings
+ALGORITHM = "HS256"
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+def create_access_token(subject: str, expires_delta: timedelta = timedelta(minutes=30)) -> str:
+    payload = {"sub": subject, "exp": datetime.now(timezone.utc) + expires_delta}
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]) -> str:
+    try:
+        data = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        subject: str | None = data.get("sub")
+        if subject is None:
+            raise ValueError
+        return subject
+    except (JWTError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+CurrentUser = Annotated[str, Depends(get_current_user)]
+```
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Pydantic V2 | `references/pydantic-v2.md` | Creating schemas, validation, model_config |
+| SQLAlchemy | `references/async-sqlalchemy.md` | Async database, models, CRUD operations |
+| Endpoints | `references/endpoints-routing.md` | APIRouter, dependencies, routing |
+| Authentication | `references/authentication.md` | JWT, OAuth2, get_current_user |
+| Testing | `references/testing-async.md` | pytest-asyncio, httpx, fixtures |
+| Django Migration | `references/migration-from-django.md` | Migrating from Django/DRF to FastAPI |
+
+## Constraints
+
+### MUST DO
+- Use type hints everywhere (FastAPI requires them)
+- Use Pydantic V2 syntax (`field_validator`, `model_validator`, `model_config`)
+- Use `Annotated` pattern for dependency injection
+- Use async/await for all I/O operations
+- Use `X | None` instead of `Optional[X]`
+- Return proper HTTP status codes
+- Document endpoints (auto-generated OpenAPI)
+
+### MUST NOT DO
+- Use synchronous database operations
+- Skip Pydantic validation
+- Store passwords in plain text
+- Expose sensitive data in responses
+- Use Pydantic V1 syntax (`@validator`, `class Config`)
+- Mix sync and async code improperly
+- Hardcode configuration values
+
+## Output Templates
+
+When implementing FastAPI features, provide:
+1. Schema file (Pydantic models)
+2. Endpoint file (router with endpoints)
+3. CRUD operations if database involved
+4. Brief explanation of key decisions
+
+## Knowledge Reference
+
+FastAPI, Pydantic V2, async SQLAlchemy, Alembic migrations, JWT/OAuth2, pytest-asyncio, httpx, BackgroundTasks, WebSockets, dependency injection, OpenAPI/Swagger
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/backend/fastapi-expert/)

--- a/.claude/skills/fastapi-expert/references/async-sqlalchemy.md
+++ b/.claude/skills/fastapi-expert/references/async-sqlalchemy.md
@@ -1,0 +1,146 @@
+# Async SQLAlchemy
+
+## Engine & Session Setup
+
+```python
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import DeclarativeBase
+
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DEBUG,
+    pool_pre_ping=True,
+)
+
+async_session = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+class Base(DeclarativeBase):
+    pass
+```
+
+## Model Definition
+
+```python
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import String, ForeignKey, DateTime, func
+from datetime import datetime
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    username: Mapped[str] = mapped_column(String(50), unique=True)
+    hashed_password: Mapped[str] = mapped_column(String(255))
+    is_active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+
+    # Relationships
+    posts: Mapped[list["Post"]] = relationship(back_populates="author", lazy="selectin")
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(200))
+    content: Mapped[str]
+    author_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+
+    author: Mapped["User"] = relationship(back_populates="posts")
+```
+
+## Database Dependency
+
+```python
+from typing import AsyncGenerator
+from fastapi import Depends
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+# Type alias for injection
+DB = Annotated[AsyncSession, Depends(get_db)]
+```
+
+## CRUD Operations
+
+```python
+from sqlalchemy import select, update, delete
+from sqlalchemy.orm import selectinload
+
+async def get_user(db: AsyncSession, user_id: int) -> User | None:
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+async def get_user_with_posts(db: AsyncSession, user_id: int) -> User | None:
+    result = await db.execute(
+        select(User)
+        .options(selectinload(User.posts))
+        .where(User.id == user_id)
+    )
+    return result.scalar_one_or_none()
+
+async def get_users(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[User]:
+    result = await db.execute(select(User).offset(skip).limit(limit))
+    return list(result.scalars().all())
+
+async def create_user(db: AsyncSession, user_in: UserCreate) -> User:
+    user = User(**user_in.model_dump())
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+async def update_user(db: AsyncSession, user_id: int, user_in: UserUpdate) -> User:
+    await db.execute(
+        update(User)
+        .where(User.id == user_id)
+        .values(**user_in.model_dump(exclude_unset=True))
+    )
+    return await get_user(db, user_id)
+
+async def delete_user(db: AsyncSession, user_id: int) -> bool:
+    result = await db.execute(delete(User).where(User.id == user_id))
+    return result.rowcount > 0
+```
+
+## Lifespan Handler
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    # Shutdown
+    await engine.dispose()
+
+app = FastAPI(lifespan=lifespan)
+```
+
+## Quick Reference
+
+| Operation | Method |
+|-----------|--------|
+| Select one | `result.scalar_one_or_none()` |
+| Select many | `result.scalars().all()` |
+| Eager load | `.options(selectinload(...))` |
+| Create | `db.add(obj)` + `await db.flush()` |
+| Update | `update(Model).where(...).values(...)` |
+| Delete | `delete(Model).where(...)` |
+| Commit | `await db.commit()` |
+| Rollback | `await db.rollback()` |

--- a/.claude/skills/fastapi-expert/references/authentication.md
+++ b/.claude/skills/fastapi-expert/references/authentication.md
@@ -1,0 +1,159 @@
+# Authentication
+
+## OAuth2 Password Flow
+
+```python
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from typing import Annotated
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/token")
+
+@router.post("/token")
+async def login(
+    db: DB,
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+) -> Token:
+    user = await authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            "Incorrect email or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return Token(
+        access_token=create_access_token(sub=str(user.id)),
+        token_type="bearer",
+    )
+```
+
+## JWT Token Creation
+
+```python
+from datetime import datetime, timedelta, UTC
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return pwd_context.verify(plain, hashed)
+
+def hash_password(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(
+    sub: str,
+    expires_delta: timedelta | None = None,
+) -> str:
+    expire = datetime.now(UTC) + (expires_delta or timedelta(minutes=15))
+    return jwt.encode(
+        {"sub": sub, "exp": expire, "type": "access"},
+        settings.SECRET_KEY,
+        algorithm="HS256",
+    )
+
+def create_refresh_token(sub: str) -> str:
+    expire = datetime.now(UTC) + timedelta(days=7)
+    return jwt.encode(
+        {"sub": sub, "exp": expire, "type": "refresh"},
+        settings.SECRET_KEY,
+        algorithm="HS256",
+    )
+```
+
+## Get Current User
+
+```python
+async def get_current_user(
+    db: DB,
+    token: Annotated[str, Depends(oauth2_scheme)],
+) -> User:
+    credentials_exception = HTTPException(
+        status.HTTP_401_UNAUTHORIZED,
+        "Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+        user_id = int(payload.get("sub"))
+        if payload.get("type") != "access":
+            raise credentials_exception
+    except (JWTError, ValueError, TypeError):
+        raise credentials_exception
+
+    user = await get_user_db(db, user_id)
+    if not user:
+        raise credentials_exception
+    return user
+
+CurrentUser = Annotated[User, Depends(get_current_user)]
+```
+
+## Role-Based Access
+
+```python
+from enum import Enum
+
+class UserRole(str, Enum):
+    USER = "user"
+    ADMIN = "admin"
+    MODERATOR = "moderator"
+
+def require_roles(*roles: UserRole):
+    async def role_checker(current_user: CurrentUser) -> User:
+        if current_user.role not in roles:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                f"Required roles: {[r.value for r in roles]}",
+            )
+        return current_user
+    return role_checker
+
+# Usage
+@router.delete("/{id}")
+async def delete_user(
+    user_id: int,
+    admin: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
+) -> None:
+    ...
+```
+
+## Refresh Token
+
+```python
+@router.post("/refresh", response_model=Token)
+async def refresh_token(
+    db: DB,
+    refresh_token: str = Body(..., embed=True),
+) -> Token:
+    try:
+        payload = jwt.decode(refresh_token, settings.SECRET_KEY, algorithms=["HS256"])
+        if payload.get("type") != "refresh":
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token type")
+        user_id = int(payload.get("sub"))
+    except (JWTError, ValueError):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid refresh token")
+
+    user = await get_user_db(db, user_id)
+    if not user:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
+
+    return Token(
+        access_token=create_access_token(sub=str(user.id)),
+        token_type="bearer",
+    )
+```
+
+## Quick Reference
+
+| Component | Purpose |
+|-----------|---------|
+| `OAuth2PasswordBearer` | Extract token from header |
+| `OAuth2PasswordRequestForm` | Login form data |
+| `jwt.encode()` | Create JWT |
+| `jwt.decode()` | Verify JWT |
+| `pwd_context.hash()` | Hash password |
+| `pwd_context.verify()` | Check password |
+| `Depends(get_current_user)` | Require auth |
+| `require_roles()` | Role-based access |

--- a/.claude/skills/fastapi-expert/references/endpoints-routing.md
+++ b/.claude/skills/fastapi-expert/references/endpoints-routing.md
@@ -1,0 +1,142 @@
+# Endpoints & Routing
+
+## Router Setup
+
+```python
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+from typing import Annotated
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+# Type aliases for common dependencies
+DB = Annotated[AsyncSession, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(get_current_user)]
+Pagination = Annotated[int, Query(ge=1, le=100)]
+```
+
+## CRUD Endpoints
+
+```python
+@router.post("/", response_model=UserOut, status_code=status.HTTP_201_CREATED)
+async def create_user(db: DB, user_in: UserCreate) -> User:
+    if await get_user_by_email(db, user_in.email):
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Email already registered")
+    return await create_user_db(db, user_in)
+
+@router.get("/", response_model=list[UserOut])
+async def list_users(
+    db: DB,
+    current_user: CurrentUser,
+    skip: int = Query(0, ge=0),
+    limit: Pagination = 20,
+) -> list[User]:
+    return await get_users(db, skip=skip, limit=limit)
+
+@router.get("/{user_id}", response_model=UserOut)
+async def get_user(
+    db: DB,
+    user_id: Annotated[int, Path(gt=0)],
+) -> User:
+    user = await get_user_db(db, user_id)
+    if not user:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+    return user
+
+@router.patch("/{user_id}", response_model=UserOut)
+async def update_user(
+    db: DB,
+    user_id: int,
+    user_in: UserUpdate,
+    current_user: CurrentUser,
+) -> User:
+    if current_user.id != user_id and not current_user.is_admin:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Not authorized")
+    return await update_user_db(db, user_id, user_in)
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user(db: DB, user_id: int, current_user: CurrentUser) -> None:
+    if not await delete_user_db(db, user_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "User not found")
+```
+
+## Custom Dependencies
+
+```python
+from fastapi import Depends
+
+async def get_current_active_user(
+    current_user: CurrentUser,
+) -> User:
+    if not current_user.is_active:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "Inactive user")
+    return current_user
+
+ActiveUser = Annotated[User, Depends(get_current_active_user)]
+
+async def require_admin(current_user: CurrentUser) -> User:
+    if not current_user.is_admin:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Admin required")
+    return current_user
+
+AdminUser = Annotated[User, Depends(require_admin)]
+```
+
+## Query Parameters
+
+```python
+@router.get("/search")
+async def search_users(
+    db: DB,
+    q: str = Query(min_length=1, max_length=100),
+    is_active: bool | None = None,
+    role: UserRole | None = None,
+    created_after: datetime | None = None,
+    sort_by: Annotated[str, Query(pattern="^(name|email|created_at)$")] = "created_at",
+    order: Annotated[str, Query(pattern="^(asc|desc)$")] = "desc",
+) -> list[User]:
+    return await search_users_db(db, q, is_active, role, created_after, sort_by, order)
+```
+
+## Include Router
+
+```python
+# main.py
+from fastapi import FastAPI
+from app.api.v1 import users, auth, posts
+
+app = FastAPI()
+
+app.include_router(users.router, prefix="/api/v1")
+app.include_router(auth.router, prefix="/api/v1")
+app.include_router(posts.router, prefix="/api/v1")
+```
+
+## Response Models
+
+```python
+from fastapi import Response
+
+@router.get("/", response_model=list[UserOut], response_model_exclude_unset=True)
+async def list_users(...) -> list[User]:
+    ...
+
+@router.get("/{id}", responses={
+    200: {"model": UserOut},
+    404: {"description": "User not found"},
+})
+async def get_user(...) -> User:
+    ...
+```
+
+## Quick Reference
+
+| Decorator | Purpose |
+|-----------|---------|
+| `@router.get("/")` | GET endpoint |
+| `@router.post("/", status_code=201)` | POST with status |
+| `Query(ge=0)` | Query param validation |
+| `Path(gt=0)` | Path param validation |
+| `Depends(func)` | Dependency injection |
+| `Annotated[T, Depends()]` | Type alias pattern |
+| `response_model=Model` | Response schema |
+| `HTTPException(status, detail)` | Error response |

--- a/.claude/skills/fastapi-expert/references/migration-from-django.md
+++ b/.claude/skills/fastapi-expert/references/migration-from-django.md
@@ -1,0 +1,997 @@
+# Django to FastAPI Migration Guide
+
+---
+
+## When to Use This Guide
+
+**Migrate to FastAPI when:**
+- Need async/await for I/O-bound operations
+- Require WebSocket or Server-Sent Events
+- Want automatic OpenAPI/Swagger documentation
+- Need better performance for API-heavy workloads
+- Desire modern Python type hints and editor support
+- Building microservices from Django monolith
+- Require lower resource consumption
+
+**DO NOT migrate when:**
+- Heavy use of Django admin interface
+- Extensive Django ORM model inheritance
+- Complex form handling and validation
+- Server-side template rendering required
+- Team lacks async Python experience
+- Django ecosystem plugins are critical
+- Migration cost exceeds business value
+
+---
+
+## Concept Mapping: Django/DRF → FastAPI
+
+| Django/DRF Concept | FastAPI Equivalent | Notes |
+|-------------------|-------------------|-------|
+| `models.Model` | Pydantic `BaseModel` + SQLAlchemy | Separate schema from ORM |
+| `serializers.Serializer` | Pydantic `BaseModel` | Type-safe validation |
+| `ModelSerializer` | Multiple Pydantic models | Create/Read/Update schemas |
+| `ViewSet` | `APIRouter` + path operations | More explicit routing |
+| `GenericAPIView` | Dependency injection | Function-based approach |
+| `@api_view` decorator | `@router.get/post` | Built-in HTTP methods |
+| `urls.py` | `APIRouter` + `app.include_router` | Nested routers |
+| `settings.py` | `pydantic-settings` | Environment-based config |
+| `middleware` | Middleware + dependencies | More granular control |
+| `permissions` | Dependencies | Composable auth |
+| `authentication` | OAuth2 + JWT dependencies | Standards-based |
+| `pagination` | Query parameters + dependencies | Manual implementation |
+| `filters` | Query parameters | Type-safe filtering |
+| `Django ORM` | SQLAlchemy 2.0+ | Async support |
+| `select_related` | `selectinload` | Eager loading |
+| `prefetch_related` | `joinedload` | Join strategies |
+| `pytest-django` | `pytest + httpx` | Async test client |
+| `admin.py` | External (SQLAdmin, etc.) | Not built-in |
+
+---
+
+## Serializer → Pydantic V2 Migration
+
+### Django REST Framework Serializer
+
+```python
+# Django DRF
+from rest_framework import serializers
+from .models import User, Post
+
+class UserSerializer(serializers.ModelSerializer):
+    post_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'created_at', 'post_count']
+        read_only_fields = ['id', 'created_at']
+        extra_kwargs = {
+            'email': {'write_only': True}
+        }
+
+    def get_post_count(self, obj):
+        return obj.posts.count()
+
+    def validate_username(self, value):
+        if len(value) < 3:
+            raise serializers.ValidationError("Username too short")
+        return value
+
+class PostSerializer(serializers.ModelSerializer):
+    author = UserSerializer(read_only=True)
+    tags = serializers.ListField(child=serializers.CharField())
+
+    class Meta:
+        model = Post
+        fields = ['id', 'title', 'content', 'author', 'tags', 'published']
+
+    def create(self, validated_data):
+        tags = validated_data.pop('tags', [])
+        post = Post.objects.create(**validated_data)
+        post.tags.set(tags)
+        return post
+```
+
+### FastAPI Pydantic V2 Schemas
+
+```python
+# FastAPI with Pydantic V2
+from pydantic import BaseModel, EmailStr, Field, field_validator, computed_field
+from datetime import datetime
+from typing import Annotated
+
+# Base schemas
+class UserBase(BaseModel):
+    username: Annotated[str, Field(min_length=3, max_length=50)]
+    email: EmailStr
+
+# Create schema (input)
+class UserCreate(UserBase):
+    password: Annotated[str, Field(min_length=8)]
+
+    @field_validator('username')
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        if len(v) < 3:
+            raise ValueError("Username too short")
+        return v
+
+# Update schema (partial)
+class UserUpdate(BaseModel):
+    username: Annotated[str | None, Field(min_length=3, max_length=50)] = None
+    email: EmailStr | None = None
+
+# Read schema (output) - analogous to read_only_fields
+class UserRead(UserBase):
+    id: int
+    created_at: datetime
+
+    model_config = {
+        "from_attributes": True  # Pydantic V2: replaces orm_mode
+    }
+
+# Read schema with relations - analogous to SerializerMethodField
+class UserReadWithStats(UserRead):
+    post_count: int
+
+    @computed_field  # Pydantic V2 computed fields
+    @property
+    def display_name(self) -> str:
+        return f"@{self.username}"
+
+# Nested schemas
+class PostBase(BaseModel):
+    title: Annotated[str, Field(max_length=200)]
+    content: str
+    tags: list[str] = []
+    published: bool = False
+
+class PostCreate(PostBase):
+    pass
+
+class PostRead(PostBase):
+    id: int
+    author: UserRead  # Nested serialization
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+# Embedding vs side-loading
+class PostReadMinimal(BaseModel):
+    """Minimal post representation (just ID)"""
+    id: int
+    title: str
+    author_id: int  # Side-loaded reference
+
+    model_config = {"from_attributes": True}
+```
+
+---
+
+## ViewSet → APIRouter Migration
+
+### Django REST Framework ViewSet
+
+```python
+# Django DRF ViewSet
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django.shortcuts import get_object_or_404
+
+class PostViewSet(viewsets.ModelViewSet):
+    queryset = Post.objects.all()
+    serializer_class = PostSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.user.is_authenticated:
+            return queryset.filter(author=self.request.user)
+        return queryset.none()
+
+    def perform_create(self, serializer):
+        serializer.save(author=self.request.user)
+
+    @action(detail=True, methods=['post'])
+    def publish(self, request, pk=None):
+        post = self.get_object()
+        post.published = True
+        post.save()
+        return Response({'status': 'published'})
+
+    @action(detail=False, methods=['get'])
+    def recent(self, request):
+        recent_posts = self.get_queryset().order_by('-created_at')[:10]
+        serializer = self.get_serializer(recent_posts, many=True)
+        return Response(serializer.data)
+```
+
+### FastAPI APIRouter with Dependencies
+
+```python
+# FastAPI APIRouter
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from typing import Annotated
+
+from .database import get_db
+from .auth import get_current_user
+from .models import Post as PostModel, User as UserModel
+from .schemas import PostRead, PostCreate, PostUpdate, UserRead
+
+router = APIRouter(prefix="/posts", tags=["posts"])
+
+# Dependency for database session
+DbSession = Annotated[AsyncSession, Depends(get_db)]
+CurrentUser = Annotated[UserModel, Depends(get_current_user)]
+
+# List posts (GET /posts)
+@router.get("/", response_model=list[PostRead])
+async def list_posts(
+    db: DbSession,
+    current_user: CurrentUser,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, le=100),
+):
+    """Analogous to ViewSet.list()"""
+    result = await db.execute(
+        select(PostModel)
+        .where(PostModel.author_id == current_user.id)
+        .offset(skip)
+        .limit(limit)
+    )
+    posts = result.scalars().all()
+    return posts
+
+# Create post (POST /posts)
+@router.post("/", response_model=PostRead, status_code=status.HTTP_201_CREATED)
+async def create_post(
+    post_data: PostCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    """Analogous to ViewSet.create()"""
+    post = PostModel(**post_data.model_dump(), author_id=current_user.id)
+    db.add(post)
+    await db.commit()
+    await db.refresh(post)
+    return post
+
+# Retrieve single post (GET /posts/{post_id})
+@router.get("/{post_id}", response_model=PostRead)
+async def get_post(
+    post_id: int,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    """Analogous to ViewSet.retrieve()"""
+    result = await db.execute(
+        select(PostModel).where(
+            PostModel.id == post_id,
+            PostModel.author_id == current_user.id
+        )
+    )
+    post = result.scalar_one_or_none()
+    if not post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    return post
+
+# Update post (PUT /posts/{post_id})
+@router.put("/{post_id}", response_model=PostRead)
+async def update_post(
+    post_id: int,
+    post_data: PostUpdate,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    """Analogous to ViewSet.update()"""
+    result = await db.execute(
+        select(PostModel).where(
+            PostModel.id == post_id,
+            PostModel.author_id == current_user.id
+        )
+    )
+    post = result.scalar_one_or_none()
+    if not post:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    # Update only provided fields
+    for field, value in post_data.model_dump(exclude_unset=True).items():
+        setattr(post, field, value)
+
+    await db.commit()
+    await db.refresh(post)
+    return post
+
+# Delete post (DELETE /posts/{post_id})
+@router.delete("/{post_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_post(
+    post_id: int,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    """Analogous to ViewSet.destroy()"""
+    result = await db.execute(
+        select(PostModel).where(
+            PostModel.id == post_id,
+            PostModel.author_id == current_user.id
+        )
+    )
+    post = result.scalar_one_or_none()
+    if not post:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    await db.delete(post)
+    await db.commit()
+
+# Custom action: Publish (POST /posts/{post_id}/publish)
+@router.post("/{post_id}/publish", response_model=dict)
+async def publish_post(
+    post_id: int,
+    db: DbSession,
+    current_user: CurrentUser,
+):
+    """Analogous to @action(detail=True)"""
+    result = await db.execute(
+        select(PostModel).where(
+            PostModel.id == post_id,
+            PostModel.author_id == current_user.id
+        )
+    )
+    post = result.scalar_one_or_none()
+    if not post:
+        raise HTTPException(status_code=404, detail="Post not found")
+
+    post.published = True
+    await db.commit()
+    return {"status": "published"}
+
+# Custom collection action: Recent posts (GET /posts/recent)
+@router.get("/actions/recent", response_model=list[PostRead])
+async def recent_posts(
+    db: DbSession,
+    current_user: CurrentUser,
+    limit: int = Query(10, le=50),
+):
+    """Analogous to @action(detail=False)"""
+    result = await db.execute(
+        select(PostModel)
+        .where(PostModel.author_id == current_user.id)
+        .order_by(PostModel.created_at.desc())
+        .limit(limit)
+    )
+    posts = result.scalars().all()
+    return posts
+```
+
+---
+
+## Django ORM → Async SQLAlchemy
+
+### Django ORM Models
+
+```python
+# Django models
+from django.db import models
+
+class User(models.Model):
+    username = models.CharField(max_length=50, unique=True)
+    email = models.EmailField(unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'users'
+        indexes = [
+            models.Index(fields=['username']),
+        ]
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+    content = models.TextField()
+    author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='posts')
+    created_at = models.DateTimeField(auto_now_add=True)
+    published = models.BooleanField(default=False)
+
+    class Meta:
+        db_table = 'posts'
+        ordering = ['-created_at']
+```
+
+### SQLAlchemy 2.0 Async Models
+
+```python
+# SQLAlchemy 2.0 models
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy import String, Text, Boolean, ForeignKey, Index
+from datetime import datetime
+from typing import List
+
+class Base(DeclarativeBase):
+    pass
+
+class User(Base):
+    __tablename__ = 'users'
+
+    # Primary key
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # Columns with type hints
+    username: Mapped[str] = mapped_column(String(50), unique=True, index=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+
+    # Relationships (analogous to related_name)
+    posts: Mapped[List["Post"]] = relationship(back_populates="author")
+
+    __table_args__ = (
+        Index('ix_users_username', 'username'),
+    )
+
+class Post(Base):
+    __tablename__ = 'posts'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column(String(200))
+    content: Mapped[str] = mapped_column(Text)
+    author_id: Mapped[int] = mapped_column(ForeignKey('users.id', ondelete='CASCADE'))
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    published: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # Relationship
+    author: Mapped["User"] = relationship(back_populates="posts")
+
+    __table_args__ = (
+        Index('ix_posts_created_at', 'created_at'),
+    )
+```
+
+### Query Patterns: Django ORM vs SQLAlchemy
+
+```python
+# Django ORM queries
+from django.db.models import Count, Q
+
+# Simple filter
+posts = Post.objects.filter(published=True)
+
+# Select related (JOIN)
+posts = Post.objects.select_related('author').filter(published=True)
+
+# Prefetch related (separate query)
+users = User.objects.prefetch_related('posts').all()
+
+# Complex filtering
+posts = Post.objects.filter(
+    Q(published=True) | Q(author__username='admin')
+).order_by('-created_at')[:10]
+
+# Aggregation
+user_stats = User.objects.annotate(
+    post_count=Count('posts')
+).filter(post_count__gte=5)
+```
+
+```python
+# SQLAlchemy 2.0 async queries
+from sqlalchemy import select, func, or_
+from sqlalchemy.orm import selectinload, joinedload
+
+# Simple filter
+async def get_published_posts(db: AsyncSession):
+    result = await db.execute(
+        select(Post).where(Post.published == True)
+    )
+    return result.scalars().all()
+
+# Eager loading with JOIN (selectinload = separate query)
+async def get_posts_with_authors(db: AsyncSession):
+    result = await db.execute(
+        select(Post)
+        .options(selectinload(Post.author))
+        .where(Post.published == True)
+    )
+    return result.scalars().all()
+
+# Prefetch related (joinedload = single query with JOIN)
+async def get_users_with_posts(db: AsyncSession):
+    result = await db.execute(
+        select(User).options(joinedload(User.posts))
+    )
+    return result.unique().scalars().all()
+
+# Complex filtering
+async def get_complex_posts(db: AsyncSession):
+    result = await db.execute(
+        select(Post)
+        .join(Post.author)
+        .where(
+            or_(
+                Post.published == True,
+                User.username == 'admin'
+            )
+        )
+        .order_by(Post.created_at.desc())
+        .limit(10)
+    )
+    return result.scalars().all()
+
+# Aggregation
+async def get_user_stats(db: AsyncSession):
+    result = await db.execute(
+        select(User, func.count(Post.id).label('post_count'))
+        .join(Post)
+        .group_by(User.id)
+        .having(func.count(Post.id) >= 5)
+    )
+    return result.all()
+```
+
+---
+
+## Authentication: SimpleJWT → FastAPI JWT
+
+### Django SimpleJWT
+
+```python
+# Django settings.py
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
+}
+
+# Views
+from rest_framework_simplejwt.views import TokenObtainPairView
+
+# Usage in ViewSet
+from rest_framework.permissions import IsAuthenticated
+
+class ProtectedViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return Post.objects.filter(author=self.request.user)
+```
+
+### FastAPI JWT Authentication
+
+```python
+# auth.py - FastAPI JWT implementation
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from datetime import datetime, timedelta
+from pydantic import BaseModel
+from typing import Annotated
+
+# Configuration
+SECRET_KEY = "your-secret-key"  # Use environment variable
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+# Password hashing
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# OAuth2 scheme
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+
+# Schemas
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class TokenData(BaseModel):
+    username: str | None = None
+
+# Helper functions
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+# Dependency: Get current user from token
+async def get_current_user(
+    token: Annotated[str, Depends(oauth2_scheme)],
+    db: Annotated[AsyncSession, Depends(get_db)]
+) -> UserModel:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = TokenData(username=username)
+    except JWTError:
+        raise credentials_exception
+
+    result = await db.execute(
+        select(UserModel).where(UserModel.username == token_data.username)
+    )
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise credentials_exception
+    return user
+
+# Login endpoint
+auth_router = APIRouter(prefix="/auth", tags=["auth"])
+
+@auth_router.post("/token", response_model=Token)
+async def login(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    db: Annotated[AsyncSession, Depends(get_db)]
+):
+    # Authenticate user
+    result = await db.execute(
+        select(UserModel).where(UserModel.username == form_data.username)
+    )
+    user = result.scalar_one_or_none()
+
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Create access token
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+# Protected endpoint usage
+@router.get("/protected")
+async def protected_route(current_user: Annotated[UserModel, Depends(get_current_user)]):
+    return {"message": f"Hello {current_user.username}"}
+```
+
+---
+
+## Testing Migration
+
+### Django/DRF Tests
+
+```python
+# Django pytest
+import pytest
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username='test', password='test123')
+
+@pytest.mark.django_db
+def test_create_post(api_client, user):
+    api_client.force_authenticate(user=user)
+    response = api_client.post('/api/posts/', {
+        'title': 'Test Post',
+        'content': 'Test content'
+    })
+    assert response.status_code == 201
+    assert response.data['title'] == 'Test Post'
+```
+
+### FastAPI Tests
+
+```python
+# FastAPI pytest with httpx
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from app.main import app
+from app.database import get_db, Base
+from app.models import User
+
+# Test database setup
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+@pytest.fixture
+async def db_engine():
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+@pytest.fixture
+async def db_session(db_engine):
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with async_session() as session:
+        yield session
+
+@pytest.fixture
+async def client(db_session):
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+@pytest.fixture
+async def auth_headers(client, db_session):
+    # Create test user
+    user = User(username="test", email="test@example.com")
+    user.hashed_password = get_password_hash("test123")
+    db_session.add(user)
+    await db_session.commit()
+
+    # Get token
+    response = await client.post("/auth/token", data={
+        "username": "test",
+        "password": "test123"
+    })
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+@pytest.mark.asyncio
+async def test_create_post(client, auth_headers):
+    response = await client.post(
+        "/posts/",
+        json={"title": "Test Post", "content": "Test content"},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Test Post"
+
+@pytest.mark.asyncio
+async def test_list_posts(client, auth_headers, db_session):
+    # Create test data
+    user = await db_session.execute(select(User).where(User.username == "test"))
+    user = user.scalar_one()
+
+    post = Post(title="Test", content="Content", author_id=user.id)
+    db_session.add(post)
+    await db_session.commit()
+
+    # Test endpoint
+    response = await client.get("/posts/", headers=auth_headers)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+```
+
+---
+
+## Incremental Migration Strategy
+
+### Phase 1: Parallel API (Strangler Pattern)
+
+Run Django and FastAPI side-by-side, migrating endpoints incrementally.
+
+```python
+# Nginx routing config
+location /api/v2/ {
+    proxy_pass http://fastapi:8000;
+}
+
+location /api/ {
+    proxy_pass http://django:8001;
+}
+```
+
+**Approach:**
+1. Stand up FastAPI with shared database (read-only initially)
+2. Migrate GET endpoints first (lowest risk)
+3. Add write endpoints with dual-write to both systems
+4. Validate data consistency
+5. Switch traffic gradually (feature flags)
+
+### Phase 2: Shared Database Migration
+
+```python
+# FastAPI with existing Django database
+from sqlalchemy import MetaData
+
+# Reflect existing Django tables
+metadata = MetaData()
+metadata.reflect(bind=engine, only=['users', 'posts'])
+
+# Or define models matching Django schema
+class User(Base):
+    __tablename__ = 'auth_user'  # Django's user table
+    # Map to Django's column names
+```
+
+### Phase 3: Database Schema Modernization
+
+After traffic migration, modernize schema:
+- Remove Django-specific fields (`content_type`, `permissions`)
+- Simplify table names (remove app prefixes)
+- Add database-level constraints
+- Optimize indexes for async queries
+
+### Phase 4: Complete Cutover
+
+```python
+# Decommission Django
+# 1. Archive Django admin usage
+# 2. Export management commands to FastAPI CLI
+# 3. Migrate background tasks to Celery/Dramatiq
+# 4. Remove Django dependency
+```
+
+---
+
+## Common Pitfalls
+
+### 1. Async/Await Mistakes
+
+**WRONG:**
+```python
+# Blocking call in async function
+@router.get("/users")
+async def get_users(db: AsyncSession):
+    users = db.execute(select(User)).scalars().all()  # Missing await
+    return users
+```
+
+**CORRECT:**
+```python
+@router.get("/users")
+async def get_users(db: AsyncSession):
+    result = await db.execute(select(User))  # Await async operation
+    users = result.scalars().all()
+    return users
+```
+
+### 2. Missing `from_attributes` (orm_mode)
+
+**WRONG:**
+```python
+class UserRead(BaseModel):
+    id: int
+    username: str
+    # Missing config - won't work with SQLAlchemy models
+```
+
+**CORRECT:**
+```python
+class UserRead(BaseModel):
+    id: int
+    username: str
+
+    model_config = {"from_attributes": True}  # Pydantic V2
+```
+
+### 3. Session Management
+
+**WRONG:**
+```python
+# Reusing session across requests
+db_session = async_sessionmaker(engine)()
+
+@router.get("/users")
+async def get_users():
+    return await db_session.execute(select(User))  # Session leak
+```
+
+**CORRECT:**
+```python
+# Dependency injection per request
+async def get_db():
+    async with async_sessionmaker(engine)() as session:
+        yield session
+        await session.commit()
+
+@router.get("/users")
+async def get_users(db: Annotated[AsyncSession, Depends(get_db)]):
+    result = await db.execute(select(User))
+    return result.scalars().all()
+```
+
+### 4. Relationship Loading
+
+**WRONG:**
+```python
+# Lazy loading in async (causes errors)
+user = await db.get(User, user_id)
+posts = user.posts  # Error: lazy loading not supported in async
+```
+
+**CORRECT:**
+```python
+# Eager loading with selectinload
+result = await db.execute(
+    select(User).options(selectinload(User.posts)).where(User.id == user_id)
+)
+user = result.scalar_one()
+posts = user.posts  # Already loaded
+```
+
+### 5. Transaction Handling
+
+**WRONG:**
+```python
+# Auto-commit not configured
+@router.post("/users")
+async def create_user(user: UserCreate, db: AsyncSession):
+    db_user = User(**user.dict())
+    db.add(db_user)
+    # Missing commit - changes lost
+    return db_user
+```
+
+**CORRECT:**
+```python
+@router.post("/users")
+async def create_user(user: UserCreate, db: AsyncSession):
+    db_user = User(**user.model_dump())
+    db.add(db_user)
+    await db.commit()  # Explicit commit
+    await db.refresh(db_user)  # Refresh to get DB-generated fields
+    return db_user
+```
+
+---
+
+## Cross-Reference
+
+For comprehensive migration strategies and modernization patterns:
+- **Legacy Modernizer**: `../legacy-modernizer/references/migration-strategies.md`
+  - Strangler pattern implementation
+  - Feature flag strategies
+  - Rollback procedures
+  - Data migration pipelines
+
+---
+
+## Migration Checklist
+
+**Pre-Migration:**
+- [ ] Async readiness assessment (I/O bound workload?)
+- [ ] Team async Python experience validated
+- [ ] Database compatibility verified (async drivers available)
+- [ ] Admin interface replacement identified
+- [ ] Migration timeline approved (6-12 months realistic)
+
+**During Migration:**
+- [ ] Parallel deployment configured
+- [ ] Monitoring and alerting set up
+- [ ] Load testing completed
+- [ ] Data consistency validation automated
+- [ ] Rollback procedure tested
+
+**Post-Migration:**
+- [ ] Django dependencies removed
+- [ ] Documentation updated
+- [ ] Team training completed
+- [ ] Performance gains measured
+- [ ] Cost savings validated
+
+---
+
+**Key Takeaway:** Migrate incrementally. Start with read-heavy endpoints, validate thoroughly, then gradually move write operations. Always maintain rollback capability.

--- a/.claude/skills/fastapi-expert/references/pydantic-v2.md
+++ b/.claude/skills/fastapi-expert/references/pydantic-v2.md
@@ -1,0 +1,135 @@
+# Pydantic V2 Schemas
+
+## Schema Patterns
+
+```python
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
+from typing import Self
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+    username: str = Field(min_length=3, max_length=50)
+    age: int = Field(ge=18, le=120)
+
+    @field_validator('password')
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if not any(c.isupper() for c in v):
+            raise ValueError('Password must contain uppercase')
+        if not any(c.isdigit() for c in v):
+            raise ValueError('Password must contain digit')
+        return v
+
+    @field_validator('username')
+    @classmethod
+    def validate_username(cls, v: str) -> str:
+        if not v.isalnum():
+            raise ValueError('Username must be alphanumeric')
+        return v.lower()
+
+class UserUpdate(BaseModel):
+    email: EmailStr | None = None
+    username: str | None = Field(None, min_length=3, max_length=50)
+```
+
+## ORM Mode (from_attributes)
+
+```python
+class UserResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: int
+    email: EmailStr
+    username: str
+    is_active: bool = True
+    created_at: datetime
+
+# Usage with SQLAlchemy model
+user_response = UserResponse.model_validate(db_user)
+```
+
+## Model Validator
+
+```python
+class OrderCreate(BaseModel):
+    items: list[OrderItem]
+    discount_code: str | None = None
+    total: float
+
+    @model_validator(mode='after')
+    def validate_order(self) -> Self:
+        calculated = sum(item.price * item.quantity for item in self.items)
+        if abs(self.total - calculated) > 0.01:
+            raise ValueError('Total does not match items')
+        return self
+```
+
+## Nested Models
+
+```python
+class Address(BaseModel):
+    street: str
+    city: str
+    country: str = Field(default="US")
+
+class UserWithAddress(BaseModel):
+    name: str
+    addresses: list[Address] = Field(default_factory=list)
+```
+
+## Serialization Control
+
+```python
+class User(BaseModel):
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {"email": "user@example.com", "username": "johndoe"}
+        }
+    }
+
+    id: int
+    email: EmailStr
+    password: str = Field(exclude=True)  # Never serialize
+    internal_id: str = Field(repr=False)  # Hide from repr
+
+# Serialize with aliases
+class ApiResponse(BaseModel):
+    model_config = {"populate_by_name": True}
+
+    user_id: int = Field(alias="userId", serialization_alias="user_id")
+```
+
+## Settings (Pydantic V2)
+
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=True,
+    )
+
+    DATABASE_URL: str
+    SECRET_KEY: str
+    DEBUG: bool = False
+    CORS_ORIGINS: list[str] = ["http://localhost:3000"]
+    API_V1_PREFIX: str = "/api/v1"
+
+settings = Settings()
+```
+
+## Quick Reference
+
+| V1 Syntax | V2 Syntax |
+|-----------|-----------|
+| `@validator` | `@field_validator` |
+| `@root_validator` | `@model_validator` |
+| `class Config` | `model_config = {}` |
+| `orm_mode = True` | `from_attributes = True` |
+| `Optional[X]` | `X \| None` |
+| `.dict()` | `.model_dump()` |
+| `.parse_obj()` | `.model_validate()` |

--- a/.claude/skills/fastapi-expert/references/testing-async.md
+++ b/.claude/skills/fastapi-expert/references/testing-async.md
@@ -1,0 +1,159 @@
+# Async Testing
+
+## Test Setup
+
+```python
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+
+from app.main import app
+from app.core.deps import get_db
+from app.models import Base
+
+# Test database
+TEST_DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+test_engine = create_async_engine(TEST_DATABASE_URL, echo=True)
+test_session = async_sessionmaker(test_engine, expire_on_commit=False)
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"
+
+@pytest.fixture(scope="function")
+async def db():
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with test_session() as session:
+        yield session
+    async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+@pytest.fixture
+async def client(db: AsyncSession):
+    def override_get_db():
+        return db
+
+    app.dependency_overrides[get_db] = override_get_db
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+    app.dependency_overrides.clear()
+```
+
+## Endpoint Tests
+
+```python
+@pytest.mark.asyncio
+async def test_create_user(client: AsyncClient):
+    response = await client.post("/api/v1/users/", json={
+        "email": "test@example.com",
+        "username": "testuser",
+        "password": "Test1234"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "test@example.com"
+    assert "password" not in data
+
+@pytest.mark.asyncio
+async def test_get_user_not_found(client: AsyncClient):
+    response = await client.get("/api/v1/users/999")
+    assert response.status_code == 404
+
+@pytest.mark.asyncio
+async def test_list_users(client: AsyncClient, auth_headers: dict):
+    response = await client.get("/api/v1/users/", headers=auth_headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+```
+
+## Auth Helper Fixture
+
+```python
+@pytest.fixture
+async def test_user(db: AsyncSession) -> User:
+    user = User(
+        email="auth@test.com",
+        username="authuser",
+        hashed_password=hash_password("Test1234"),
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+@pytest.fixture
+async def auth_headers(test_user: User) -> dict:
+    token = create_access_token(sub=str(test_user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+@pytest.mark.asyncio
+async def test_protected_endpoint(client: AsyncClient, auth_headers: dict):
+    response = await client.get("/api/v1/users/me", headers=auth_headers)
+    assert response.status_code == 200
+
+@pytest.mark.asyncio
+async def test_protected_endpoint_no_auth(client: AsyncClient):
+    response = await client.get("/api/v1/users/me")
+    assert response.status_code == 401
+```
+
+## Service Tests
+
+```python
+@pytest.mark.asyncio
+async def test_create_user_service(db: AsyncSession):
+    user_in = UserCreate(
+        email="service@test.com",
+        username="serviceuser",
+        password="Test1234"
+    )
+    user = await create_user_db(db, user_in)
+
+    assert user.id is not None
+    assert user.email == "service@test.com"
+
+@pytest.mark.asyncio
+async def test_get_user_not_found_service(db: AsyncSession):
+    user = await get_user_db(db, 999)
+    assert user is None
+
+@pytest.mark.asyncio
+async def test_duplicate_email(db: AsyncSession):
+    user_in = UserCreate(email="dup@test.com", username="user1", password="Test1234")
+    await create_user_db(db, user_in)
+
+    with pytest.raises(IntegrityError):
+        user_in2 = UserCreate(email="dup@test.com", username="user2", password="Test1234")
+        await create_user_db(db, user_in2)
+```
+
+## Mocking Dependencies
+
+```python
+from unittest.mock import AsyncMock, patch
+
+@pytest.mark.asyncio
+async def test_with_mock_service(client: AsyncClient):
+    mock_user = User(id=1, email="mock@test.com", username="mock")
+
+    with patch("app.api.v1.users.get_user_db", new_callable=AsyncMock) as mock:
+        mock.return_value = mock_user
+        response = await client.get("/api/v1/users/1")
+        assert response.status_code == 200
+        assert response.json()["email"] == "mock@test.com"
+```
+
+## Quick Reference
+
+| Component | Purpose |
+|-----------|---------|
+| `@pytest.mark.asyncio` | Mark async test |
+| `AsyncClient` | HTTP client |
+| `ASGITransport(app=app)` | Test transport |
+| `app.dependency_overrides` | Override deps |
+| `AsyncMock` | Mock async functions |
+| `pytest.raises()` | Assert exception |

--- a/.claude/skills/python-pro/SKILL.md
+++ b/.claude/skills/python-pro/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: python-pro
+description: Use when building Python 3.11+ applications requiring type safety, async programming, or robust error handling. Generates type-annotated Python code, configures mypy in strict mode, writes pytest test suites with fixtures and mocking, and validates code with black and ruff. Invoke for type hints, async/await patterns, dataclasses, dependency injection, logging configuration, and structured error handling.
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: language
+  triggers: Python development, type hints, async Python, pytest, mypy, dataclasses, Python best practices, Pythonic code
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: fastapi-expert, devops-engineer
+---
+
+# Python Pro
+
+Modern Python 3.11+ specialist focused on type-safe, async-first, production-ready code.
+
+## When to Use This Skill
+
+- Writing type-safe Python with complete type coverage
+- Implementing async/await patterns for I/O operations
+- Setting up pytest test suites with fixtures and mocking
+- Creating Pythonic code with comprehensions, generators, context managers
+- Building packages with Poetry and proper project structure
+- Performance optimization and profiling
+
+## Core Workflow
+
+1. **Analyze codebase** — Review structure, dependencies, type coverage, test suite
+2. **Design interfaces** — Define protocols, dataclasses, type aliases
+3. **Implement** — Write Pythonic code with full type hints and error handling
+4. **Test** — Create comprehensive pytest suite with >90% coverage
+5. **Validate** — Run `mypy --strict`, `black`, `ruff`
+   - If mypy fails: fix type errors reported and re-run before proceeding
+   - If tests fail: debug assertions, update fixtures, and iterate until green
+   - If ruff/black reports issues: apply auto-fixes, then re-validate
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Type System | `references/type-system.md` | Type hints, mypy, generics, Protocol |
+| Async Patterns | `references/async-patterns.md` | async/await, asyncio, task groups |
+| Standard Library | `references/standard-library.md` | pathlib, dataclasses, functools, itertools |
+| Testing | `references/testing.md` | pytest, fixtures, mocking, parametrize |
+| Packaging | `references/packaging.md` | poetry, pip, pyproject.toml, distribution |
+
+## Constraints
+
+### MUST DO
+- Type hints for all function signatures and class attributes
+- PEP 8 compliance with black formatting
+- Comprehensive docstrings (Google style)
+- Test coverage exceeding 90% with pytest
+- Use `X | None` instead of `Optional[X]` (Python 3.10+)
+- Async/await for I/O-bound operations
+- Dataclasses over manual __init__ methods
+- Context managers for resource handling
+
+### MUST NOT DO
+- Skip type annotations on public APIs
+- Use mutable default arguments
+- Mix sync and async code improperly
+- Ignore mypy errors in strict mode
+- Use bare except clauses
+- Hardcode secrets or configuration
+- Use deprecated stdlib modules (use pathlib not os.path)
+
+## Code Examples
+
+### Type-annotated function with error handling
+```python
+from pathlib import Path
+
+def read_config(path: Path) -> dict[str, str]:
+    """Read configuration from a file.
+
+    Args:
+        path: Path to the configuration file.
+
+    Returns:
+        Parsed key-value configuration entries.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        ValueError: If a line cannot be parsed.
+    """
+    config: dict[str, str] = {}
+    with path.open() as f:
+        for line in f:
+            key, _, value = line.partition("=")
+            if not key.strip():
+                raise ValueError(f"Invalid config line: {line!r}")
+            config[key.strip()] = value.strip()
+    return config
+```
+
+### Dataclass with validation
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class AppConfig:
+    host: str
+    port: int
+    debug: bool = False
+    allowed_origins: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not (1 <= self.port <= 65535):
+            raise ValueError(f"Invalid port: {self.port}")
+```
+
+### Async pattern
+```python
+import asyncio
+import httpx
+
+async def fetch_all(urls: list[str]) -> list[bytes]:
+    """Fetch multiple URLs concurrently."""
+    async with httpx.AsyncClient() as client:
+        tasks = [client.get(url) for url in urls]
+        responses = await asyncio.gather(*tasks)
+        return [r.content for r in responses]
+```
+
+### pytest fixture and parametrize
+```python
+import pytest
+from pathlib import Path
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    cfg = tmp_path / "config.txt"
+    cfg.write_text("host=localhost\nport=8080\n")
+    return cfg
+
+@pytest.mark.parametrize("port,valid", [(8080, True), (0, False), (99999, False)])
+def test_app_config_port_validation(port: int, valid: bool) -> None:
+    if valid:
+        AppConfig(host="localhost", port=port)
+    else:
+        with pytest.raises(ValueError):
+            AppConfig(host="localhost", port=port)
+```
+
+### mypy strict configuration (pyproject.toml)
+```toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+```
+
+Clean `mypy --strict` output looks like:
+```
+Success: no issues found in 12 source files
+```
+Any reported error (e.g., `error: Function is missing a return type annotation`) must be resolved before the implementation is considered complete.
+
+## Output Templates
+
+When implementing Python features, provide:
+1. Module file with complete type hints
+2. Test file with pytest fixtures
+3. Type checking confirmation (mypy --strict passes)
+4. Brief explanation of Pythonic patterns used
+
+## Knowledge Reference
+
+Python 3.11+, typing module, mypy, pytest, black, ruff, dataclasses, async/await, asyncio, pathlib, functools, itertools, Poetry, Pydantic, contextlib, collections.abc, Protocol
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/language/python-pro/)

--- a/.claude/skills/python-pro/references/async-patterns.md
+++ b/.claude/skills/python-pro/references/async-patterns.md
@@ -1,0 +1,356 @@
+# Async Programming Patterns
+
+## Basic Async/Await
+
+```python
+import asyncio
+from collections.abc import Coroutine
+
+# Basic async function
+async def fetch_data(url: str) -> dict[str, str]:
+    await asyncio.sleep(1)  # Simulate I/O
+    return {"url": url, "status": "ok"}
+
+# Running async code
+async def main() -> None:
+    result = await fetch_data("https://api.example.com")
+    print(result)
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+# Multiple concurrent operations
+async def fetch_all(urls: list[str]) -> list[dict[str, str]]:
+    tasks = [fetch_data(url) for url in urls]
+    return await asyncio.gather(*tasks)
+
+# Error handling with gather
+async def safe_fetch_all(urls: list[str]) -> list[dict[str, str] | None]:
+    tasks = [fetch_data(url) for url in urls]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    return [r if not isinstance(r, Exception) else None for r in results]
+```
+
+## Task Groups (Python 3.11+)
+
+```python
+from asyncio import TaskGroup
+
+# Task groups for structured concurrency
+async def process_batch(items: list[int]) -> list[int]:
+    results: list[int] = []
+
+    async with TaskGroup() as tg:
+        tasks = [tg.create_task(process_item(item)) for item in items]
+
+    # All tasks complete before this line
+    return [task.result() for task in tasks]
+
+# Error handling with TaskGroup
+async def robust_processing(items: list[str]) -> tuple[list[str], list[Exception]]:
+    results: list[str] = []
+    errors: list[Exception] = []
+
+    try:
+        async with TaskGroup() as tg:
+            for item in items:
+                tg.create_task(process_item_safe(item))
+    except ExceptionGroup as eg:
+        for exc in eg.exceptions:
+            errors.append(exc)
+
+    return results, errors
+```
+
+## Async Context Managers
+
+```python
+from typing import Self
+from collections.abc import AsyncIterator
+
+class AsyncDatabaseConnection:
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self._conn: Connection | None = None
+
+    async def __aenter__(self) -> Self:
+        self._conn = await connect(self.url)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        if self._conn:
+            await self._conn.close()
+
+    async def query(self, sql: str) -> list[dict[str, Any]]:
+        if not self._conn:
+            raise RuntimeError("Not connected")
+        return await self._conn.execute(sql)
+
+# Usage
+async def get_users() -> list[dict[str, Any]]:
+    async with AsyncDatabaseConnection("postgresql://...") as db:
+        return await db.query("SELECT * FROM users")
+
+# Async context manager with contextlib
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def get_db_session() -> AsyncIterator[Session]:
+    session = await create_session()
+    try:
+        yield session
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        raise
+    finally:
+        await session.close()
+```
+
+## Async Generators
+
+```python
+from collections.abc import AsyncIterator
+
+# Async generator for streaming data
+async def read_lines(filepath: str) -> AsyncIterator[str]:
+    async with aiofiles.open(filepath) as f:
+        async for line in f:
+            yield line.strip()
+
+# Process stream
+async def process_file(filepath: str) -> int:
+    count = 0
+    async for line in read_lines(filepath):
+        await process_line(line)
+        count += 1
+    return count
+
+# Async generator with cleanup
+async def fetch_paginated(url: str) -> AsyncIterator[dict[str, Any]]:
+    page = 1
+    session = await create_session()
+    try:
+        while True:
+            data = await session.get(f"{url}?page={page}")
+            if not data:
+                break
+            yield data
+            page += 1
+    finally:
+        await session.close()
+```
+
+## Async Comprehensions
+
+```python
+# Async list comprehension
+async def fetch_all_users(user_ids: list[int]) -> list[User]:
+    return [user async for user in fetch_users(user_ids)]
+
+# Async dict comprehension
+async def build_user_map(user_ids: list[int]) -> dict[int, User]:
+    return {
+        user.id: user
+        async for user in fetch_users(user_ids)
+    }
+
+# Conditional async comprehension
+async def get_active_users(user_ids: list[int]) -> list[User]:
+    return [
+        user
+        async for user in fetch_users(user_ids)
+        if user.is_active
+    ]
+```
+
+## Synchronization Primitives
+
+```python
+import asyncio
+
+# Lock for critical sections
+class SharedResource:
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._data: dict[str, Any] = {}
+
+    async def update(self, key: str, value: Any) -> None:
+        async with self._lock:
+            # Critical section
+            current = self._data.get(key, 0)
+            await asyncio.sleep(0.1)  # Simulate processing
+            self._data[key] = current + value
+
+# Semaphore for rate limiting
+class RateLimiter:
+    def __init__(self, max_concurrent: int) -> None:
+        self._semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def process(self, item: str) -> str:
+        async with self._semaphore:
+            return await expensive_operation(item)
+
+# Event for coordination
+class AsyncWorker:
+    def __init__(self) -> None:
+        self._ready = asyncio.Event()
+        self._shutdown = asyncio.Event()
+
+    async def start(self) -> None:
+        # Initialization
+        await self._initialize()
+        self._ready.set()
+
+        # Wait for shutdown
+        await self._shutdown.wait()
+
+    async def wait_ready(self) -> None:
+        await self._ready.wait()
+
+    def stop(self) -> None:
+        self._shutdown.set()
+```
+
+## Async Queue Patterns
+
+```python
+from asyncio import Queue
+
+# Producer-consumer pattern
+async def producer(queue: Queue[int], n: int) -> None:
+    for i in range(n):
+        await queue.put(i)
+        await asyncio.sleep(0.1)
+
+async def consumer(queue: Queue[int], name: str) -> None:
+    while True:
+        item = await queue.get()
+        try:
+            await process_item(item)
+        finally:
+            queue.task_done()
+
+async def run_pipeline(num_items: int, num_workers: int) -> None:
+    queue: Queue[int] = Queue(maxsize=10)
+
+    # Start producer and consumers
+    async with TaskGroup() as tg:
+        tg.create_task(producer(queue, num_items))
+        for i in range(num_workers):
+            tg.create_task(consumer(queue, f"worker-{i}"))
+
+        # Wait for all items to be processed
+        await queue.join()
+```
+
+## Async Timeouts
+
+```python
+# Timeout for single operation
+async def fetch_with_timeout(url: str, timeout: float) -> dict[str, Any]:
+    try:
+        async with asyncio.timeout(timeout):
+            return await fetch_data(url)
+    except TimeoutError:
+        return {"error": "timeout"}
+
+# Timeout for multiple operations
+async def fetch_all_with_timeout(
+    urls: list[str],
+    timeout: float
+) -> list[dict[str, Any] | None]:
+    try:
+        async with asyncio.timeout(timeout):
+            return await fetch_all(urls)
+    except TimeoutError:
+        return [None] * len(urls)
+```
+
+## Background Tasks
+
+```python
+from asyncio import create_task, Task
+
+class BackgroundTaskManager:
+    def __init__(self) -> None:
+        self._tasks: set[Task[None]] = set()
+
+    def create_task(self, coro: Coroutine[None, None, None]) -> Task[None]:
+        task = create_task(coro)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def shutdown(self) -> None:
+        # Cancel all background tasks
+        for task in self._tasks:
+            task.cancel()
+        # Wait for cancellation
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+
+# Usage
+manager = BackgroundTaskManager()
+manager.create_task(background_job())
+```
+
+## Async Iteration Protocol
+
+```python
+class AsyncRange:
+    def __init__(self, start: int, end: int) -> None:
+        self.start = start
+        self.end = end
+        self.current = start
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> int:
+        if self.current >= self.end:
+            raise StopAsyncIteration
+        await asyncio.sleep(0.1)  # Simulate async work
+        value = self.current
+        self.current += 1
+        return value
+
+# Usage
+async for i in AsyncRange(0, 5):
+    print(i)
+```
+
+## Mixing Sync and Async
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+import functools
+
+# Run sync code in executor
+async def run_in_executor(func: Callable[..., T], *args: Any) -> T:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, func, *args)
+
+# Run async code from sync context
+def sync_wrapper(coro: Coroutine[None, None, T]) -> T:
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+# Async wrapper for sync function
+def to_async(func: Callable[..., T]) -> Callable[..., Coroutine[None, None, T]]:
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> T:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            functools.partial(func, *args, **kwargs)
+        )
+    return wrapper
+```

--- a/.claude/skills/python-pro/references/packaging.md
+++ b/.claude/skills/python-pro/references/packaging.md
@@ -1,0 +1,460 @@
+# Python Packaging and Project Setup
+
+## Project Structure
+
+```
+myproject/
+├── pyproject.toml          # Project metadata and dependencies
+├── README.md               # Project description
+├── .gitignore             # Git ignore patterns
+├── .python-version        # Python version for pyenv
+├── src/
+│   └── myproject/
+│       ├── __init__.py    # Package initialization
+│       ├── py.typed       # PEP 561 type marker
+│       ├── core.py        # Core functionality
+│       └── utils.py       # Utilities
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py        # Pytest configuration
+│   └── test_core.py       # Tests
+└── docs/
+    └── index.md           # Documentation
+```
+
+## Pyproject.toml Configuration
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "myproject"
+version = "0.1.0"
+description = "A Python project"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Your Name", email = "you@example.com"}
+]
+keywords = ["python", "package"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "requests>=2.31.0",
+    "pydantic>=2.5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-cov>=4.1.0",
+    "mypy>=1.7.0",
+    "black>=23.11.0",
+    "ruff>=0.1.6",
+]
+docs = [
+    "mkdocs>=1.5.0",
+    "mkdocs-material>=9.4.0",
+]
+
+[project.scripts]
+myproject = "myproject.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/username/myproject"
+Documentation = "https://myproject.readthedocs.io"
+Repository = "https://github.com/username/myproject"
+Changelog = "https://github.com/username/myproject/blob/main/CHANGELOG.md"
+
+# Tool configurations
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+include = '\.pyi?$'
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = []
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]  # Ignore unused imports in __init__.py
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "third_party.*"
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "--cov=myproject",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]
+```
+
+## Poetry Project Management
+
+```toml
+# pyproject.toml for Poetry
+[tool.poetry]
+name = "myproject"
+version = "0.1.0"
+description = "A Python project"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+license = "MIT"
+packages = [{include = "myproject", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "^2.31.0"
+pydantic = "^2.5.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.0"
+pytest-cov = "^4.1.0"
+mypy = "^1.7.0"
+black = "^23.11.0"
+ruff = "^0.1.6"
+
+[tool.poetry.scripts]
+myproject = "myproject.cli:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+```
+
+```bash
+# Poetry commands
+poetry init                    # Initialize new project
+poetry add requests            # Add dependency
+poetry add --group dev pytest  # Add dev dependency
+poetry install                 # Install dependencies
+poetry update                  # Update dependencies
+poetry shell                   # Activate virtual environment
+poetry run pytest              # Run command in venv
+poetry build                   # Build package
+poetry publish                 # Publish to PyPI
+poetry export -f requirements.txt --output requirements.txt
+```
+
+## Virtual Environments
+
+```bash
+# Using venv (built-in)
+python -m venv .venv
+source .venv/bin/activate  # Linux/Mac
+.venv\Scripts\activate     # Windows
+
+# Install in editable mode
+pip install -e .
+pip install -e ".[dev]"    # With optional dependencies
+
+# Using virtualenv
+pip install virtualenv
+virtualenv venv
+source venv/bin/activate
+
+# Using pyenv for Python version management
+pyenv install 3.11.6
+pyenv local 3.11.6         # Set for current directory
+echo "3.11.6" > .python-version
+```
+
+## Package __init__.py
+
+```python
+# src/myproject/__init__.py
+"""MyProject - A Python package."""
+
+from myproject.core import main_function, CoreClass
+from myproject.utils import helper_function
+
+__version__ = "0.1.0"
+__all__ = ["main_function", "CoreClass", "helper_function"]
+
+# Package-level configuration
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+```
+
+## Type Stub Files (py.typed)
+
+```python
+# src/myproject/py.typed
+# Empty file indicates package includes type hints
+
+# src/myproject/__init__.pyi (optional stub file)
+from typing import Any
+
+__version__: str
+
+def main_function(arg: str) -> dict[str, Any]: ...
+
+class CoreClass:
+    def __init__(self, name: str) -> None: ...
+    def process(self) -> str: ...
+```
+
+## CLI Entry Points
+
+```python
+# src/myproject/cli.py
+import sys
+from typing import NoReturn
+
+def main() -> NoReturn:
+    """Main CLI entry point."""
+    print("MyProject CLI")
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+```
+
+## Requirements Files
+
+```bash
+# requirements.txt - Production dependencies
+requests>=2.31.0,<3.0.0
+pydantic>=2.5.0,<3.0.0
+
+# requirements-dev.txt - Development dependencies
+-r requirements.txt
+pytest>=7.4.0
+pytest-cov>=4.1.0
+mypy>=1.7.0
+black>=23.11.0
+ruff>=0.1.6
+
+# Generate from Poetry
+poetry export -f requirements.txt --output requirements.txt --without-hashes
+poetry export -f requirements.txt --with dev --output requirements-dev.txt
+```
+
+## Building and Distribution
+
+```bash
+# Build package
+python -m build
+
+# Check package
+twine check dist/*
+
+# Upload to PyPI
+twine upload dist/*
+
+# Upload to Test PyPI
+twine upload --repository testpypi dist/*
+
+# Install from Test PyPI
+pip install --index-url https://test.pypi.org/simple/ myproject
+```
+
+## Setuptools Configuration (Legacy)
+
+```python
+# setup.py (if not using pyproject.toml)
+from setuptools import setup, find_packages
+
+setup(
+    name="myproject",
+    version="0.1.0",
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    python_requires=">=3.11",
+    install_requires=[
+        "requests>=2.31.0",
+        "pydantic>=2.5.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=7.4.0",
+            "mypy>=1.7.0",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "myproject=myproject.cli:main",
+        ],
+    },
+)
+```
+
+## Manifest for Package Data
+
+```
+# MANIFEST.in
+include README.md
+include LICENSE
+include pyproject.toml
+recursive-include src/myproject *.py
+recursive-include src/myproject py.typed
+recursive-include tests *.py
+prune docs/_build
+```
+
+## Version Management
+
+```python
+# src/myproject/__version__.py
+__version__ = "0.1.0"
+
+# src/myproject/__init__.py
+from myproject.__version__ import __version__
+
+# Read version in pyproject.toml
+import tomli
+from pathlib import Path
+
+def get_version() -> str:
+    pyproject = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject, "rb") as f:
+        data = tomli.load(f)
+    return data["project"]["version"]
+```
+
+## Dependency Management Best Practices
+
+```python
+# Pin dependencies for applications
+requests==2.31.0
+pydantic==2.5.2
+
+# Use ranges for libraries
+requests>=2.31.0,<3.0.0
+pydantic>=2.5.0,<3.0.0
+
+# Lock files
+# Poetry: poetry.lock
+# pip: requirements.txt with exact versions
+pip freeze > requirements-lock.txt
+
+# Update dependencies
+poetry update
+pip install --upgrade -r requirements.txt
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run tests
+      run: |
+        pytest --cov --cov-report=xml
+
+    - name: Type check
+      run: mypy src
+
+    - name: Lint
+      run: |
+        black --check src tests
+        ruff check src tests
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3
+```
+
+## Pre-commit Hooks
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.6
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.1
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]
+```
+
+```bash
+# Install pre-commit
+pip install pre-commit
+pre-commit install
+
+# Run manually
+pre-commit run --all-files
+```

--- a/.claude/skills/python-pro/references/standard-library.md
+++ b/.claude/skills/python-pro/references/standard-library.md
@@ -1,0 +1,378 @@
+# Standard Library Mastery
+
+## Pathlib for File Operations
+
+```python
+from pathlib import Path
+
+# Path creation and manipulation
+project_root = Path(__file__).parent.parent
+config_file = project_root / "config" / "settings.toml"
+data_dir = Path.home() / "data"
+
+# File operations
+def read_config(config_path: Path) -> dict[str, str]:
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config not found: {config_path}")
+
+    # Read text
+    content = config_path.read_text(encoding="utf-8")
+
+    # Read bytes
+    binary = config_path.read_bytes()
+
+    return parse_config(content)
+
+# Path traversal
+def find_python_files(directory: Path) -> list[Path]:
+    # Recursive glob
+    return list(directory.rglob("*.py"))
+
+def get_file_info(path: Path) -> dict[str, Any]:
+    stat = path.stat()
+    return {
+        "size": stat.st_size,
+        "modified": stat.st_mtime,
+        "is_file": path.is_file(),
+        "is_dir": path.is_dir(),
+        "suffix": path.suffix,
+        "stem": path.stem,
+    }
+
+# Creating directories
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+# Temporary files
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+def process_with_temp() -> None:
+    with TemporaryDirectory() as tmpdir:
+        temp_path = Path(tmpdir) / "output.txt"
+        temp_path.write_text("data")
+```
+
+## Dataclasses for Data Structures
+
+```python
+from dataclasses import dataclass, field, asdict, replace
+from typing import ClassVar
+
+# Basic dataclass
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+    active: bool = True
+
+# Post-init processing
+@dataclass
+class Product:
+    name: str
+    price: float
+    discount: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.discount > 1.0:
+            raise ValueError("Discount must be <= 1.0")
+
+    @property
+    def final_price(self) -> float:
+        return self.price * (1 - self.discount)
+
+# Field with factory
+@dataclass
+class ShoppingCart:
+    user_id: int
+    items: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+# Frozen dataclass (immutable)
+@dataclass(frozen=True)
+class Point:
+    x: float
+    y: float
+
+    def distance(self, other: "Point") -> float:
+        return ((self.x - other.x)**2 + (self.y - other.y)**2)**0.5
+
+# Class variables
+@dataclass
+class Config:
+    API_VERSION: ClassVar[str] = "v1"
+    BASE_URL: ClassVar[str] = "https://api.example.com"
+
+    timeout: int = 30
+    retries: int = 3
+
+# Ordered dataclass for comparison
+@dataclass(order=True)
+class Priority:
+    level: int
+    name: str = field(compare=False)
+
+# Convert to/from dict
+user = User(1, "Alice", "alice@example.com")
+user_dict = asdict(user)
+updated = replace(user, name="Alice Smith")
+```
+
+## Functools for Function Tools
+
+```python
+from functools import (
+    cache, lru_cache, cached_property,
+    partial, wraps, reduce, singledispatch
+)
+
+# Caching
+@cache  # Unlimited cache (Python 3.9+)
+def fibonacci(n: int) -> int:
+    if n < 2:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+@lru_cache(maxsize=128)  # LRU cache with size limit
+def fetch_user(user_id: int) -> dict[str, Any]:
+    # Expensive database call
+    return {"id": user_id, "name": "User"}
+
+# Cached property
+class DataProcessor:
+    def __init__(self, data: list[int]) -> None:
+        self._data = data
+
+    @cached_property
+    def mean(self) -> float:
+        """Computed once, then cached."""
+        return sum(self._data) / len(self._data)
+
+# Partial application
+from operator import mul
+
+double = partial(mul, 2)
+triple = partial(mul, 3)
+print(double(5))  # 10
+
+# Decorator preservation
+def timing_decorator(func: Callable[P, R]) -> Callable[P, R]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        start = time.time()
+        result = func(*args, **kwargs)
+        print(f"{func.__name__} took {time.time() - start:.2f}s")
+        return result
+    return wrapper
+
+# Reduce for aggregation
+from operator import add
+
+total = reduce(add, [1, 2, 3, 4, 5])  # 15
+product = reduce(mul, [1, 2, 3, 4], 1)  # 24
+
+# Single dispatch for polymorphism
+@singledispatch
+def process(arg: Any) -> str:
+    return f"Unknown type: {type(arg)}"
+
+@process.register
+def _(arg: int) -> str:
+    return f"Integer: {arg * 2}"
+
+@process.register
+def _(arg: str) -> str:
+    return f"String: {arg.upper()}"
+
+@process.register(list)
+def _(arg: list[Any]) -> str:
+    return f"List with {len(arg)} items"
+```
+
+## Itertools for Iteration
+
+```python
+from itertools import (
+    chain, islice, cycle, repeat,
+    groupby, accumulate, combinations, permutations,
+    product, zip_longest, tee, filterfalse
+)
+
+# Chain multiple iterables
+combined = list(chain([1, 2], [3, 4], [5, 6]))  # [1,2,3,4,5,6]
+
+# Slice iterator (memory efficient)
+first_10 = list(islice(range(1000), 10))
+
+# Infinite iterators
+from itertools import count
+counter = count(start=1, step=2)  # 1, 3, 5, 7, ...
+
+# Groupby for grouping
+data = [("A", 1), ("A", 2), ("B", 1), ("B", 2)]
+grouped = {k: list(v) for k, v in groupby(data, key=lambda x: x[0])}
+
+# Accumulate for running totals
+cumsum = list(accumulate([1, 2, 3, 4, 5]))  # [1, 3, 6, 10, 15]
+
+# Combinations and permutations
+combos = list(combinations([1, 2, 3], 2))  # [(1,2), (1,3), (2,3)]
+perms = list(permutations([1, 2, 3], 2))  # [(1,2), (1,3), (2,1), ...]
+
+# Cartesian product
+pairs = list(product([1, 2], ['a', 'b']))  # [(1,'a'), (1,'b'), (2,'a'), (2,'b')]
+
+# Zip with different lengths
+from itertools import zip_longest
+paired = list(zip_longest([1, 2], ['a', 'b', 'c'], fillvalue=0))
+
+# Tee for multiple iterators
+it1, it2 = tee(range(5), 2)
+
+# Filter false
+odds = list(filterfalse(lambda x: x % 2 == 0, range(10)))
+```
+
+## Collections for Data Structures
+
+```python
+from collections import (
+    defaultdict, Counter, deque, namedtuple,
+    ChainMap, OrderedDict
+)
+
+# defaultdict for automatic defaults
+word_index: defaultdict[str, list[int]] = defaultdict(list)
+for i, word in enumerate(["hello", "world", "hello"]):
+    word_index[word].append(i)
+
+# Counter for counting
+from collections import Counter
+
+word_counts = Counter(["apple", "banana", "apple", "cherry", "banana", "apple"])
+print(word_counts.most_common(2))  # [('apple', 3), ('banana', 2)]
+
+# Counter operations
+c1 = Counter(a=3, b=1)
+c2 = Counter(a=1, b=2)
+print(c1 + c2)  # Counter({'a': 4, 'b': 3})
+
+# deque for efficient queue operations
+from collections import deque
+
+queue: deque[str] = deque()
+queue.append("first")
+queue.append("second")
+queue.appendleft("priority")
+item = queue.popleft()  # "priority"
+
+# Ring buffer with maxlen
+recent: deque[int] = deque(maxlen=3)
+for i in range(5):
+    recent.append(i)  # Only keeps last 3
+
+# namedtuple for lightweight classes
+from collections import namedtuple
+
+Point = namedtuple('Point', ['x', 'y'])
+p = Point(1, 2)
+print(p.x, p.y)
+
+# ChainMap for layered configs
+from collections import ChainMap
+
+defaults = {'color': 'red', 'user': 'guest'}
+environment = {'user': 'admin'}
+combined = ChainMap(environment, defaults)
+print(combined['user'])  # 'admin' (from environment)
+```
+
+## Context Managers
+
+```python
+from contextlib import contextmanager, suppress, ExitStack
+
+# Custom context manager
+@contextmanager
+def managed_resource(resource_id: str) -> Iterator[Resource]:
+    resource = acquire_resource(resource_id)
+    try:
+        yield resource
+    finally:
+        release_resource(resource)
+
+# Suppress exceptions
+with suppress(FileNotFoundError):
+    Path("nonexistent.txt").unlink()
+
+# ExitStack for dynamic context managers
+def process_files(filenames: list[str]) -> None:
+    with ExitStack() as stack:
+        files = [stack.enter_context(open(fn)) for fn in filenames]
+        # All files auto-closed on exit
+        for f in files:
+            process(f.read())
+```
+
+## Enum for Constants
+
+```python
+from enum import Enum, auto, IntEnum, Flag
+
+# Basic enum
+class Status(Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+# Auto values
+class Color(Enum):
+    RED = auto()
+    GREEN = auto()
+    BLUE = auto()
+
+# IntEnum for numeric values
+class Priority(IntEnum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+# Flag for bit flags
+class Permission(Flag):
+    READ = auto()
+    WRITE = auto()
+    EXECUTE = auto()
+
+user_perms = Permission.READ | Permission.WRITE
+if Permission.READ in user_perms:
+    print("Can read")
+```
+
+## Logging
+
+```python
+import logging
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('app.log'),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger(__name__)
+
+# Structured logging
+def process_user(user_id: int) -> None:
+    logger.info("Processing user", extra={"user_id": user_id})
+    try:
+        # Process...
+        logger.debug("User data loaded", extra={"user_id": user_id})
+    except Exception as e:
+        logger.exception("Failed to process user", extra={"user_id": user_id})
+```

--- a/.claude/skills/python-pro/references/testing.md
+++ b/.claude/skills/python-pro/references/testing.md
@@ -1,0 +1,404 @@
+# Testing with Pytest
+
+## Basic Pytest Structure
+
+```python
+# test_user.py
+import pytest
+from myapp.user import User, UserService
+
+# Simple test function
+def test_user_creation() -> None:
+    user = User(id=1, name="Alice", email="alice@example.com")
+    assert user.name == "Alice"
+    assert user.is_active is True
+
+# Test with multiple assertions
+def test_user_validation() -> None:
+    with pytest.raises(ValueError, match="Invalid email"):
+        User(id=1, name="Alice", email="invalid")
+
+# Test class for grouping
+class TestUserService:
+    def test_find_user(self) -> None:
+        service = UserService()
+        user = service.find(1)
+        assert user is not None
+
+    def test_create_user(self) -> None:
+        service = UserService()
+        user = service.create(name="Bob", email="bob@example.com")
+        assert user.id > 0
+```
+
+## Fixtures for Setup/Teardown
+
+```python
+# conftest.py - shared fixtures
+import pytest
+from typing import Iterator
+from myapp.database import Database, Session
+
+@pytest.fixture
+def db() -> Iterator[Database]:
+    """Provide database instance with cleanup."""
+    database = Database("test.db")
+    database.create_tables()
+    yield database
+    database.drop_tables()
+    database.close()
+
+@pytest.fixture
+def db_session(db: Database) -> Iterator[Session]:
+    """Provide database session with rollback."""
+    session = db.create_session()
+    yield session
+    session.rollback()
+    session.close()
+
+@pytest.fixture
+def sample_user() -> User:
+    """Provide test user."""
+    return User(id=1, name="Test User", email="test@example.com")
+
+# Using fixtures in tests
+def test_user_creation(db_session: Session, sample_user: User) -> None:
+    db_session.add(sample_user)
+    db_session.commit()
+
+    retrieved = db_session.query(User).filter_by(id=1).first()
+    assert retrieved.name == "Test User"
+
+# Fixture with parameters
+@pytest.fixture(params=["sqlite", "postgresql", "mysql"])
+def db_engine(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+def test_connection(db_engine: str) -> None:
+    # Test runs 3 times with different engines
+    assert create_connection(db_engine)
+
+# Autouse fixture (runs automatically)
+@pytest.fixture(autouse=True)
+def reset_state() -> Iterator[None]:
+    """Reset global state before each test."""
+    clear_caches()
+    yield
+    cleanup_temp_files()
+```
+
+## Parametrize for Multiple Cases
+
+```python
+import pytest
+
+# Parametrize test function
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (2, 4),
+        (3, 9),
+        (4, 16),
+        (-2, 4),
+    ]
+)
+def test_square(input: int, expected: int) -> None:
+    assert square(input) == expected
+
+# Multiple parameters
+@pytest.mark.parametrize("base", [2, 10])
+@pytest.mark.parametrize("exponent", [0, 1, 2])
+def test_power(base: int, exponent: int) -> None:
+    result = base ** exponent
+    assert result >= 0
+
+# Parametrize with IDs
+@pytest.mark.parametrize(
+    "email,valid",
+    [
+        ("user@example.com", True),
+        ("invalid", False),
+        ("@example.com", False),
+        ("user@", False),
+    ],
+    ids=["valid", "no_at", "no_user", "no_domain"]
+)
+def test_email_validation(email: str, valid: bool) -> None:
+    assert is_valid_email(email) == valid
+
+# Parametrize with fixtures
+@pytest.fixture
+def user_factory():
+    def _make_user(name: str, active: bool = True) -> User:
+        return User(name=name, active=active)
+    return _make_user
+
+@pytest.mark.parametrize("name", ["Alice", "Bob", "Charlie"])
+def test_user_names(user_factory, name: str) -> None:
+    user = user_factory(name)
+    assert user.name == name
+```
+
+## Mocking and Patching
+
+```python
+from unittest.mock import Mock, MagicMock, patch, AsyncMock, call
+import pytest
+
+# Mock object
+def test_api_call_with_mock() -> None:
+    mock_client = Mock()
+    mock_client.get.return_value = {"status": "ok"}
+
+    service = ApiService(mock_client)
+    result = service.fetch_data()
+
+    mock_client.get.assert_called_once_with("/api/data")
+    assert result["status"] == "ok"
+
+# Patch function/method
+def test_database_call() -> None:
+    with patch("myapp.database.connect") as mock_connect:
+        mock_connect.return_value = Mock()
+
+        db = Database()
+        db.connect()
+
+        mock_connect.assert_called_once()
+
+# Patch as decorator
+@patch("myapp.user.send_email")
+def test_user_registration(mock_send_email: Mock) -> None:
+    service = UserService()
+    service.register("user@example.com")
+
+    mock_send_email.assert_called_with(
+        to="user@example.com",
+        subject="Welcome"
+    )
+
+# Multiple patches
+@patch("myapp.api.requests.get")
+@patch("myapp.api.cache.get")
+def test_cached_api(mock_cache: Mock, mock_requests: Mock) -> None:
+    mock_cache.return_value = None
+    mock_requests.return_value.json.return_value = {"data": "value"}
+
+    result = fetch_with_cache("key")
+
+    mock_cache.assert_called_once_with("key")
+    mock_requests.assert_called_once()
+
+# Mock side effects
+def test_retry_logic() -> None:
+    mock_api = Mock()
+    mock_api.call.side_effect = [
+        ConnectionError("Failed"),
+        ConnectionError("Failed"),
+        {"status": "ok"}
+    ]
+
+    result = retry_api_call(mock_api)
+    assert result["status"] == "ok"
+    assert mock_api.call.call_count == 3
+
+# Async mock
+@pytest.mark.asyncio
+async def test_async_function() -> None:
+    mock_db = AsyncMock()
+    mock_db.fetch_user.return_value = User(id=1, name="Alice")
+
+    service = AsyncUserService(mock_db)
+    user = await service.get_user(1)
+
+    mock_db.fetch_user.assert_awaited_once_with(1)
+    assert user.name == "Alice"
+```
+
+## Async Testing
+
+```python
+import pytest
+import asyncio
+
+# Mark async test
+@pytest.mark.asyncio
+async def test_async_fetch() -> None:
+    result = await fetch_data("https://api.example.com")
+    assert result["status"] == "ok"
+
+# Async fixture
+@pytest.fixture
+async def async_db() -> AsyncIterator[AsyncDatabase]:
+    db = AsyncDatabase()
+    await db.connect()
+    yield db
+    await db.disconnect()
+
+@pytest.mark.asyncio
+async def test_async_query(async_db: AsyncDatabase) -> None:
+    result = await async_db.query("SELECT * FROM users")
+    assert len(result) > 0
+
+# Test concurrent operations
+@pytest.mark.asyncio
+async def test_concurrent_requests() -> None:
+    urls = ["http://example.com/1", "http://example.com/2"]
+    results = await asyncio.gather(*[fetch(url) for url in urls])
+    assert len(results) == 2
+```
+
+## Pytest Markers
+
+```python
+import pytest
+
+# Skip test
+@pytest.mark.skip(reason="Not implemented yet")
+def test_future_feature() -> None:
+    pass
+
+# Conditional skip
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="Requires Python 3.11+")
+def test_new_feature() -> None:
+    pass
+
+# Expected failure
+@pytest.mark.xfail(reason="Known bug #123")
+def test_known_bug() -> None:
+    assert buggy_function() == expected_value
+
+# Custom markers
+@pytest.mark.slow
+def test_slow_operation() -> None:
+    time.sleep(5)
+    assert True
+
+@pytest.mark.integration
+def test_integration() -> None:
+    assert external_service.ping()
+
+# Run with: pytest -m "not slow"
+```
+
+## Test Coverage
+
+```python
+# Run with coverage
+# pytest --cov=myapp --cov-report=html --cov-report=term
+
+# conftest.py - coverage configuration
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "unit: mark test as unit test"
+    )
+
+# pytest.ini or pyproject.toml
+"""
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = [
+    "--cov=myapp",
+    "--cov-report=term-missing",
+    "--cov-fail-under=90",
+    "-ra",
+    "--strict-markers",
+]
+testpaths = ["tests"]
+"""
+```
+
+## Property-Based Testing
+
+```python
+from hypothesis import given, strategies as st
+
+# Property-based test
+@given(st.integers(), st.integers())
+def test_addition_commutative(a: int, b: int) -> None:
+    assert a + b == b + a
+
+@given(st.lists(st.integers()))
+def test_sorted_is_ordered(lst: list[int]) -> None:
+    sorted_lst = sorted(lst)
+    for i in range(len(sorted_lst) - 1):
+        assert sorted_lst[i] <= sorted_lst[i + 1]
+
+# Custom strategies
+@given(st.emails())
+def test_email_validation(email: str) -> None:
+    assert "@" in email
+    assert validate_email(email)
+
+# Composite strategies
+from hypothesis import strategies as st
+from hypothesis.strategies import composite
+
+@composite
+def users(draw) -> User:
+    return User(
+        id=draw(st.integers(min_value=1)),
+        name=draw(st.text(min_size=1, max_size=50)),
+        email=draw(st.emails()),
+        age=draw(st.integers(min_value=18, max_value=120))
+    )
+
+@given(users())
+def test_user_creation(user: User) -> None:
+    assert user.age >= 18
+    assert len(user.name) > 0
+```
+
+## Test Organization
+
+```python
+# tests/
+#   conftest.py          - Shared fixtures
+#   test_user.py         - User tests
+#   test_api.py          - API tests
+#   integration/
+#     test_workflow.py   - Integration tests
+#   unit/
+#     test_models.py     - Unit tests
+
+# Fixture factory pattern
+@pytest.fixture
+def user_factory(db_session: Session):
+    created_users: list[User] = []
+
+    def _create_user(
+        name: str = "Test User",
+        email: str | None = None,
+        **kwargs
+    ) -> User:
+        if email is None:
+            email = f"{name.lower().replace(' ', '.')}@example.com"
+
+        user = User(name=name, email=email, **kwargs)
+        db_session.add(user)
+        db_session.commit()
+        created_users.append(user)
+        return user
+
+    yield _create_user
+
+    # Cleanup
+    for user in created_users:
+        db_session.delete(user)
+    db_session.commit()
+```
+
+## Snapshot Testing
+
+```python
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+def test_api_response(snapshot: SnapshotAssertion) -> None:
+    response = api.get_user(1)
+    assert response == snapshot
+
+def test_rendered_template(snapshot: SnapshotAssertion) -> None:
+    html = render_template("user.html", user=get_user(1))
+    assert html == snapshot
+```

--- a/.claude/skills/python-pro/references/type-system.md
+++ b/.claude/skills/python-pro/references/type-system.md
@@ -1,0 +1,290 @@
+# Type System Mastery
+
+## Basic Type Annotations
+
+```python
+from typing import Any
+from collections.abc import Sequence, Mapping
+
+# Function signatures
+def process_user(name: str, age: int, active: bool = True) -> dict[str, Any]:
+    return {"name": name, "age": age, "active": active}
+
+# Use | for unions (Python 3.10+)
+def find_user(user_id: int | str) -> dict[str, Any] | None:
+    if isinstance(user_id, int):
+        return {"id": user_id}
+    return None
+
+# Collections - prefer collections.abc
+def process_items(items: Sequence[str]) -> list[str]:
+    """Accepts list, tuple, or any sequence."""
+    return [item.upper() for item in items]
+
+def merge_configs(base: Mapping[str, int], override: dict[str, int]) -> dict[str, int]:
+    """Mapping for read-only, dict for mutable."""
+    return {**base, **override}
+```
+
+## Generic Types
+
+```python
+from typing import TypeVar, Generic, Protocol
+from collections.abc import Callable
+
+T = TypeVar('T')
+K = TypeVar('K')
+V = TypeVar('V')
+
+# Generic function
+def first_element(items: Sequence[T]) -> T | None:
+    return items[0] if items else None
+
+# Generic class
+class Cache(Generic[K, V]):
+    def __init__(self) -> None:
+        self._data: dict[K, V] = {}
+
+    def get(self, key: K) -> V | None:
+        return self._data.get(key)
+
+    def set(self, key: K, value: V) -> None:
+        self._data[key] = value
+
+# Usage
+user_cache: Cache[int, str] = Cache()
+user_cache.set(1, "Alice")
+
+# Constrained TypeVar
+from numbers import Number
+NumT = TypeVar('NumT', bound=Number)
+
+def add_numbers(a: NumT, b: NumT) -> NumT:
+    return a + b  # type: ignore[return-value]
+```
+
+## Protocol for Structural Typing
+
+```python
+from typing import Protocol, runtime_checkable
+
+# Define interface without inheritance
+class Drawable(Protocol):
+    def draw(self) -> str:
+        ...
+
+    @property
+    def color(self) -> str:
+        ...
+
+class Circle:
+    def __init__(self, radius: float, color: str) -> None:
+        self.radius = radius
+        self._color = color
+
+    def draw(self) -> str:
+        return f"Drawing {self._color} circle"
+
+    @property
+    def color(self) -> str:
+        return self._color
+
+# Circle implements Drawable without inheriting
+def render(shape: Drawable) -> str:
+    return shape.draw()
+
+# Runtime checkable protocol
+@runtime_checkable
+class Closeable(Protocol):
+    def close(self) -> None:
+        ...
+
+def cleanup(resource: Closeable) -> None:
+    if isinstance(resource, Closeable):
+        resource.close()
+```
+
+## Advanced Type Features
+
+```python
+from typing import Literal, TypeAlias, TypedDict, NotRequired, Self, overload
+
+# Literal types for constants
+Mode = Literal["read", "write", "append"]
+
+def open_file(path: str, mode: Mode) -> None:
+    ...
+
+# Type aliases for complex types
+JsonDict: TypeAlias = dict[str, Any]
+UserId: TypeAlias = int | str
+
+# TypedDict for structured dictionaries
+class UserDict(TypedDict):
+    id: int
+    name: str
+    email: str
+    age: NotRequired[int]  # Optional field
+
+def create_user(data: UserDict) -> None:
+    print(data["name"])  # Type-safe access
+
+# Self type for method chaining
+class Builder:
+    def __init__(self) -> None:
+        self._value = 0
+
+    def add(self, n: int) -> Self:
+        self._value += n
+        return self
+
+    def multiply(self, n: int) -> Self:
+        self._value *= n
+        return self
+
+# Overload for different signatures
+@overload
+def process(data: str) -> str: ...
+
+@overload
+def process(data: int) -> int: ...
+
+def process(data: str | int) -> str | int:
+    if isinstance(data, str):
+        return data.upper()
+    return data * 2
+```
+
+## Callable Types
+
+```python
+from collections.abc import Callable
+from typing import ParamSpec, Concatenate
+
+# Basic callable
+def apply(func: Callable[[int, int], int], a: int, b: int) -> int:
+    return func(a, b)
+
+# ParamSpec for preserving signatures
+P = ParamSpec('P')
+R = TypeVar('R')
+
+def logging_decorator(func: Callable[P, R]) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        print(f"Calling {func.__name__}")
+        return func(*args, **kwargs)
+    return wrapper
+
+# Concatenate for dependency injection
+def with_connection(
+    func: Callable[Concatenate[Connection, P], R]
+) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        conn = get_connection()
+        return func(conn, *args, **kwargs)
+    return wrapper
+
+# Usage
+@with_connection
+def query_user(conn: Connection, user_id: int) -> User:
+    return conn.execute(f"SELECT * FROM users WHERE id = {user_id}")
+```
+
+## Mypy Configuration
+
+```toml
+# pyproject.toml
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = "third_party.*"
+ignore_missing_imports = true
+```
+
+## Common Type Patterns
+
+```python
+# Result type pattern
+from dataclasses import dataclass
+
+@dataclass
+class Success(Generic[T]):
+    value: T
+
+@dataclass
+class Error:
+    message: str
+
+Result = Success[T] | Error
+
+def divide(a: int, b: int) -> Result[float]:
+    if b == 0:
+        return Error("Division by zero")
+    return Success(a / b)
+
+# Option/Maybe type
+def safe_get(items: Sequence[T], index: int) -> T | None:
+    try:
+        return items[index]
+    except IndexError:
+        return None
+
+# Sentinel value with typing
+from typing import Final
+
+MISSING: Final = object()
+
+def get_value(key: str, default: T | type[MISSING] = MISSING) -> T:
+    if default is MISSING:
+        raise KeyError(key)
+    return default  # type: ignore[return-value]
+```
+
+## Type Narrowing
+
+```python
+from typing import assert_type, assert_never
+
+def process_value(value: int | str | None) -> str:
+    # Type guards
+    if value is None:
+        return "null"
+
+    if isinstance(value, int):
+        # Type narrowed to int
+        return str(value * 2)
+
+    # Type narrowed to str
+    return value.upper()
+
+# Exhaustiveness checking
+def handle_mode(mode: Literal["read", "write"]) -> str:
+    if mode == "read":
+        return "Reading"
+    elif mode == "write":
+        return "Writing"
+    else:
+        # Mypy will error if mode can be anything else
+        assert_never(mode)
+
+# Custom type guard
+def is_string_list(val: list[Any]) -> bool:
+    """Runtime check for list of strings."""
+    return all(isinstance(x, str) for x in val)
+```

--- a/.claude/skills/security-reviewer/SKILL.md
+++ b/.claude/skills/security-reviewer/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: security-reviewer
+description: Identifies security vulnerabilities, generates structured audit reports with severity ratings, and provides actionable remediation guidance. Use when conducting security audits, reviewing code for vulnerabilities, or analyzing infrastructure security. Invoke for SAST scans, penetration testing, DevSecOps practices, cloud security reviews, dependency audits, secrets scanning, or compliance checks. Produces vulnerability reports, prioritized recommendations, and compliance checklists.
+license: MIT
+allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.1"
+  domain: security
+  triggers: security review, vulnerability scan, SAST, security audit, penetration test, code audit, security analysis, infrastructure security, DevSecOps, cloud security, compliance audit
+  role: specialist
+  scope: review
+  output-format: report
+  related-skills: secure-code-guardian, code-reviewer, devops-engineer, cloud-architect, kubernetes-specialist, api-designer, mcp-developer
+---
+
+# Security Reviewer
+
+Security analyst specializing in code review, vulnerability identification, penetration testing, and infrastructure security.
+
+## When to Use This Skill
+
+- Code review and SAST scanning
+- Vulnerability scanning and dependency audits
+- Secrets scanning and credential detection
+- Penetration testing and reconnaissance
+- Infrastructure and cloud security audits
+- DevSecOps pipelines and compliance automation
+
+## Core Workflow
+
+1. **Scope** — Map attack surface and critical paths. Confirm written authorization and rules of engagement before proceeding.
+2. **Scan** — Run SAST, dependency, and secrets tools. Example commands:
+   - `semgrep --config=auto .`
+   - `bandit -r ./src`
+   - `gitleaks detect --source=.`
+   - `npm audit --audit-level=moderate`
+   - `trivy fs .`
+3. **Review** — Manual review of auth, input handling, and crypto. Tools miss context — manual review is mandatory.
+4. **Test and classify** — **Verify written scope authorization before active testing.** Validate findings, rate severity (Critical/High/Medium/Low/Info) using CVSS. Confirm exploitability with proof-of-concept only; do not exceed it.
+5. **Report** — Confirm findings with stakeholder before finalizing. Document with location, impact, and remediation. Report critical findings immediately.
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| SAST Tools | `references/sast-tools.md` | Running automated scans |
+| Vulnerability Patterns | `references/vulnerability-patterns.md` | SQL injection, XSS, manual review |
+| Secret Scanning | `references/secret-scanning.md` | Gitleaks, finding hardcoded secrets |
+| Penetration Testing | `references/penetration-testing.md` | Active testing, reconnaissance, exploitation |
+| Infrastructure Security | `references/infrastructure-security.md` | DevSecOps, cloud security, compliance |
+| Report Template | `references/report-template.md` | Writing security report |
+
+## Constraints
+
+### MUST DO
+- Check authentication/authorization first
+- Run automated tools before manual review
+- Provide specific file/line locations
+- Include remediation for each finding
+- Rate severity consistently
+- Check for secrets in code
+- Verify scope and authorization before active testing
+- Document all testing activities
+- Follow rules of engagement
+- Report critical findings immediately
+
+### MUST NOT DO
+- Skip manual review (tools miss things)
+- Test on production systems without authorization
+- Ignore "low" severity issues
+- Assume frameworks handle everything
+- Share detailed exploits publicly
+- Exploit beyond proof of concept
+- Cause service disruption or data loss
+- Test outside defined scope
+
+## Output Templates
+
+1. Executive summary with risk assessment
+2. Findings table with severity counts
+3. Detailed findings with location, impact, and remediation
+4. Prioritized recommendations
+
+### Example Finding Entry
+
+```
+ID: FIND-001
+Severity: High (CVSS 8.1)
+Title: SQL Injection in user search endpoint
+File: src/api/users.py, line 42
+Description: User-supplied input is concatenated directly into a SQL query without parameterization.
+Impact: An attacker can read, modify, or delete database contents.
+Remediation: Use parameterized queries or an ORM. Replace `cursor.execute(f"SELECT * FROM users WHERE name='{name}'")`
+             with `cursor.execute("SELECT * FROM users WHERE name=%s", (name,))`.
+References: CWE-89, OWASP A03:2021
+```
+
+## Knowledge Reference
+
+OWASP Top 10, CWE, Semgrep, Bandit, ESLint Security, gosec, npm audit, gitleaks, trufflehog, CVSS scoring, nmap, Burp Suite, sqlmap, Trivy, Checkov, HashiCorp Vault, AWS Security Hub, CIS benchmarks, SOC2, ISO27001
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/security/security-reviewer/)

--- a/.claude/skills/security-reviewer/references/infrastructure-security.md
+++ b/.claude/skills/security-reviewer/references/infrastructure-security.md
@@ -1,0 +1,268 @@
+# Infrastructure Security
+
+## DevSecOps Integration
+
+### CI/CD Security Pipeline
+
+```yaml
+# GitHub Actions - Security scanning
+name: Security Pipeline
+on: [push, pull_request]
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: returntocorp/semgrep-action@v1
+      - uses: gitleaks/gitleaks-action@v2
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          severity: 'CRITICAL,HIGH'
+```
+
+### Infrastructure as Code Security
+
+```bash
+# Terraform/CloudFormation scanning
+checkov -d terraform/ --framework terraform
+tfsec terraform/
+terrascan scan -d terraform/
+
+# Kubernetes manifest scanning
+kubesec scan deployment.yaml
+```
+
+## Cloud Security Controls
+
+### AWS Security Hardening
+
+```bash
+# Enable security services
+aws guardduty create-detector --enable
+aws securityhub enable-security-hub
+aws cloudtrail create-trail --name security-trail --s3-bucket-name logs
+
+# Check S3 bucket security
+aws s3api list-buckets --query "Buckets[].Name" | \
+  xargs -I {} aws s3api get-bucket-acl --bucket {}
+
+# IAM password policy
+aws iam update-account-password-policy \
+  --minimum-password-length 14 \
+  --require-symbols --require-numbers \
+  --require-uppercase-characters --require-lowercase-characters
+```
+
+### Azure Security
+
+```bash
+# Enable Security Center
+az security auto-provisioning-setting update --name default --auto-provision on
+
+# Enable disk encryption
+az vm encryption enable --resource-group myRG --name myVM --disk-encryption-keyvault myKV
+```
+
+### GCP Security
+
+```bash
+# Enable Security Command Center
+gcloud services enable securitycenter.googleapis.com
+
+# Enable VPC Flow Logs
+gcloud compute networks subnets update SUBNET --enable-flow-logs
+```
+
+## Container Security
+
+### Secure Dockerfile
+
+```dockerfile
+FROM node:18-alpine
+RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001
+WORKDIR /app
+COPY --chown=nodejs:nodejs package*.json ./
+RUN npm ci --only=production
+USER nodejs
+EXPOSE 3000
+HEALTHCHECK --interval=30s CMD node healthcheck.js
+CMD ["node", "server.js"]
+```
+
+### Kubernetes Security
+
+```yaml
+# Pod Security Standards
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 2000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: app
+    image: myapp:1.0
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+---
+# Network Policy - Default deny
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+## Compliance Automation
+
+### CIS Benchmark Scanning
+
+```bash
+# Docker CIS benchmark
+docker run --net host --pid host --cap-add audit_control \
+  -v /var/lib:/var/lib -v /var/run/docker.sock:/var/run/docker.sock \
+  docker/docker-bench-security
+
+# Kubernetes CIS benchmark
+kube-bench run --targets master,node
+
+# Linux system hardening
+lynis audit system --quick
+```
+
+### Compliance as Code (InSpec)
+
+```ruby
+# controls/baseline.rb
+control 'ssh-hardening' do
+  impact 1.0
+  title 'SSH Security Configuration'
+
+  describe sshd_config do
+    its('Protocol') { should eq '2' }
+    its('PermitRootLogin') { should eq 'no' }
+    its('PasswordAuthentication') { should eq 'no' }
+  end
+end
+
+control 'encryption-at-rest' do
+  impact 1.0
+  title 'S3 Encryption Enabled'
+
+  describe aws_s3_bucket('my-bucket') do
+    it { should have_default_encryption_enabled }
+  end
+end
+```
+
+## Secrets Management
+
+### HashiCorp Vault
+
+```bash
+# Initialize and configure
+vault operator init
+vault secrets enable -path=secret kv-v2
+
+# Store secrets
+vault kv put secret/app/config api_key="secret123"
+
+# Dynamic database credentials
+vault secrets enable database
+vault write database/config/postgresql \
+  plugin_name=postgresql-database-plugin \
+  allowed_roles="app" \
+  connection_url="postgresql://{{username}}:{{password}}@localhost:5432/" \
+  username="vault" password="vaultpass"
+
+vault write database/roles/app \
+  db_name=postgresql \
+  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}';" \
+  default_ttl="1h" max_ttl="24h"
+```
+
+### Kubernetes Secrets with External Secrets Operator
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+spec:
+  provider:
+    vault:
+      server: "https://vault.example.com"
+      path: "secret"
+      auth:
+        kubernetes:
+          role: "app-role"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: vault-backend
+  target:
+    name: app-secrets
+  data:
+  - secretKey: api_key
+    remoteRef:
+      key: secret/app/config
+      property: api_key
+```
+
+## Security Monitoring
+
+### SIEM Log Shipping (Filebeat)
+
+```yaml
+filebeat.inputs:
+- type: log
+  paths:
+    - /var/log/auth.log
+    - /var/log/nginx/*.log
+  fields:
+    environment: production
+
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+  index: "security-logs-%{+yyyy.MM.dd}"
+```
+
+## Quick Reference
+
+| Area | Tool | Purpose |
+|------|------|---------|
+| Cloud Security | Prowler, ScoutSuite | AWS/Azure/GCP audit |
+| Container | Trivy, Clair | Image scanning |
+| IaC | Checkov, tfsec | Terraform/CloudFormation |
+| Secrets | Vault, Sealed Secrets | Secret management |
+| Compliance | InSpec, OpenSCAP | CIS benchmarks |
+| Monitoring | ELK, Splunk | SIEM |
+
+| Framework | Focus | Key Controls |
+|-----------|-------|--------------|
+| SOC 2 | Security controls | Access, encryption, monitoring |
+| ISO 27001 | ISMS | Policy, risk, audit |
+| PCI DSS | Payment security | Network segmentation, encryption |
+| HIPAA | Healthcare | Encryption, access logs |
+| GDPR | Data privacy | Consent, retention, DLP |

--- a/.claude/skills/security-reviewer/references/penetration-testing.md
+++ b/.claude/skills/security-reviewer/references/penetration-testing.md
@@ -1,0 +1,268 @@
+# Penetration Testing
+
+## Reconnaissance
+
+### Passive Information Gathering
+
+```bash
+# DNS enumeration
+dig example.com ANY
+nslookup -type=any example.com
+
+# Subdomain discovery
+subfinder -d example.com
+amass enum -d example.com
+
+# Certificate transparency
+curl -s "https://crt.sh/?q=%.example.com&output=json"
+```
+
+### Active Scanning
+
+```bash
+# Port scanning
+nmap -sV -p- target.com
+nmap -sC -sV -oA scan target.com
+
+# Web technology detection
+whatweb target.com
+```
+
+## Web Application Testing
+
+### Authentication & Authorization
+
+```bash
+# Session analysis - Check for:
+# - Session timeout, Secure/HttpOnly flags
+# - Session fixation, concurrent sessions
+
+# IDOR testing
+GET /api/users/123  # Your ID
+GET /api/users/124  # Another user - should fail
+
+# Privilege escalation
+GET /api/admin/users  # As standard user
+```
+
+### Input Validation
+
+```bash
+# SQL injection
+sqlmap -u "http://target.com/search?q=test" --batch
+
+# XSS payloads
+<script>alert(document.domain)</script>
+<img src=x onerror=alert(1)>
+<svg onload=alert(1)>
+
+# Command injection
+; ls -la
+| whoami
+$(whoami)
+
+# XXE
+<?xml version="1.0"?>
+<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<root>&xxe;</root>
+```
+
+## API Security Testing
+
+### JWT & Token Security
+
+```bash
+# Decode JWT
+echo "eyJ..." | base64 -d
+
+# Test none algorithm
+# Modify header: {"alg": "none"}
+
+# Weak secret brute force
+hashcat -m 16500 jwt.txt wordlist.txt
+```
+
+### Rate Limiting & Data Exposure
+
+```bash
+# Test rate limits
+for i in {1..1000}; do
+  curl https://api.target.com/login -d "user=test&pass=test"
+done
+
+# Check for excessive data exposure
+GET /api/users/me
+# Look for: password hashes, internal IDs, sensitive PII
+
+# Mass assignment
+POST /api/users/profile
+{"email": "new@email.com", "isAdmin": true}
+```
+
+## Network Penetration
+
+### Privilege Escalation (Linux)
+
+```bash
+# SUID binaries
+find / -perm -4000 -type f 2>/dev/null
+
+# Sudo permissions
+sudo -l
+
+# Writable paths in PATH
+echo $PATH | tr ':' '\n' | xargs -I {} ls -ld {}
+
+# Kernel exploits
+uname -a
+searchsploit linux kernel $(uname -r)
+```
+
+### Lateral Movement
+
+```bash
+# Network enumeration
+arp -a
+netstat -ant
+
+# Service discovery
+nmap -sV 192.168.1.0/24
+
+# Credential harvesting
+grep -r "password" /home/*/
+cat ~/.bash_history | grep -i "pass\|pwd\|secret"
+```
+
+## Mobile Application Testing
+
+### Android
+
+```bash
+# Decompile APK
+apktool d app.apk
+jadx -d output app.apk
+
+# Check for secrets
+grep -r "api_key\|secret\|password" .
+
+# Insecure storage
+adb shell
+run-as com.app.package
+find . -type f -exec cat {} \;
+```
+
+### iOS
+
+```bash
+# Class dump
+class-dump App.app
+
+# Check data storage
+sqlite3 /var/mobile/Applications/.../Library/Caches/data.db
+```
+
+## Cloud Security Testing
+
+### AWS
+
+```bash
+# S3 bucket enumeration
+aws s3 ls s3://bucket-name --no-sign-request
+aws s3api get-bucket-acl --bucket bucket-name
+
+# IAM enumeration
+aws iam get-user
+aws iam list-attached-user-policies --user-name username
+```
+
+### Container & Kubernetes
+
+```bash
+# Docker escape testing
+docker inspect container_id | grep -i privileged
+docker inspect container_id | grep -A 5 Mounts
+
+# Kubernetes
+kubectl get pods --all-namespaces
+kubectl get secrets --all-namespaces
+kubectl auth can-i --list
+```
+
+## Exploitation Validation
+
+### Proof of Concept Guidelines
+
+```python
+# Always demonstrate impact SAFELY
+
+# SQL injection PoC
+# DON'T: Extract actual data
+# DO: Prove injection with sleep
+payload = "' OR SLEEP(5)--"
+
+# DON'T: Delete/modify production data
+# DO: Show you COULD with SELECT
+payload = "' UNION SELECT 'proof_of_concept'--"
+```
+
+### Rules of Engagement
+
+1. **Scope verification** - Only test authorized targets
+2. **Time windows** - Respect testing hours
+3. **DoS prevention** - Avoid resource exhaustion
+4. **Data handling** - Don't exfiltrate real data
+5. **Stop on discovery** - Don't exploit beyond proof
+6. **Immediate reporting** - Report critical findings ASAP
+7. **Documentation** - Record all actions
+8. **Cleanup** - Remove test artifacts
+
+## Vulnerability Classification
+
+### Severity Scoring
+
+| Severity | Exploitability | Impact | CVSS Range |
+|----------|---------------|---------|------------|
+| Critical | Easy | Full compromise | 9.0-10.0 |
+| High | Medium | Significant access | 7.0-8.9 |
+| Medium | Hard | Limited access | 4.0-6.9 |
+| Low | Very hard | Minimal impact | 0.1-3.9 |
+
+### Impact Assessment
+
+- **Critical**: Remote code execution, full data access, admin takeover
+- **High**: Authentication bypass, privilege escalation, sensitive data exposure
+- **Medium**: CSRF, XSS (non-admin), information disclosure
+- **Low**: Missing security headers, verbose errors, rate limiting issues
+
+## Testing Checklist
+
+### OWASP Top 10 Coverage
+
+- [ ] Broken Access Control (IDOR, path traversal)
+- [ ] Cryptographic Failures (weak encryption, plaintext)
+- [ ] Injection (SQL, XSS, command)
+- [ ] Insecure Design (missing auth flows)
+- [ ] Security Misconfiguration (defaults, debug mode)
+- [ ] Vulnerable Components (outdated dependencies)
+- [ ] Authentication Failures (weak passwords, session issues)
+- [ ] Data Integrity (deserialization, lack of verification)
+- [ ] Logging Failures (missing logs, exposed sensitive data)
+- [ ] SSRF (unvalidated URLs)
+
+## Quick Reference
+
+| Test Type | Tools | Focus |
+|-----------|-------|-------|
+| Web App | Burp Suite, OWASP ZAP | OWASP Top 10 |
+| API | Postman, curl | AuthN/AuthZ, data exposure |
+| Network | nmap, Metasploit | Services, exploits |
+| Mobile | MobSF, Frida | Data storage, crypto |
+| Cloud | ScoutSuite, Prowler | Misconfigurations |
+
+| Finding Type | Validation Method | Evidence Required |
+|--------------|------------------|-------------------|
+| SQL Injection | Sleep-based, error-based | Request/response, timing |
+| XSS | Alert box, DOM manipulation | Screenshot, payload |
+| IDOR | Access other user's resource | Two user accounts, IDs |
+| Auth Bypass | Unauthorized access | Before/after screenshots |
+| RCE | Command output (safe) | Whoami, id command output |

--- a/.claude/skills/security-reviewer/references/report-template.md
+++ b/.claude/skills/security-reviewer/references/report-template.md
@@ -1,0 +1,170 @@
+# Security Report Template
+
+## Full Report Template
+
+```markdown
+# Security Review Report
+
+## Executive Summary
+
+| Field | Value |
+|-------|-------|
+| **Application** | [Application Name] |
+| **Review Date** | [YYYY-MM-DD] |
+| **Reviewer** | [Name] |
+| **Scope** | [Files/modules reviewed] |
+| **Overall Risk Level** | [Critical/High/Medium/Low] |
+
+### Key Findings
+- X Critical vulnerabilities requiring immediate attention
+- Y High-severity issues to address before deployment
+- Z Medium/Low issues for future consideration
+
+## Findings Summary
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| Critical | X | Requires immediate fix |
+| High | X | Fix before deployment |
+| Medium | X | Fix in next sprint |
+| Low | X | Backlog |
+
+## Detailed Findings
+
+### [CRITICAL] SQL Injection in User Search
+
+| Field | Value |
+|-------|-------|
+| **ID** | SEC-001 |
+| **Location** | `src/api/users.ts:45` |
+| **CWE** | CWE-89 |
+| **CVSS** | 9.8 (Critical) |
+
+**Description**
+User input directly concatenated into SQL query without sanitization.
+
+**Vulnerable Code**
+```typescript
+const query = `SELECT * FROM users WHERE name LIKE '%${searchTerm}%'`;
+```
+
+**Proof of Concept**
+```
+GET /api/users?search=' OR '1'='1
+```
+
+**Impact**
+- Full database access
+- Data exfiltration
+- Data modification/deletion
+- Potential RCE via SQL features
+
+**Remediation**
+Use parameterized queries:
+```typescript
+const query = 'SELECT * FROM users WHERE name LIKE $1';
+db.query(query, [`%${searchTerm}%`]);
+```
+
+**Effort**: 1 hour
+**Priority**: Immediate
+
+---
+
+### [HIGH] Weak Password Requirements
+
+| Field | Value |
+|-------|-------|
+| **ID** | SEC-002 |
+| **Location** | `src/auth/validation.ts:12` |
+| **CWE** | CWE-521 |
+| **CVSS** | 7.5 (High) |
+
+**Description**
+Password policy requires only 6 characters with no complexity requirements.
+
+**Current Policy**
+```typescript
+const isValid = password.length >= 6;
+```
+
+**Impact**
+- Susceptible to brute force attacks
+- Dictionary attack vulnerability
+
+**Remediation**
+Implement stronger requirements:
+```typescript
+const isValid =
+  password.length >= 12 &&
+  /[A-Z]/.test(password) &&
+  /[a-z]/.test(password) &&
+  /[0-9]/.test(password) &&
+  /[^A-Za-z0-9]/.test(password);
+```
+
+**Effort**: 30 minutes
+**Priority**: Before deployment
+
+## Automated Scan Results
+
+### Dependency Vulnerabilities
+| Package | Severity | CVE | Fix |
+|---------|----------|-----|-----|
+| lodash | High | CVE-2021-xxxx | Upgrade to 4.17.21 |
+
+### SAST Findings
+| Tool | Critical | High | Medium | Low |
+|------|----------|------|--------|-----|
+| Semgrep | 1 | 3 | 5 | 8 |
+| npm audit | 0 | 2 | 4 | 10 |
+
+## Recommendations
+
+### Immediate (This Sprint)
+1. Fix SQL injection vulnerability (SEC-001)
+2. Implement parameterized queries globally
+3. Update vulnerable dependencies
+
+### Short-term (Next Sprint)
+1. Strengthen password policy (SEC-002)
+2. Add input validation middleware
+3. Enable security headers
+
+### Long-term
+1. Implement SAST in CI/CD pipeline
+2. Schedule regular security reviews
+3. Security training for developers
+
+## Appendix
+
+### Tools Used
+- Semgrep v1.x
+- npm audit
+- Gitleaks v8.x
+- Manual code review
+
+### References
+- OWASP Top 10 2021
+- CWE Database
+- CVSS Calculator
+```
+
+## Severity Definitions
+
+| Severity | CVSS Score | Response Time |
+|----------|------------|---------------|
+| Critical | 9.0 - 10.0 | Immediate |
+| High | 7.0 - 8.9 | 24-48 hours |
+| Medium | 4.0 - 6.9 | 1-2 weeks |
+| Low | 0.1 - 3.9 | Next release |
+
+## Quick Reference
+
+| Section | Purpose |
+|---------|---------|
+| Executive Summary | Management overview |
+| Findings Summary | Quick count by severity |
+| Detailed Findings | Technical details |
+| Scan Results | Automated tool output |
+| Recommendations | Prioritized action items |

--- a/.claude/skills/security-reviewer/references/sast-tools.md
+++ b/.claude/skills/security-reviewer/references/sast-tools.md
@@ -1,0 +1,117 @@
+# SAST Tools
+
+## JavaScript/TypeScript
+
+```bash
+# Dependency vulnerabilities
+npm audit
+npm audit --json > npm-audit.json
+
+# ESLint security plugin
+npm install eslint-plugin-security --save-dev
+npx eslint --ext .js,.ts . --plugin security
+
+# Snyk
+npx snyk test
+npx snyk code test
+```
+
+## Python
+
+```bash
+# Bandit - Python SAST
+pip install bandit
+bandit -r . -f json -o bandit-report.json
+bandit -r . -ll  # Only high severity
+
+# Safety - Dependency check
+pip install safety
+safety check
+safety check -r requirements.txt --json > safety-report.json
+
+# Pyup Safety
+pip install pyupio-safety
+pyupio-safety check
+```
+
+## Go
+
+```bash
+# GoSec - Go security checker
+go install github.com/securego/gosec/v2/cmd/gosec@latest
+gosec ./...
+gosec -fmt=json -out=gosec-report.json ./...
+
+# Go vulnerability database
+go install golang.org/x/vuln/cmd/govulncheck@latest
+govulncheck ./...
+```
+
+## Multi-Language Tools
+
+```bash
+# Semgrep - Universal SAST
+pip install semgrep
+semgrep --config=auto .
+semgrep --config=p/security-audit .
+semgrep --config=p/owasp-top-ten .
+
+# Trivy - Comprehensive scanner
+brew install trivy
+trivy fs .
+trivy fs --security-checks vuln,secret,config .
+
+# SonarQube (requires server)
+sonar-scanner -Dsonar.projectKey=myproject
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Run Semgrep
+  uses: returntocorp/semgrep-action@v1
+  with:
+    config: p/security-audit
+
+- name: Run npm audit
+  run: npm audit --audit-level=high
+
+- name: Run Trivy
+  uses: aquasecurity/trivy-action@master
+  with:
+    scan-type: 'fs'
+    severity: 'CRITICAL,HIGH'
+```
+
+### GitLab CI
+
+```yaml
+security-scan:
+  image: returntocorp/semgrep
+  script:
+    - semgrep --config=auto --json -o semgrep.json .
+  artifacts:
+    reports:
+      sast: semgrep.json
+```
+
+## Quick Reference
+
+| Language | Primary Tool | Dependency Check |
+|----------|--------------|------------------|
+| JavaScript | ESLint + security | npm audit |
+| TypeScript | ESLint + security | npm audit |
+| Python | Bandit | Safety |
+| Go | GoSec | govulncheck |
+| Java | SpotBugs | OWASP Dependency-Check |
+| Ruby | Brakeman | bundler-audit |
+
+| Tool | Strengths | Best For |
+|------|-----------|----------|
+| Semgrep | Multi-language, custom rules | General SAST |
+| Trivy | Container + code + secrets | Comprehensive |
+| Bandit | Python-specific | Python projects |
+| GoSec | Go-specific | Go projects |
+| npm audit | Built-in, fast | Node.js deps |

--- a/.claude/skills/security-reviewer/references/secret-scanning.md
+++ b/.claude/skills/security-reviewer/references/secret-scanning.md
@@ -1,0 +1,125 @@
+# Secret Scanning
+
+## Gitleaks
+
+```bash
+# Install
+brew install gitleaks
+
+# Scan current directory
+gitleaks detect --source . --verbose
+
+# Scan with report
+gitleaks detect --source . -f json -r gitleaks-report.json
+
+# Scan git history
+gitleaks detect --source . --log-opts="--all"
+
+# Use baseline (ignore known)
+gitleaks detect --baseline-path .gitleaks-baseline.json
+```
+
+## TruffleHog
+
+```bash
+# Install
+pip install trufflehog
+
+# Scan filesystem
+trufflehog filesystem .
+
+# Scan git repo
+trufflehog git file://. --since-commit HEAD~100
+
+# Scan with JSON output
+trufflehog filesystem . --json > trufflehog-report.json
+```
+
+## Manual Grep Patterns
+
+```bash
+# Common secret patterns
+grep -rn "api_key\|apikey\|api-key" --include="*.{ts,js,py}" .
+grep -rn "secret\|password\|passwd" --include="*.{ts,js,py}" .
+grep -rn "private_key\|privatekey" --include="*.{ts,js,py}" .
+grep -rn "access_token\|accesstoken" --include="*.{ts,js,py}" .
+
+# AWS credentials
+grep -rn "AKIA[0-9A-Z]{16}" .
+grep -rn "aws_secret_access_key" .
+
+# Base64 encoded (potential secrets)
+grep -rn "[A-Za-z0-9+/]{40,}=" .
+
+# JWT tokens
+grep -rn "eyJ[A-Za-z0-9_-]*\.eyJ[A-Za-z0-9_-]*\." .
+```
+
+## Common Secret Patterns
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| AWS Access Key | `AKIA[0-9A-Z]{16}` | AKIAIOSFODNN7EXAMPLE |
+| AWS Secret Key | 40 char base64 | wJalrXUtnFEMI/K7MDENG... |
+| GitHub Token | `ghp_[A-Za-z0-9]{36}` | ghp_xxxxxxxxxxxx |
+| Slack Token | `xox[baprs]-` | xoxb-xxx-xxx |
+| Stripe Key | `sk_live_[A-Za-z0-9]{24}` | sk_live_xxxx |
+| Private Key | `-----BEGIN.*PRIVATE KEY-----` | RSA/EC keys |
+| JWT | `eyJ[A-Za-z0-9_-]*\.eyJ` | Encoded tokens |
+
+## Pre-commit Hook
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
+
+## CI/CD Integration
+
+```yaml
+# GitHub Actions
+- name: Gitleaks
+  uses: gitleaks/gitleaks-action@v2
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# GitLab CI
+secret_detection:
+  image: zricethezav/gitleaks
+  script:
+    - gitleaks detect --source . -f sarif -r gl-secret-detection-report.sarif
+  artifacts:
+    reports:
+      secret_detection: gl-secret-detection-report.sarif
+```
+
+## Remediation Steps
+
+1. **Rotate immediately** - Consider secret compromised
+2. **Remove from history** - Use git filter-branch or BFG
+3. **Add to .gitignore** - Prevent future commits
+4. **Use env variables** - Move to environment
+5. **Use secret manager** - AWS Secrets Manager, Vault
+
+```bash
+# Remove from git history (BFG)
+bfg --replace-text passwords.txt repo.git
+
+# Or git filter-branch
+git filter-branch --force --index-filter \
+  "git rm --cached --ignore-unmatch path/to/secret" \
+  --prune-empty --tag-name-filter cat -- --all
+```
+
+## Quick Reference
+
+| Tool | Best For | Speed |
+|------|----------|-------|
+| Gitleaks | Git history | Fast |
+| TruffleHog | Deep scanning | Medium |
+| grep | Quick checks | Fast |
+| GitHub Secret Scanning | GitHub repos | Auto |

--- a/.claude/skills/security-reviewer/references/vulnerability-patterns.md
+++ b/.claude/skills/security-reviewer/references/vulnerability-patterns.md
@@ -1,0 +1,152 @@
+# Vulnerability Patterns
+
+## SQL Injection
+
+```typescript
+// VULNERABLE
+const query = `SELECT * FROM users WHERE id = ${userId}`;
+const query = `SELECT * FROM users WHERE name = '${name}'`;
+
+// SECURE - Parameterized queries
+const query = 'SELECT * FROM users WHERE id = $1';
+db.query(query, [userId]);
+
+// SECURE - ORM
+const user = await User.findOne({ where: { id: userId } });
+```
+
+## XSS (Cross-Site Scripting)
+
+```typescript
+// VULNERABLE - Direct HTML injection
+element.innerHTML = userInput;
+document.write(userInput);
+
+// SECURE - Text content
+element.textContent = userInput;
+
+// SECURE - Sanitization
+import DOMPurify from 'dompurify';
+element.innerHTML = DOMPurify.sanitize(userInput);
+
+// SECURE - React (auto-escaped)
+return <div>{userInput}</div>;
+
+// VULNERABLE - React dangerouslySetInnerHTML
+return <div dangerouslySetInnerHTML={{ __html: userInput }} />;
+```
+
+## Path Traversal
+
+```typescript
+// VULNERABLE
+const file = path.join(uploadDir, req.query.filename);
+res.sendFile(file);
+
+// SECURE - Validate and normalize
+const filename = path.basename(req.query.filename);
+const file = path.resolve(uploadDir, filename);
+
+if (!file.startsWith(path.resolve(uploadDir))) {
+  throw new Error('Invalid path');
+}
+res.sendFile(file);
+```
+
+## Command Injection
+
+```typescript
+// VULNERABLE
+exec(`ls ${userInput}`);
+exec('git clone ' + repoUrl);
+
+// SECURE - Use arrays, avoid shell
+execFile('ls', [userInput]);
+spawn('git', ['clone', repoUrl]);
+
+// SECURE - Validation
+const allowedCommands = ['status', 'log'];
+if (!allowedCommands.includes(cmd)) throw new Error('Invalid');
+```
+
+## IDOR (Insecure Direct Object Reference)
+
+```typescript
+// VULNERABLE - No authorization check
+app.get('/documents/:id', async (req, res) => {
+  const doc = await Document.findById(req.params.id);
+  res.json(doc);
+});
+
+// SECURE - Verify ownership
+app.get('/documents/:id', async (req, res) => {
+  const doc = await Document.findOne({
+    _id: req.params.id,
+    userId: req.user.id  // Ensure user owns document
+  });
+  if (!doc) return res.status(404).json({ error: 'Not found' });
+  res.json(doc);
+});
+```
+
+## Insecure Deserialization
+
+```typescript
+// VULNERABLE - Python pickle
+import pickle
+data = pickle.loads(user_input)
+
+// SECURE - Use JSON
+import json
+data = json.loads(user_input)
+
+// VULNERABLE - Node.js
+const obj = eval('(' + userInput + ')');
+
+// SECURE
+const obj = JSON.parse(userInput);
+```
+
+## Sensitive Data Exposure
+
+```typescript
+// VULNERABLE - Logging sensitive data
+logger.info('User login', { email, password });
+console.log('Token:', authToken);
+
+// SECURE - Redact sensitive fields
+logger.info('User login', { email, password: '[REDACTED]' });
+
+// VULNERABLE - Error response exposes internals
+res.status(500).json({ error: err.stack });
+
+// SECURE - Generic error
+res.status(500).json({ error: 'Internal server error' });
+```
+
+## Quick Reference
+
+| Vulnerability | Input Vector | Prevention |
+|---------------|--------------|------------|
+| SQL Injection | Query params | Parameterized queries |
+| XSS | User content | Output encoding |
+| Path Traversal | File paths | path.basename + validation |
+| Command Injection | Shell args | execFile, no shell |
+| IDOR | Resource IDs | Authorization checks |
+| Deserialization | Serialized data | JSON only |
+| Data Exposure | Logs, errors | Redaction, generic errors |
+
+## OWASP Top 10 Mapping
+
+| OWASP | Vulnerabilities |
+|-------|-----------------|
+| A01 Broken Access Control | IDOR, path traversal |
+| A02 Cryptographic Failures | Weak encryption, plaintext |
+| A03 Injection | SQL, XSS, command |
+| A04 Insecure Design | Missing auth, IDOR |
+| A05 Security Misconfiguration | Debug mode, default creds |
+| A06 Vulnerable Components | Outdated dependencies |
+| A07 Auth Failures | Weak passwords, session issues |
+| A08 Data Integrity | Insecure deserialization |
+| A09 Logging Failures | Missing logs, exposed data |
+| A10 SSRF | Unvalidated URLs |

--- a/.claude/skills/sql-pro/SKILL.md
+++ b/.claude/skills/sql-pro/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: sql-pro
+description: Optimizes SQL queries, designs database schemas, and troubleshoots performance issues. Use when a user asks why their query is slow, needs help writing complex joins or aggregations, mentions database performance issues, or wants to design or migrate a schema. Invoke for complex queries, window functions, CTEs, indexing strategies, query plan analysis, covering index creation, recursive queries, EXPLAIN/ANALYZE interpretation, before/after query benchmarking, or migrating queries between database dialects (PostgreSQL, MySQL, SQL Server, Oracle).
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.0"
+  domain: language
+  triggers: SQL optimization, query performance, database design, PostgreSQL, MySQL, SQL Server, window functions, CTEs, query tuning, EXPLAIN plan, database indexing
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: devops-engineer
+---
+
+# SQL Pro
+
+## Core Workflow
+
+1. **Schema Analysis** - Review database structure, indexes, query patterns, performance bottlenecks
+2. **Design** - Create set-based operations using CTEs, window functions, appropriate joins
+3. **Optimize** - Analyze execution plans, implement covering indexes, eliminate table scans
+4. **Verify** - Run `EXPLAIN ANALYZE` and confirm no sequential scans on large tables; if query does not meet sub-100ms target, iterate on index selection or query rewrite before proceeding
+5. **Document** - Provide query explanations, index rationale, performance metrics
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Query Patterns | `references/query-patterns.md` | JOINs, CTEs, subqueries, recursive queries |
+| Window Functions | `references/window-functions.md` | ROW_NUMBER, RANK, LAG/LEAD, analytics |
+| Optimization | `references/optimization.md` | EXPLAIN plans, indexes, statistics, tuning |
+| Database Design | `references/database-design.md` | Normalization, keys, constraints, schemas |
+| Dialect Differences | `references/dialect-differences.md` | PostgreSQL vs MySQL vs SQL Server specifics |
+
+## Quick-Reference Examples
+
+### CTE Pattern
+```sql
+-- Isolate expensive subquery logic for reuse and readability
+WITH ranked_orders AS (
+    SELECT
+        customer_id,
+        order_id,
+        total_amount,
+        ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rn
+    FROM orders
+    WHERE status = 'completed'          -- filter early, before the join
+)
+SELECT customer_id, order_id, total_amount
+FROM ranked_orders
+WHERE rn = 1;                           -- latest completed order per customer
+```
+
+### Window Function Pattern
+```sql
+-- Running total and rank within partition — no self-join required
+SELECT
+    department_id,
+    employee_id,
+    salary,
+    SUM(salary)  OVER (PARTITION BY department_id ORDER BY hire_date) AS running_payroll,
+    RANK()       OVER (PARTITION BY department_id ORDER BY salary DESC) AS salary_rank
+FROM employees;
+```
+
+### EXPLAIN ANALYZE Interpretation
+```sql
+-- PostgreSQL: always use ANALYZE to see actual row counts vs. estimates
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT)
+SELECT *
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+WHERE o.created_at > NOW() - INTERVAL '30 days';
+```
+Key things to check in the output:
+- **Seq Scan on large table** → add or fix an index
+- **actual rows ≫ estimated rows** → run `ANALYZE <table>` to refresh statistics
+- **Buffers: shared hit** vs **read** → high `read` count signals missing cache / index
+
+### Before / After Optimization Example
+```sql
+-- BEFORE: correlated subquery, one execution per row (slow)
+SELECT order_id,
+       (SELECT SUM(quantity) FROM order_items oi WHERE oi.order_id = o.id) AS item_count
+FROM orders o;
+
+-- AFTER: single aggregation join (fast)
+SELECT o.order_id, COALESCE(agg.item_count, 0) AS item_count
+FROM orders o
+LEFT JOIN (
+    SELECT order_id, SUM(quantity) AS item_count
+    FROM order_items
+    GROUP BY order_id
+) agg ON agg.order_id = o.id;
+
+-- Supporting covering index (includes all columns touched by the query)
+CREATE INDEX idx_order_items_order_qty
+    ON order_items (order_id)
+    INCLUDE (quantity);
+```
+
+## Constraints
+
+### MUST DO
+- Analyze execution plans before recommending optimizations
+- Use set-based operations over row-by-row processing
+- Apply filtering early in query execution (before joins where possible)
+- Use EXISTS over COUNT for existence checks
+- Handle NULLs explicitly in comparisons and aggregations
+- Create covering indexes for frequent queries
+- Test with production-scale data volumes
+
+### MUST NOT DO
+- Use SELECT * in production queries
+- Use cursors when set-based operations work
+- Ignore platform-specific optimizations when targeting a specific dialect
+- Implement solutions without considering data volume and cardinality
+
+## Output Templates
+
+When implementing SQL solutions, provide:
+1. Optimized query with inline comments
+2. Required indexes with rationale
+3. Execution plan analysis
+4. Performance metrics (before/after)
+5. Platform-specific notes if applicable
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/language/sql-pro/)

--- a/.claude/skills/sql-pro/references/database-design.md
+++ b/.claude/skills/sql-pro/references/database-design.md
@@ -1,0 +1,402 @@
+# Database Design
+
+## Normalization Levels
+
+```sql
+-- 1NF: Atomic values, no repeating groups
+-- Bad: Non-atomic phone column
+CREATE TABLE customers_bad (
+    customer_id INT PRIMARY KEY,
+    name VARCHAR(100),
+    phones VARCHAR(500)  -- "555-1234,555-5678,555-9012"
+);
+
+-- Good: Atomic values
+CREATE TABLE customers (
+    customer_id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE customer_phones (
+    phone_id SERIAL PRIMARY KEY,
+    customer_id INT NOT NULL REFERENCES customers(customer_id),
+    phone_number VARCHAR(20) NOT NULL,
+    phone_type VARCHAR(20) CHECK (phone_type IN ('mobile', 'home', 'work'))
+);
+
+-- 2NF: No partial dependencies (all non-key attributes depend on entire key)
+-- Bad: Partial dependency on composite key
+CREATE TABLE order_items_bad (
+    order_id INT,
+    product_id INT,
+    product_name VARCHAR(100),  -- Depends only on product_id
+    product_price DECIMAL(10,2),  -- Depends only on product_id
+    quantity INT,
+    PRIMARY KEY (order_id, product_id)
+);
+
+-- Good: Separate product attributes
+CREATE TABLE products (
+    product_id SERIAL PRIMARY KEY,
+    product_name VARCHAR(100) NOT NULL,
+    product_price DECIMAL(10,2) NOT NULL CHECK (product_price >= 0)
+);
+
+CREATE TABLE order_items (
+    order_id INT,
+    product_id INT,
+    quantity INT NOT NULL CHECK (quantity > 0),
+    unit_price DECIMAL(10,2) NOT NULL,  -- Snapshot at order time
+    PRIMARY KEY (order_id, product_id),
+    FOREIGN KEY (order_id) REFERENCES orders(order_id),
+    FOREIGN KEY (product_id) REFERENCES products(product_id)
+);
+
+-- 3NF: No transitive dependencies
+-- Bad: City/State depends on ZIP
+CREATE TABLE addresses_bad (
+    address_id INT PRIMARY KEY,
+    street VARCHAR(200),
+    city VARCHAR(100),
+    state VARCHAR(2),
+    zip_code VARCHAR(10)
+);
+
+-- Good: Separate ZIP code reference
+CREATE TABLE zip_codes (
+    zip_code VARCHAR(10) PRIMARY KEY,
+    city VARCHAR(100) NOT NULL,
+    state VARCHAR(2) NOT NULL,
+    county VARCHAR(100)
+);
+
+CREATE TABLE addresses (
+    address_id SERIAL PRIMARY KEY,
+    street VARCHAR(200) NOT NULL,
+    zip_code VARCHAR(10) NOT NULL REFERENCES zip_codes(zip_code)
+);
+```
+
+## Primary and Foreign Keys
+
+```sql
+-- Natural vs Surrogate keys
+-- Natural key (business meaning)
+CREATE TABLE countries (
+    country_code CHAR(2) PRIMARY KEY,  -- ISO 3166-1 alpha-2
+    country_name VARCHAR(100) NOT NULL
+);
+
+-- Surrogate key (technical, no business meaning)
+CREATE TABLE customers (
+    customer_id SERIAL PRIMARY KEY,  -- Auto-incrementing surrogate
+    email VARCHAR(255) NOT NULL UNIQUE,  -- Natural candidate key
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Composite primary key
+CREATE TABLE student_courses (
+    student_id INT,
+    course_id INT,
+    enrollment_date DATE NOT NULL,
+    grade CHAR(2),
+    PRIMARY KEY (student_id, course_id),
+    FOREIGN KEY (student_id) REFERENCES students(student_id),
+    FOREIGN KEY (course_id) REFERENCES courses(course_id)
+);
+
+-- UUID primary keys (distributed systems, no sequence conflicts)
+CREATE TABLE events (
+    event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type VARCHAR(50) NOT NULL,
+    event_data JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Foreign key with cascading actions
+CREATE TABLE orders (
+    order_id SERIAL PRIMARY KEY,
+    customer_id INT NOT NULL,
+    order_date DATE DEFAULT CURRENT_DATE,
+    FOREIGN KEY (customer_id) REFERENCES customers(customer_id)
+        ON DELETE CASCADE  -- Delete orders when customer deleted
+        ON UPDATE CASCADE  -- Update order.customer_id when customers.customer_id changes
+);
+
+CREATE TABLE order_items (
+    order_item_id SERIAL PRIMARY KEY,
+    order_id INT NOT NULL,
+    product_id INT NOT NULL,
+    quantity INT NOT NULL,
+    FOREIGN KEY (order_id) REFERENCES orders(order_id)
+        ON DELETE CASCADE,  -- Delete items when order deleted
+    FOREIGN KEY (product_id) REFERENCES products(product_id)
+        ON DELETE RESTRICT  -- Prevent deleting product if used in orders
+);
+```
+
+## Constraints and Validation
+
+```sql
+-- CHECK constraints
+CREATE TABLE employees (
+    employee_id SERIAL PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    salary DECIMAL(12,2) NOT NULL,
+    hire_date DATE NOT NULL,
+    birth_date DATE NOT NULL,
+
+    CONSTRAINT chk_salary_positive CHECK (salary > 0),
+    CONSTRAINT chk_email_format CHECK (email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z]{2,}$'),
+    CONSTRAINT chk_hire_after_birth CHECK (hire_date > birth_date + INTERVAL '16 years'),
+    CONSTRAINT chk_hire_not_future CHECK (hire_date <= CURRENT_DATE)
+);
+
+-- Unique constraints (including composite)
+CREATE TABLE user_preferences (
+    user_id INT NOT NULL,
+    preference_key VARCHAR(50) NOT NULL,
+    preference_value TEXT,
+
+    CONSTRAINT uq_user_preference UNIQUE (user_id, preference_key)
+);
+
+-- NOT NULL constraints with defaults
+CREATE TABLE products (
+    product_id SERIAL PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    price DECIMAL(10,2) NOT NULL DEFAULT 0.00,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Exclusion constraints (PostgreSQL - prevent overlapping ranges)
+CREATE TABLE room_bookings (
+    booking_id SERIAL PRIMARY KEY,
+    room_id INT NOT NULL,
+    booked_during TSTZRANGE NOT NULL,
+
+    EXCLUDE USING GIST (
+        room_id WITH =,
+        booked_during WITH &&
+    )  -- Prevent overlapping bookings for same room
+);
+```
+
+## Indexing Strategy
+
+```sql
+-- Index foreign keys (critical for JOIN performance)
+CREATE INDEX idx_orders_customer_id ON orders(customer_id);
+CREATE INDEX idx_order_items_order_id ON order_items(order_id);
+CREATE INDEX idx_order_items_product_id ON order_items(product_id);
+
+-- Composite index for common queries
+CREATE INDEX idx_orders_customer_date ON orders(customer_id, order_date DESC);
+-- Supports:
+-- WHERE customer_id = ? AND order_date > ?
+-- WHERE customer_id = ? ORDER BY order_date DESC
+
+-- Partial index for common filters
+CREATE INDEX idx_active_products ON products(category, price)
+WHERE is_active = true AND deleted_at IS NULL;
+
+-- Unique index for business rules
+CREATE UNIQUE INDEX idx_users_active_email ON users(LOWER(email))
+WHERE deleted_at IS NULL;
+-- Ensures no duplicate emails among active users
+```
+
+## Common Design Patterns
+
+```sql
+-- Polymorphic associations (flexible but harder to enforce integrity)
+CREATE TABLE comments (
+    comment_id SERIAL PRIMARY KEY,
+    commentable_type VARCHAR(50) NOT NULL,  -- 'Post', 'Photo', 'Video'
+    commentable_id INT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- Cannot enforce FK without triggers/application logic
+    CHECK (commentable_type IN ('Post', 'Photo', 'Video'))
+);
+
+-- Better: Separate tables with proper FKs
+CREATE TABLE post_comments (
+    comment_id SERIAL PRIMARY KEY,
+    post_id INT NOT NULL REFERENCES posts(post_id),
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE photo_comments (
+    comment_id SERIAL PRIMARY KEY,
+    photo_id INT NOT NULL REFERENCES photos(photo_id),
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Many-to-many with attributes (junction/bridge table)
+CREATE TABLE students (
+    student_id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE courses (
+    course_id SERIAL PRIMARY KEY,
+    course_name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE enrollments (
+    enrollment_id SERIAL PRIMARY KEY,
+    student_id INT NOT NULL REFERENCES students(student_id),
+    course_id INT NOT NULL REFERENCES courses(course_id),
+    enrollment_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    grade CHAR(2),
+    status VARCHAR(20) DEFAULT 'active',
+
+    UNIQUE (student_id, course_id),
+    CHECK (status IN ('active', 'completed', 'dropped'))
+);
+
+-- Self-referencing hierarchy
+CREATE TABLE categories (
+    category_id SERIAL PRIMARY KEY,
+    category_name VARCHAR(100) NOT NULL,
+    parent_category_id INT REFERENCES categories(category_id),
+    level INT NOT NULL DEFAULT 0,
+
+    CHECK (category_id != parent_category_id)  -- Prevent self-reference
+);
+
+-- Adjacency list example
+INSERT INTO categories VALUES
+    (1, 'Electronics', NULL, 0),
+    (2, 'Computers', 1, 1),
+    (3, 'Laptops', 2, 2),
+    (4, 'Desktops', 2, 2);
+```
+
+## Temporal/Historical Data
+
+```sql
+-- Slowly Changing Dimension Type 2 (SCD2) - Full history
+CREATE TABLE customer_history (
+    customer_history_id SERIAL PRIMARY KEY,
+    customer_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    address TEXT,
+    valid_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    valid_to TIMESTAMP,
+    is_current BOOLEAN NOT NULL DEFAULT true,
+
+    CHECK (valid_to IS NULL OR valid_to > valid_from)
+);
+
+-- Ensure only one current record per customer
+CREATE UNIQUE INDEX idx_customer_current ON customer_history(customer_id)
+WHERE is_current = true;
+
+-- Temporal tables (PostgreSQL system-versioning)
+CREATE TABLE products (
+    product_id SERIAL PRIMARY KEY,
+    name VARCHAR(200) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    sys_period TSTZRANGE NOT NULL DEFAULT tstzrange(CURRENT_TIMESTAMP, NULL)
+);
+
+CREATE TABLE products_history (LIKE products);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON products
+FOR EACH ROW EXECUTE FUNCTION versioning('sys_period', 'products_history', true);
+```
+
+## Soft Deletes
+
+```sql
+-- Soft delete pattern
+CREATE TABLE posts (
+    post_id SERIAL PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    author_id INT NOT NULL REFERENCES users(user_id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP,  -- NULL = active, non-NULL = deleted
+    deleted_by INT REFERENCES users(user_id)
+);
+
+-- Index for filtering active records
+CREATE INDEX idx_posts_active ON posts(created_at DESC)
+WHERE deleted_at IS NULL;
+
+-- View for active posts only
+CREATE VIEW active_posts AS
+SELECT post_id, title, content, author_id, created_at, updated_at
+FROM posts
+WHERE deleted_at IS NULL;
+```
+
+## Audit Trails
+
+```sql
+-- Audit table pattern
+CREATE TABLE audit_log (
+    audit_id BIGSERIAL PRIMARY KEY,
+    table_name VARCHAR(100) NOT NULL,
+    record_id BIGINT NOT NULL,
+    action VARCHAR(10) NOT NULL CHECK (action IN ('INSERT', 'UPDATE', 'DELETE')),
+    old_values JSONB,
+    new_values JSONB,
+    changed_by INT REFERENCES users(user_id),
+    changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_audit_table_record ON audit_log(table_name, record_id);
+CREATE INDEX idx_audit_timestamp ON audit_log(changed_at DESC);
+
+-- Trigger function for automatic auditing
+CREATE OR REPLACE FUNCTION audit_trigger_func()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        INSERT INTO audit_log (table_name, record_id, action, old_values)
+        VALUES (TG_TABLE_NAME, OLD.product_id, 'DELETE', row_to_json(OLD));
+        RETURN OLD;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        INSERT INTO audit_log (table_name, record_id, action, old_values, new_values)
+        VALUES (TG_TABLE_NAME, NEW.product_id, 'UPDATE', row_to_json(OLD), row_to_json(NEW));
+        RETURN NEW;
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO audit_log (table_name, record_id, action, new_values)
+        VALUES (TG_TABLE_NAME, NEW.product_id, 'INSERT', row_to_json(NEW));
+        RETURN NEW;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER products_audit
+AFTER INSERT OR UPDATE OR DELETE ON products
+FOR EACH ROW EXECUTE FUNCTION audit_trigger_func();
+```
+
+## Schema Design Best Practices
+
+1. **Choose appropriate data types**: Use smallest type that fits (INT vs BIGINT, VARCHAR(50) vs TEXT)
+2. **Index foreign keys**: Always index FK columns for JOIN performance
+3. **Avoid NULLs when possible**: Use NOT NULL with defaults
+4. **Use constraints**: Enforce data integrity at database level
+5. **Normalize to 3NF**: Then denormalize strategically for performance
+6. **Consider soft deletes**: For auditing and data recovery
+7. **Plan for growth**: Use BIGINT for high-volume PKs
+8. **Document schema**: Comment tables and complex constraints
+9. **Version control**: Track schema changes with migrations
+10. **Test with realistic data**: Validate design with production-scale data

--- a/.claude/skills/sql-pro/references/dialect-differences.md
+++ b/.claude/skills/sql-pro/references/dialect-differences.md
@@ -1,0 +1,419 @@
+# Database Dialect Differences
+
+## Auto-Incrementing Primary Keys
+
+```sql
+-- PostgreSQL
+CREATE TABLE users (
+    user_id SERIAL PRIMARY KEY,  -- or BIGSERIAL for BIGINT
+    name VARCHAR(100)
+);
+-- Alternative (PostgreSQL 10+)
+CREATE TABLE users (
+    user_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name VARCHAR(100)
+);
+
+-- MySQL
+CREATE TABLE users (
+    user_id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100)
+);
+
+-- SQL Server
+CREATE TABLE users (
+    user_id INT IDENTITY(1,1) PRIMARY KEY,
+    name VARCHAR(100)
+);
+
+-- Oracle
+CREATE TABLE users (
+    user_id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name VARCHAR2(100)
+);
+-- Or using sequence (older approach)
+CREATE SEQUENCE user_id_seq;
+CREATE TABLE users (
+    user_id NUMBER DEFAULT user_id_seq.NEXTVAL PRIMARY KEY,
+    name VARCHAR2(100)
+);
+```
+
+## String Concatenation
+
+```sql
+-- PostgreSQL (strict - automatic casting)
+SELECT first_name || ' ' || last_name AS full_name FROM users;
+SELECT CONCAT(first_name, ' ', last_name) AS full_name FROM users;  -- NULL-safe
+
+-- MySQL (automatic type conversion)
+SELECT CONCAT(first_name, ' ', last_name) AS full_name FROM users;
+SELECT first_name + ' ' + last_name FROM users;  -- ERROR in MySQL
+
+-- SQL Server
+SELECT first_name + ' ' + last_name AS full_name FROM users;
+SELECT CONCAT(first_name, ' ', last_name) AS full_name FROM users;  -- 2012+
+
+-- Oracle
+SELECT first_name || ' ' || last_name AS full_name FROM users;
+SELECT CONCAT(first_name, last_name) FROM users;  -- Only 2 arguments!
+```
+
+## Date/Time Functions
+
+```sql
+-- Current timestamp
+-- PostgreSQL
+SELECT CURRENT_TIMESTAMP, NOW(), CURRENT_DATE, CURRENT_TIME;
+
+-- MySQL
+SELECT CURRENT_TIMESTAMP, NOW(), CURDATE(), CURTIME();
+
+-- SQL Server
+SELECT GETDATE(), SYSDATETIME(), CAST(GETDATE() AS DATE);
+
+-- Oracle
+SELECT SYSDATE, SYSTIMESTAMP, TRUNC(SYSDATE) FROM DUAL;
+
+-- Date arithmetic
+-- PostgreSQL
+SELECT order_date + INTERVAL '7 days' FROM orders;
+SELECT order_date - INTERVAL '1 month' FROM orders;
+SELECT AGE(CURRENT_DATE, birth_date) FROM users;  -- Interval type
+
+-- MySQL
+SELECT DATE_ADD(order_date, INTERVAL 7 DAY) FROM orders;
+SELECT DATE_SUB(order_date, INTERVAL 1 MONTH) FROM orders;
+SELECT DATEDIFF(CURRENT_DATE, birth_date) FROM users;  -- Days only
+
+-- SQL Server
+SELECT DATEADD(day, 7, order_date) FROM orders;
+SELECT DATEADD(month, -1, order_date) FROM orders;
+SELECT DATEDIFF(year, birth_date, GETDATE()) FROM users;
+
+-- Oracle
+SELECT order_date + 7 FROM orders;  -- +7 days
+SELECT ADD_MONTHS(order_date, -1) FROM orders;
+SELECT MONTHS_BETWEEN(SYSDATE, birth_date) / 12 FROM users;
+
+-- Date formatting
+-- PostgreSQL
+SELECT TO_CHAR(order_date, 'YYYY-MM-DD') FROM orders;
+
+-- MySQL
+SELECT DATE_FORMAT(order_date, '%Y-%m-%d') FROM orders;
+
+-- SQL Server
+SELECT FORMAT(order_date, 'yyyy-MM-dd') FROM orders;
+SELECT CONVERT(VARCHAR(10), order_date, 120) FROM orders;  -- Style 120 = yyyy-MM-dd
+
+-- Oracle
+SELECT TO_CHAR(order_date, 'YYYY-MM-DD') FROM orders;
+```
+
+## LIMIT/OFFSET (Pagination)
+
+```sql
+-- PostgreSQL & MySQL
+SELECT * FROM products
+ORDER BY product_id
+LIMIT 10 OFFSET 20;
+
+-- SQL Server (2012+)
+SELECT * FROM products
+ORDER BY product_id
+OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY;
+
+-- SQL Server (older - ROW_NUMBER)
+SELECT * FROM (
+    SELECT *, ROW_NUMBER() OVER (ORDER BY product_id) as rn
+    FROM products
+) x
+WHERE rn BETWEEN 21 AND 30;
+
+-- Oracle (12c+)
+SELECT * FROM products
+ORDER BY product_id
+OFFSET 20 ROWS FETCH NEXT 10 ROWS ONLY;
+
+-- Oracle (older - ROWNUM)
+SELECT * FROM (
+    SELECT a.*, ROWNUM rnum FROM (
+        SELECT * FROM products ORDER BY product_id
+    ) a
+    WHERE ROWNUM <= 30
+)
+WHERE rnum > 20;
+```
+
+## Boolean Data Type
+
+```sql
+-- PostgreSQL (native BOOLEAN)
+CREATE TABLE users (
+    user_id SERIAL PRIMARY KEY,
+    is_active BOOLEAN DEFAULT true
+);
+SELECT * FROM users WHERE is_active = true;
+
+-- MySQL (TINYINT(1) or BOOLEAN alias)
+CREATE TABLE users (
+    user_id INT AUTO_INCREMENT PRIMARY KEY,
+    is_active BOOLEAN DEFAULT 1  -- Stored as TINYINT(1)
+);
+SELECT * FROM users WHERE is_active = 1;
+
+-- SQL Server (BIT)
+CREATE TABLE users (
+    user_id INT IDENTITY(1,1) PRIMARY KEY,
+    is_active BIT DEFAULT 1
+);
+SELECT * FROM users WHERE is_active = 1;
+
+-- Oracle (no native boolean in tables, use NUMBER or CHAR)
+CREATE TABLE users (
+    user_id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    is_active NUMBER(1) DEFAULT 1 CHECK (is_active IN (0, 1))
+);
+SELECT * FROM users WHERE is_active = 1;
+```
+
+## JSON/JSONB Support
+
+```sql
+-- PostgreSQL (JSONB - binary, indexable)
+CREATE TABLE events (
+    event_id SERIAL PRIMARY KEY,
+    event_data JSONB NOT NULL
+);
+
+INSERT INTO events (event_data) VALUES ('{"user_id": 123, "action": "login"}');
+
+SELECT event_data->>'user_id' as user_id FROM events;
+SELECT * FROM events WHERE event_data @> '{"action": "login"}';
+SELECT * FROM events WHERE event_data->>'user_id' = '123';
+
+CREATE INDEX idx_events_data ON events USING GIN (event_data);
+
+-- MySQL (8.0+)
+CREATE TABLE events (
+    event_id INT AUTO_INCREMENT PRIMARY KEY,
+    event_data JSON NOT NULL
+);
+
+SELECT JSON_EXTRACT(event_data, '$.user_id') as user_id FROM events;
+SELECT * FROM events WHERE JSON_EXTRACT(event_data, '$.action') = 'login';
+
+CREATE INDEX idx_events_user ON events ((CAST(event_data->>'$.user_id' AS UNSIGNED)));
+
+-- SQL Server (2016+)
+CREATE TABLE events (
+    event_id INT IDENTITY(1,1) PRIMARY KEY,
+    event_data NVARCHAR(MAX) CHECK (ISJSON(event_data) = 1)
+);
+
+SELECT JSON_VALUE(event_data, '$.user_id') as user_id FROM events;
+SELECT * FROM events WHERE JSON_VALUE(event_data, '$.action') = 'login';
+
+-- Oracle (12c+)
+CREATE TABLE events (
+    event_id NUMBER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    event_data CLOB CHECK (event_data IS JSON)
+);
+
+SELECT JSON_VALUE(event_data, '$.user_id') as user_id FROM events;
+SELECT * FROM events WHERE JSON_EXISTS(event_data, '$.action?(@ == "login")');
+```
+
+## String Comparison (Case Sensitivity)
+
+```sql
+-- PostgreSQL (case-sensitive by default)
+SELECT * FROM users WHERE email = 'USER@EXAMPLE.COM';  -- Won't match 'user@example.com'
+SELECT * FROM users WHERE LOWER(email) = LOWER('USER@EXAMPLE.COM');
+SELECT * FROM users WHERE email ILIKE 'user@example.com';  -- Case-insensitive
+
+-- MySQL (case-insensitive by default with utf8_general_ci collation)
+SELECT * FROM users WHERE email = 'USER@EXAMPLE.COM';  -- Matches 'user@example.com'
+SELECT * FROM users WHERE email COLLATE utf8_bin = 'user@example.com';  -- Case-sensitive
+
+-- SQL Server (depends on collation, usually case-insensitive)
+SELECT * FROM users WHERE email = 'USER@EXAMPLE.COM';  -- Usually matches
+SELECT * FROM users WHERE email COLLATE Latin1_General_BIN = 'user@example.com';  -- Case-sensitive
+
+-- Oracle (case-sensitive by default)
+SELECT * FROM users WHERE email = 'USER@EXAMPLE.COM';  -- Won't match 'user@example.com'
+SELECT * FROM users WHERE UPPER(email) = UPPER('user@example.com');
+```
+
+## Recursive CTEs
+
+```sql
+-- PostgreSQL
+WITH RECURSIVE subordinates AS (
+    SELECT employee_id, name, manager_id, 1 as level
+    FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT e.employee_id, e.name, e.manager_id, s.level + 1
+    FROM employees e
+    INNER JOIN subordinates s ON e.manager_id = s.employee_id
+)
+SELECT * FROM subordinates;
+
+-- MySQL (8.0+) - Same syntax as PostgreSQL
+WITH RECURSIVE subordinates AS (
+    SELECT employee_id, name, manager_id, 1 as level
+    FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT e.employee_id, e.name, e.manager_id, s.level + 1
+    FROM employees e
+    INNER JOIN subordinates s ON e.manager_id = s.employee_id
+)
+SELECT * FROM subordinates;
+
+-- SQL Server - No RECURSIVE keyword
+WITH subordinates AS (
+    SELECT employee_id, name, manager_id, 1 as level
+    FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT e.employee_id, e.name, e.manager_id, s.level + 1
+    FROM employees e
+    INNER JOIN subordinates s ON e.manager_id = s.employee_id
+)
+SELECT * FROM subordinates;
+
+-- Oracle - CONNECT BY (traditional hierarchical queries)
+SELECT employee_id, name, manager_id, LEVEL
+FROM employees
+START WITH manager_id IS NULL
+CONNECT BY PRIOR employee_id = manager_id;
+```
+
+## Window Functions - Frame Specifications
+
+```sql
+-- PostgreSQL - Full support
+SELECT
+    order_date,
+    total,
+    SUM(total) OVER (
+        ORDER BY order_date
+        RANGE BETWEEN INTERVAL '7 days' PRECEDING AND CURRENT ROW
+    ) as rolling_7day
+FROM orders;
+
+-- MySQL (8.0+) - Limited RANGE support (no intervals)
+SELECT
+    order_date,
+    total,
+    SUM(total) OVER (
+        ORDER BY order_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+    ) as rolling_7rows
+FROM orders;
+
+-- SQL Server - Full support
+SELECT
+    order_date,
+    total,
+    SUM(total) OVER (
+        ORDER BY order_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+    ) as rolling_7rows
+FROM orders;
+
+-- Oracle - Full support
+SELECT
+    order_date,
+    total,
+    SUM(total) OVER (
+        ORDER BY order_date
+        RANGE BETWEEN INTERVAL '7' DAY PRECEDING AND CURRENT ROW
+    ) as rolling_7day
+FROM orders;
+```
+
+## UPSERT (Insert or Update)
+
+```sql
+-- PostgreSQL (ON CONFLICT)
+INSERT INTO products (product_id, name, price)
+VALUES (123, 'Widget', 29.99)
+ON CONFLICT (product_id)
+DO UPDATE SET name = EXCLUDED.name, price = EXCLUDED.price;
+
+-- MySQL (ON DUPLICATE KEY)
+INSERT INTO products (product_id, name, price)
+VALUES (123, 'Widget', 29.99)
+ON DUPLICATE KEY UPDATE name = VALUES(name), price = VALUES(price);
+
+-- MySQL 8.0.19+ (alternative)
+INSERT INTO products (product_id, name, price)
+VALUES (123, 'Widget', 29.99) AS new
+ON DUPLICATE KEY UPDATE name = new.name, price = new.price;
+
+-- SQL Server (MERGE)
+MERGE INTO products AS target
+USING (SELECT 123 AS product_id, 'Widget' AS name, 29.99 AS price) AS source
+ON target.product_id = source.product_id
+WHEN MATCHED THEN
+    UPDATE SET name = source.name, price = source.price
+WHEN NOT MATCHED THEN
+    INSERT (product_id, name, price)
+    VALUES (source.product_id, source.name, source.price);
+
+-- Oracle (MERGE)
+MERGE INTO products target
+USING (SELECT 123 AS product_id, 'Widget' AS name, 29.99 AS price FROM DUAL) source
+ON (target.product_id = source.product_id)
+WHEN MATCHED THEN
+    UPDATE SET name = source.name, price = source.price
+WHEN NOT MATCHED THEN
+    INSERT (product_id, name, price)
+    VALUES (source.product_id, source.name, source.price);
+```
+
+## Data Type Mapping
+
+| Concept | PostgreSQL | MySQL | SQL Server | Oracle |
+|---------|-----------|-------|------------|--------|
+| Integer | INT, BIGINT | INT, BIGINT | INT, BIGINT | NUMBER(10), NUMBER(19) |
+| Decimal | NUMERIC, DECIMAL | DECIMAL | DECIMAL, NUMERIC | NUMBER(p,s) |
+| String | VARCHAR, TEXT | VARCHAR, TEXT | VARCHAR, NVARCHAR | VARCHAR2, CLOB |
+| Binary | BYTEA | BLOB, BINARY | VARBINARY, IMAGE | BLOB, RAW |
+| Boolean | BOOLEAN | BOOLEAN/TINYINT(1) | BIT | NUMBER(1) |
+| Date | DATE | DATE | DATE | DATE |
+| Timestamp | TIMESTAMP | DATETIME, TIMESTAMP | DATETIME, DATETIME2 | TIMESTAMP |
+| UUID | UUID | CHAR(36), BINARY(16) | UNIQUEIDENTIFIER | RAW(16) |
+| JSON | JSON, JSONB | JSON | NVARCHAR(MAX) | CLOB |
+| Array | ARRAY | JSON | Table variable | VARRAY, nested table |
+
+## Performance Tips by Database
+
+**PostgreSQL:**
+- Use EXPLAIN ANALYZE with BUFFERS
+- Leverage JSONB with GIN indexes
+- Use parallel query settings for large scans
+- Vacuum and analyze regularly
+- Consider table partitioning for 10M+ rows
+
+**MySQL:**
+- Choose InnoDB over MyISAM
+- Optimize buffer pool size
+- Use covering indexes aggressively
+- Be aware of case-insensitive defaults
+- Consider read replicas for scaling
+
+**SQL Server:**
+- Update statistics regularly
+- Use columnstore indexes for warehousing
+- Leverage query hints sparingly
+- Monitor execution plans
+- Use In-Memory OLTP for hot tables
+
+**Oracle:**
+- Use EXPLAIN PLAN
+- Leverage partitioning features
+- Use bind variables to avoid parsing
+- Configure SGA/PGA appropriately
+- Consider Real Application Clusters (RAC)

--- a/.claude/skills/sql-pro/references/optimization.md
+++ b/.claude/skills/sql-pro/references/optimization.md
@@ -1,0 +1,384 @@
+# Query Optimization
+
+## EXPLAIN Plan Analysis
+
+```sql
+-- PostgreSQL EXPLAIN ANALYZE
+EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
+SELECT
+    c.customer_id,
+    c.name,
+    COUNT(o.order_id) as order_count,
+    SUM(o.total) as lifetime_value
+FROM customers c
+LEFT JOIN orders o ON c.customer_id = o.customer_id
+WHERE c.created_at >= '2024-01-01'
+GROUP BY c.customer_id, c.name
+HAVING COUNT(o.order_id) > 5;
+
+/*
+Key metrics to analyze:
+- Planning Time: Time to generate plan
+- Execution Time: Actual runtime
+- Seq Scan: Table scans (bad for large tables)
+- Index Scan: Using indexes (good)
+- Rows: Estimated vs actual (large difference = stale stats)
+- Buffers: shared hit = cache, read = disk I/O
+- Loops: Nested loop iterations
+*/
+
+-- MySQL EXPLAIN
+EXPLAIN FORMAT=JSON
+SELECT * FROM orders o
+INNER JOIN customers c ON o.customer_id = c.customer_id
+WHERE o.order_date >= '2024-01-01'
+  AND c.country = 'US';
+
+-- SQL Server execution plan
+SET STATISTICS IO ON;
+SET STATISTICS TIME ON;
+
+SELECT ...;
+
+-- Check actual vs estimated rows
+SELECT * FROM sys.dm_exec_query_stats;
+```
+
+## Index Design and Optimization
+
+```sql
+-- Covering index (all columns in index)
+CREATE INDEX idx_orders_covering ON orders (
+    customer_id,
+    order_date
+) INCLUDE (total, status);
+
+-- Query uses index-only scan (no table access needed)
+SELECT customer_id, order_date, total, status
+FROM orders
+WHERE customer_id = 123
+  AND order_date >= '2024-01-01';
+
+-- Composite index (order matters!)
+CREATE INDEX idx_orders_customer_date ON orders (customer_id, order_date DESC);
+-- Good: WHERE customer_id = X AND order_date > Y
+-- Good: WHERE customer_id = X
+-- Bad: WHERE order_date > Y (doesn't use index)
+
+-- Partial/Filtered index (smaller, faster)
+CREATE INDEX idx_active_orders ON orders (customer_id, order_date)
+WHERE status = 'active';
+
+-- Only used when query includes the filter
+SELECT * FROM orders
+WHERE customer_id = 123
+  AND status = 'active'
+  AND order_date >= '2024-01-01';
+
+-- Expression/Function-based index
+CREATE INDEX idx_users_lower_email ON users (LOWER(email));
+
+-- Now this uses the index
+SELECT * FROM users WHERE LOWER(email) = 'user@example.com';
+
+-- GIN index for arrays/JSONB (PostgreSQL)
+CREATE INDEX idx_products_tags ON products USING GIN (tags);
+SELECT * FROM products WHERE tags @> ARRAY['electronics', 'sale'];
+
+CREATE INDEX idx_orders_metadata ON orders USING GIN (metadata jsonb_path_ops);
+SELECT * FROM orders WHERE metadata @> '{"priority": "high"}';
+```
+
+## Index Maintenance
+
+```sql
+-- PostgreSQL: Find missing indexes
+SELECT
+    schemaname,
+    tablename,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    seq_tup_read / seq_scan as avg_seq_read
+FROM pg_stat_user_tables
+WHERE seq_scan > 0
+  AND seq_tup_read / seq_scan > 10000
+ORDER BY seq_tup_read DESC;
+
+-- Find unused indexes
+SELECT
+    schemaname,
+    tablename,
+    indexname,
+    idx_scan,
+    pg_size_pretty(pg_relation_size(indexrelid)) as index_size
+FROM pg_stat_user_indexes
+WHERE idx_scan = 0
+  AND indexrelname NOT LIKE 'pg_toast%'
+ORDER BY pg_relation_size(indexrelid) DESC;
+
+-- Find duplicate indexes
+SELECT
+    pg_size_pretty(SUM(pg_relation_size(idx))::BIGINT) as size,
+    (array_agg(idx))[1] as idx1,
+    (array_agg(idx))[2] as idx2,
+    (array_agg(idx))[3] as idx3
+FROM (
+    SELECT
+        indexrelid::regclass as idx,
+        (indrelid::text ||E'\n'|| indclass::text ||E'\n'||
+         indkey::text ||E'\n'|| COALESCE(indexprs::text,'')||E'\n'||
+         COALESCE(indpred::text,'')) as key
+    FROM pg_index
+) sub
+GROUP BY key
+HAVING COUNT(*) > 1
+ORDER BY SUM(pg_relation_size(idx)) DESC;
+
+-- Reindex to reduce bloat
+REINDEX INDEX CONCURRENTLY idx_orders_customer_date;
+
+-- Update statistics
+ANALYZE orders;
+ANALYZE VERBOSE;  -- Show progress
+```
+
+## Query Rewriting Patterns
+
+```sql
+-- Avoid SELECT DISTINCT when possible
+-- Bad: Forces sort/dedup
+SELECT DISTINCT customer_id FROM orders WHERE status = 'active';
+
+-- Good: Use EXISTS
+SELECT customer_id FROM customers c
+WHERE EXISTS (
+    SELECT 1 FROM orders o
+    WHERE o.customer_id = c.customer_id
+      AND o.status = 'active'
+);
+
+-- Avoid NOT IN with NULLs
+-- Bad: NULL handling issues and poor performance
+SELECT * FROM customers
+WHERE customer_id NOT IN (SELECT customer_id FROM orders);
+
+-- Good: Use NOT EXISTS
+SELECT * FROM customers c
+WHERE NOT EXISTS (
+    SELECT 1 FROM orders o WHERE o.customer_id = c.customer_id
+);
+
+-- Push down filtering early
+-- Bad: Filter after JOIN
+SELECT c.*, o.*
+FROM customers c
+JOIN orders o ON c.customer_id = o.customer_id
+WHERE c.country = 'US' AND o.order_date >= '2024-01-01';
+
+-- Good: Use WHERE in subquery/CTE to reduce JOIN size
+WITH us_customers AS (
+    SELECT customer_id, name
+    FROM customers
+    WHERE country = 'US'
+),
+recent_orders AS (
+    SELECT customer_id, order_id, total
+    FROM orders
+    WHERE order_date >= '2024-01-01'
+)
+SELECT c.*, o.*
+FROM us_customers c
+JOIN recent_orders o ON c.customer_id = o.customer_id;
+
+-- Avoid scalar subqueries in SELECT
+-- Bad: N+1 problem
+SELECT
+    p.product_id,
+    p.name,
+    (SELECT COUNT(*) FROM reviews WHERE product_id = p.product_id) as review_count
+FROM products p;
+
+-- Good: Single JOIN with GROUP BY
+SELECT
+    p.product_id,
+    p.name,
+    COUNT(r.review_id) as review_count
+FROM products p
+LEFT JOIN reviews r ON p.product_id = r.product_id
+GROUP BY p.product_id, p.name;
+```
+
+## Partitioning Strategies
+
+```sql
+-- Range partitioning by date (PostgreSQL)
+CREATE TABLE orders (
+    order_id SERIAL,
+    customer_id INT,
+    order_date DATE NOT NULL,
+    total DECIMAL(10,2)
+) PARTITION BY RANGE (order_date);
+
+CREATE TABLE orders_2024_q1 PARTITION OF orders
+    FOR VALUES FROM ('2024-01-01') TO ('2024-04-01');
+
+CREATE TABLE orders_2024_q2 PARTITION OF orders
+    FOR VALUES FROM ('2024-04-01') TO ('2024-07-01');
+
+-- Partition pruning in action
+EXPLAIN SELECT * FROM orders WHERE order_date >= '2024-02-01' AND order_date < '2024-03-01';
+-- Only scans orders_2024_q1 partition
+
+-- List partitioning by category
+CREATE TABLE products (
+    product_id SERIAL,
+    category VARCHAR(50) NOT NULL,
+    name VARCHAR(200)
+) PARTITION BY LIST (category);
+
+CREATE TABLE products_electronics PARTITION OF products
+    FOR VALUES IN ('electronics', 'computers', 'phones');
+
+CREATE TABLE products_clothing PARTITION OF products
+    FOR VALUES IN ('clothing', 'shoes', 'accessories');
+
+-- Hash partitioning for even distribution
+CREATE TABLE users (
+    user_id SERIAL,
+    email VARCHAR(255)
+) PARTITION BY HASH (user_id);
+
+CREATE TABLE users_p0 PARTITION OF users
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE users_p1 PARTITION OF users
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+```
+
+## Materialized Views
+
+```sql
+-- Create materialized view for expensive aggregations
+CREATE MATERIALIZED VIEW daily_sales_summary AS
+SELECT
+    DATE_TRUNC('day', order_date) as day,
+    COUNT(*) as order_count,
+    SUM(total) as revenue,
+    AVG(total) as avg_order_value,
+    COUNT(DISTINCT customer_id) as unique_customers
+FROM orders
+GROUP BY DATE_TRUNC('day', order_date);
+
+CREATE UNIQUE INDEX idx_daily_sales_day ON daily_sales_summary (day);
+
+-- Refresh strategy
+REFRESH MATERIALIZED VIEW CONCURRENTLY daily_sales_summary;
+
+-- Auto-refresh with trigger (PostgreSQL)
+CREATE OR REPLACE FUNCTION refresh_daily_sales()
+RETURNS TRIGGER AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY daily_sales_summary;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_refresh_daily_sales
+AFTER INSERT OR UPDATE OR DELETE ON orders
+FOR EACH STATEMENT
+EXECUTE FUNCTION refresh_daily_sales();
+```
+
+## Query Hints and Optimization
+
+```sql
+-- PostgreSQL: Force index usage (use sparingly)
+SET enable_seqscan = OFF;
+SELECT /*+ IndexScan(orders idx_orders_customer) */ * FROM orders WHERE customer_id = 123;
+SET enable_seqscan = ON;
+
+-- SQL Server: Query hints
+SELECT * FROM orders WITH (INDEX(idx_orders_customer_date))
+WHERE customer_id = 123;
+
+-- Force specific join type
+SELECT * FROM customers c
+INNER MERGE JOIN orders o ON c.customer_id = o.customer_id;
+
+-- MySQL: Index hints
+SELECT * FROM orders USE INDEX (idx_orders_customer_date)
+WHERE customer_id = 123;
+
+SELECT * FROM orders FORCE INDEX (idx_orders_customer_date)
+WHERE customer_id = 123;
+
+-- PostgreSQL: Parallel query tuning
+SET max_parallel_workers_per_gather = 4;
+ALTER TABLE large_table SET (parallel_workers = 4);
+```
+
+## Performance Monitoring Queries
+
+```sql
+-- PostgreSQL: Find slow queries
+SELECT
+    query,
+    calls,
+    total_exec_time,
+    mean_exec_time,
+    max_exec_time,
+    rows / calls as avg_rows
+FROM pg_stat_statements
+ORDER BY mean_exec_time DESC
+LIMIT 20;
+
+-- Find blocking queries
+SELECT
+    blocked_locks.pid AS blocked_pid,
+    blocked_activity.usename AS blocked_user,
+    blocking_locks.pid AS blocking_pid,
+    blocking_activity.usename AS blocking_user,
+    blocked_activity.query AS blocked_statement,
+    blocking_activity.query AS blocking_statement
+FROM pg_catalog.pg_locks blocked_locks
+JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+JOIN pg_catalog.pg_locks blocking_locks
+    ON blocking_locks.locktype = blocked_locks.locktype
+    AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+    AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+    AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+    AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+    AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+    AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+    AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+    AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+    AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+    AND blocking_locks.pid != blocked_locks.pid
+JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+WHERE NOT blocked_locks.granted;
+
+-- Table bloat detection
+SELECT
+    schemaname,
+    tablename,
+    pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) as size,
+    n_dead_tup,
+    n_live_tup,
+    ROUND(n_dead_tup * 100.0 / NULLIF(n_live_tup + n_dead_tup, 0), 2) as dead_pct
+FROM pg_stat_user_tables
+WHERE n_dead_tup > 1000
+ORDER BY n_dead_tup DESC;
+```
+
+## Best Practices Checklist
+
+1. Always run EXPLAIN ANALYZE before optimizing
+2. Create indexes on foreign keys and WHERE/JOIN columns
+3. Use covering indexes for frequent queries
+4. Keep statistics up to date (ANALYZE regularly)
+5. Avoid SELECT *, specify needed columns
+6. Use EXISTS instead of IN for subqueries
+7. Filter early, aggregate late
+8. Consider partitioning for large tables (>10M rows)
+9. Use materialized views for expensive aggregations
+10. Monitor slow query log and pg_stat_statements

--- a/.claude/skills/sql-pro/references/query-patterns.md
+++ b/.claude/skills/sql-pro/references/query-patterns.md
@@ -1,0 +1,285 @@
+# Query Patterns
+
+## Common Table Expressions (CTEs)
+
+```sql
+-- Basic CTE for readability
+WITH active_users AS (
+    SELECT user_id, username, created_at
+    FROM users
+    WHERE is_active = true
+      AND last_login >= CURRENT_DATE - INTERVAL '30 days'
+),
+user_orders AS (
+    SELECT user_id, COUNT(*) as order_count, SUM(total) as total_spent
+    FROM orders
+    WHERE status = 'completed'
+    GROUP BY user_id
+)
+SELECT
+    u.username,
+    u.created_at,
+    COALESCE(o.order_count, 0) as orders,
+    COALESCE(o.total_spent, 0) as lifetime_value
+FROM active_users u
+LEFT JOIN user_orders o ON u.user_id = o.user_id
+WHERE COALESCE(o.order_count, 0) > 0
+ORDER BY o.total_spent DESC;
+
+-- CTE with multiple references (avoiding duplicate computation)
+WITH monthly_sales AS (
+    SELECT
+        DATE_TRUNC('month', sale_date) as month,
+        product_id,
+        SUM(quantity) as total_quantity,
+        SUM(amount) as total_amount
+    FROM sales
+    WHERE sale_date >= '2024-01-01'
+    GROUP BY DATE_TRUNC('month', sale_date), product_id
+)
+SELECT
+    current.month,
+    current.product_id,
+    current.total_amount,
+    current.total_amount - COALESCE(previous.total_amount, 0) as growth,
+    ROUND(100.0 * (current.total_amount - COALESCE(previous.total_amount, 0))
+        / NULLIF(previous.total_amount, 0), 2) as growth_pct
+FROM monthly_sales current
+LEFT JOIN monthly_sales previous
+    ON current.product_id = previous.product_id
+    AND current.month = previous.month + INTERVAL '1 month';
+```
+
+## Recursive CTEs
+
+```sql
+-- Organizational hierarchy traversal
+WITH RECURSIVE org_hierarchy AS (
+    -- Anchor member: top-level managers
+    SELECT
+        employee_id,
+        name,
+        manager_id,
+        1 as level,
+        ARRAY[employee_id] as path,
+        name as hierarchy_path
+    FROM employees
+    WHERE manager_id IS NULL
+
+    UNION ALL
+
+    -- Recursive member: employees reporting to current level
+    SELECT
+        e.employee_id,
+        e.name,
+        e.manager_id,
+        h.level + 1,
+        h.path || e.employee_id,
+        h.hierarchy_path || ' > ' || e.name
+    FROM employees e
+    INNER JOIN org_hierarchy h ON e.manager_id = h.employee_id
+    WHERE NOT e.employee_id = ANY(h.path)  -- Prevent cycles
+)
+SELECT
+    employee_id,
+    REPEAT('  ', level - 1) || name as indented_name,
+    level,
+    hierarchy_path
+FROM org_hierarchy
+ORDER BY path;
+
+-- Bill of materials (parts explosion)
+WITH RECURSIVE parts_explosion AS (
+    SELECT
+        part_id,
+        component_id,
+        quantity,
+        1 as level,
+        ARRAY[part_id] as path
+    FROM bill_of_materials
+    WHERE part_id = 'PRODUCT-123'
+
+    UNION ALL
+
+    SELECT
+        pe.part_id,
+        bom.component_id,
+        pe.quantity * bom.quantity,
+        pe.level + 1,
+        pe.path || bom.part_id
+    FROM parts_explosion pe
+    INNER JOIN bill_of_materials bom ON pe.component_id = bom.part_id
+    WHERE NOT bom.part_id = ANY(pe.path)
+)
+SELECT
+    component_id,
+    SUM(quantity) as total_quantity,
+    MAX(level) as max_depth
+FROM parts_explosion
+GROUP BY component_id;
+```
+
+## Advanced JOIN Patterns
+
+```sql
+-- Self-join for finding gaps in sequences
+SELECT
+    a.order_id as current_id,
+    MIN(b.order_id) as next_id,
+    MIN(b.order_id) - a.order_id - 1 as gap_size
+FROM orders a
+LEFT JOIN orders b ON b.order_id > a.order_id
+GROUP BY a.order_id
+HAVING MIN(b.order_id) - a.order_id > 1;
+
+-- LATERAL join for correlated subqueries (PostgreSQL)
+SELECT
+    c.customer_id,
+    c.name,
+    recent.order_date,
+    recent.total
+FROM customers c
+CROSS JOIN LATERAL (
+    SELECT order_date, total
+    FROM orders o
+    WHERE o.customer_id = c.customer_id
+    ORDER BY order_date DESC
+    LIMIT 3
+) recent;
+
+-- Anti-join pattern (records in A not in B)
+SELECT u.user_id, u.email
+FROM users u
+LEFT JOIN orders o ON u.user_id = o.user_id
+WHERE o.order_id IS NULL;
+
+-- Using EXISTS (more efficient than IN for large sets)
+SELECT u.user_id, u.email
+FROM users u
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM orders o
+    WHERE o.user_id = u.user_id
+);
+```
+
+## Subquery Optimization
+
+```sql
+-- Scalar subquery in SELECT (use sparingly - can cause N+1)
+SELECT
+    p.product_id,
+    p.name,
+    (SELECT COUNT(*) FROM reviews r WHERE r.product_id = p.product_id) as review_count,
+    (SELECT AVG(rating) FROM reviews r WHERE r.product_id = p.product_id) as avg_rating
+FROM products p;
+
+-- Better: Use JOINs with aggregation
+SELECT
+    p.product_id,
+    p.name,
+    COALESCE(r.review_count, 0) as review_count,
+    r.avg_rating
+FROM products p
+LEFT JOIN (
+    SELECT
+        product_id,
+        COUNT(*) as review_count,
+        AVG(rating) as avg_rating
+    FROM reviews
+    GROUP BY product_id
+) r ON p.product_id = r.product_id;
+
+-- Correlated subquery for filtering
+SELECT
+    order_id,
+    customer_id,
+    total
+FROM orders o1
+WHERE total > (
+    SELECT AVG(total)
+    FROM orders o2
+    WHERE o2.customer_id = o1.customer_id
+);
+
+-- Better: Use window functions
+SELECT
+    order_id,
+    customer_id,
+    total
+FROM (
+    SELECT
+        order_id,
+        customer_id,
+        total,
+        AVG(total) OVER (PARTITION BY customer_id) as avg_customer_total
+    FROM orders
+) x
+WHERE total > avg_customer_total;
+```
+
+## PIVOT/UNPIVOT Operations
+
+```sql
+-- PostgreSQL CROSSTAB (requires tablefunc extension)
+CREATE EXTENSION IF NOT EXISTS tablefunc;
+
+SELECT * FROM crosstab(
+    'SELECT customer_id, product_category, SUM(amount)
+     FROM sales
+     GROUP BY customer_id, product_category
+     ORDER BY customer_id, product_category',
+    'SELECT DISTINCT product_category FROM sales ORDER BY 1'
+) AS ct(customer_id INT, electronics NUMERIC, clothing NUMERIC, food NUMERIC);
+
+-- Manual PIVOT with CASE
+SELECT
+    customer_id,
+    SUM(CASE WHEN product_category = 'electronics' THEN amount ELSE 0 END) as electronics,
+    SUM(CASE WHEN product_category = 'clothing' THEN amount ELSE 0 END) as clothing,
+    SUM(CASE WHEN product_category = 'food' THEN amount ELSE 0 END) as food
+FROM sales
+GROUP BY customer_id;
+
+-- UNPIVOT pattern (row to column)
+SELECT customer_id, 'electronics' as category, electronics as amount
+FROM customer_sales WHERE electronics > 0
+UNION ALL
+SELECT customer_id, 'clothing', clothing
+FROM customer_sales WHERE clothing > 0
+UNION ALL
+SELECT customer_id, 'food', food
+FROM customer_sales WHERE food > 0;
+```
+
+## Set Operations
+
+```sql
+-- UNION for combining distinct results
+SELECT product_id FROM active_products
+UNION
+SELECT product_id FROM featured_products;
+
+-- UNION ALL for better performance (includes duplicates)
+SELECT user_id, 'signup' as event FROM signups WHERE date = CURRENT_DATE
+UNION ALL
+SELECT user_id, 'purchase' as event FROM purchases WHERE date = CURRENT_DATE;
+
+-- INTERSECT for common records
+SELECT email FROM newsletter_subscribers
+INTERSECT
+SELECT email FROM premium_members;
+
+-- EXCEPT for difference (A - B)
+SELECT email FROM all_users
+EXCEPT
+SELECT email FROM unsubscribed_users;
+```
+
+## Performance Tips
+
+1. **CTE Materialization**: PostgreSQL 12+ materializes CTEs by default. Use `WITH cte AS MATERIALIZED` or `NOT MATERIALIZED` to control
+2. **JOIN Order**: Database optimizers handle this, but put smaller tables first in manual optimization
+3. **EXISTS vs IN**: Use EXISTS for correlated checks, IN for small static lists
+4. **Subquery vs JOIN**: Prefer JOINs for readability and optimizer friendliness
+5. **UNION ALL vs UNION**: Use UNION ALL when duplicates are acceptable (no deduplication cost)

--- a/.claude/skills/sql-pro/references/window-functions.md
+++ b/.claude/skills/sql-pro/references/window-functions.md
@@ -1,0 +1,328 @@
+# Window Functions
+
+## Ranking Functions
+
+```sql
+-- ROW_NUMBER: Sequential numbering within partition
+SELECT
+    customer_id,
+    order_date,
+    total,
+    ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) as row_num
+FROM orders;
+
+-- Get most recent order per customer
+SELECT *
+FROM (
+    SELECT
+        customer_id,
+        order_id,
+        order_date,
+        total,
+        ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) as rn
+    FROM orders
+) ranked
+WHERE rn = 1;
+
+-- RANK: Same values get same rank, gaps in sequence
+SELECT
+    student_id,
+    score,
+    RANK() OVER (ORDER BY score DESC) as rank,
+    DENSE_RANK() OVER (ORDER BY score DESC) as dense_rank,
+    ROW_NUMBER() OVER (ORDER BY score DESC) as row_num
+FROM exam_results;
+/*
+score=100: rank=1, dense_rank=1, row_num=1
+score=100: rank=1, dense_rank=1, row_num=2
+score=95:  rank=3, dense_rank=2, row_num=3
+*/
+
+-- NTILE: Divide into N buckets
+SELECT
+    customer_id,
+    total_spent,
+    NTILE(4) OVER (ORDER BY total_spent DESC) as quartile
+FROM customer_lifetime_value;
+```
+
+## Aggregate Window Functions
+
+```sql
+-- Running totals and cumulative sums
+SELECT
+    order_date,
+    daily_revenue,
+    SUM(daily_revenue) OVER (ORDER BY order_date) as cumulative_revenue,
+    AVG(daily_revenue) OVER (
+        ORDER BY order_date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+    ) as rolling_7day_avg
+FROM daily_sales;
+
+-- Moving average with RANGE
+SELECT
+    sale_date,
+    amount,
+    AVG(amount) OVER (
+        ORDER BY sale_date
+        RANGE BETWEEN INTERVAL '7 days' PRECEDING AND CURRENT ROW
+    ) as avg_last_7_days
+FROM sales;
+
+-- Partition-specific aggregates
+SELECT
+    product_id,
+    sale_date,
+    quantity,
+    SUM(quantity) OVER (PARTITION BY product_id ORDER BY sale_date) as cumulative_qty,
+    AVG(quantity) OVER (PARTITION BY product_id) as avg_qty_for_product,
+    quantity::FLOAT / SUM(quantity) OVER (PARTITION BY product_id) as pct_of_total
+FROM product_sales;
+```
+
+## LAG and LEAD Functions
+
+```sql
+-- Compare with previous/next row
+SELECT
+    order_date,
+    total,
+    LAG(total) OVER (ORDER BY order_date) as previous_day_total,
+    LEAD(total) OVER (ORDER BY order_date) as next_day_total,
+    total - LAG(total) OVER (ORDER BY order_date) as day_over_day_change
+FROM daily_orders;
+
+-- Find gaps in time series
+SELECT
+    event_date,
+    LAG(event_date) OVER (ORDER BY event_date) as prev_date,
+    event_date - LAG(event_date) OVER (ORDER BY event_date) as days_since_last
+FROM events
+WHERE event_date - LAG(event_date) OVER (ORDER BY event_date) > 7;
+
+-- Session analysis with time gaps
+SELECT
+    user_id,
+    action_time,
+    LAG(action_time) OVER (PARTITION BY user_id ORDER BY action_time) as prev_action,
+    EXTRACT(EPOCH FROM (
+        action_time - LAG(action_time) OVER (PARTITION BY user_id ORDER BY action_time)
+    )) / 60 as minutes_since_last_action,
+    CASE
+        WHEN EXTRACT(EPOCH FROM (
+            action_time - LAG(action_time) OVER (PARTITION BY user_id ORDER BY action_time)
+        )) / 60 > 30 THEN 1
+        ELSE 0
+    END as new_session
+FROM user_actions;
+```
+
+## FIRST_VALUE and LAST_VALUE
+
+```sql
+-- Compare each row to first/last in partition
+SELECT
+    product_id,
+    price_date,
+    price,
+    FIRST_VALUE(price) OVER (
+        PARTITION BY product_id
+        ORDER BY price_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) as initial_price,
+    LAST_VALUE(price) OVER (
+        PARTITION BY product_id
+        ORDER BY price_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) as current_price,
+    price - FIRST_VALUE(price) OVER (
+        PARTITION BY product_id
+        ORDER BY price_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) as price_change_from_start
+FROM product_price_history;
+
+-- NTH_VALUE: Get specific positioned value
+SELECT
+    sale_date,
+    amount,
+    NTH_VALUE(amount, 2) OVER (
+        ORDER BY sale_date
+        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+    ) as second_day_amount
+FROM daily_sales;
+```
+
+## Frame Specifications
+
+```sql
+-- ROWS vs RANGE difference
+SELECT
+    order_date,
+    amount,
+    -- ROWS: Physical row offset
+    SUM(amount) OVER (
+        ORDER BY order_date
+        ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING
+    ) as sum_5_rows,
+    -- RANGE: Logical value range
+    SUM(amount) OVER (
+        ORDER BY order_date
+        RANGE BETWEEN INTERVAL '2 days' PRECEDING AND INTERVAL '2 days' FOLLOWING
+    ) as sum_5_day_range
+FROM orders;
+
+-- Common frame patterns
+SELECT
+    sale_date,
+    revenue,
+    -- All preceding rows
+    SUM(revenue) OVER (
+        ORDER BY sale_date
+        ROWS UNBOUNDED PRECEDING
+    ) as running_total,
+    -- Last 3 rows including current
+    AVG(revenue) OVER (
+        ORDER BY sale_date
+        ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+    ) as ma_3,
+    -- Entire partition
+    SUM(revenue) OVER (
+        PARTITION BY EXTRACT(YEAR FROM sale_date)
+    ) as yearly_total,
+    -- Centered window
+    AVG(revenue) OVER (
+        ORDER BY sale_date
+        ROWS BETWEEN 3 PRECEDING AND 3 FOLLOWING
+    ) as centered_ma_7
+FROM sales;
+```
+
+## Advanced Analytics
+
+```sql
+-- Percentile calculations
+SELECT
+    employee_id,
+    salary,
+    PERCENT_RANK() OVER (ORDER BY salary) as pct_rank,
+    CUME_DIST() OVER (ORDER BY salary) as cumulative_dist,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) OVER () as median_salary,
+    PERCENTILE_DISC(0.9) WITHIN GROUP (ORDER BY salary) OVER () as p90_salary
+FROM employees;
+
+-- Cohort retention analysis
+WITH user_cohorts AS (
+    SELECT
+        user_id,
+        DATE_TRUNC('month', signup_date) as cohort_month,
+        DATE_TRUNC('month', activity_date) as activity_month
+    FROM user_activity
+),
+cohort_sizes AS (
+    SELECT
+        cohort_month,
+        COUNT(DISTINCT user_id) as cohort_size
+    FROM user_cohorts
+    GROUP BY cohort_month
+)
+SELECT
+    uc.cohort_month,
+    uc.activity_month,
+    EXTRACT(MONTH FROM AGE(uc.activity_month, uc.cohort_month)) as months_since_signup,
+    COUNT(DISTINCT uc.user_id) as active_users,
+    cs.cohort_size,
+    ROUND(100.0 * COUNT(DISTINCT uc.user_id) / cs.cohort_size, 2) as retention_pct
+FROM user_cohorts uc
+JOIN cohort_sizes cs ON uc.cohort_month = cs.cohort_month
+GROUP BY uc.cohort_month, uc.activity_month, cs.cohort_size
+ORDER BY uc.cohort_month, months_since_signup;
+
+-- Time-series gap filling
+SELECT
+    date_series.date,
+    COALESCE(s.revenue, 0) as revenue,
+    AVG(s.revenue) OVER (
+        ORDER BY date_series.date
+        ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+    ) as ma_7day
+FROM generate_series(
+    '2024-01-01'::DATE,
+    '2024-12-31'::DATE,
+    '1 day'::INTERVAL
+) AS date_series(date)
+LEFT JOIN sales s ON date_series.date = s.sale_date;
+```
+
+## Conditional Aggregation with Windows
+
+```sql
+-- Filter within window function
+SELECT
+    product_id,
+    sale_date,
+    quantity,
+    SUM(quantity) FILTER (WHERE quantity > 10) OVER (
+        PARTITION BY product_id
+        ORDER BY sale_date
+    ) as cumulative_large_orders,
+    COUNT(*) FILTER (WHERE quantity > 100) OVER (
+        PARTITION BY product_id
+    ) as total_bulk_orders
+FROM sales;
+
+-- Multiple conditions
+SELECT
+    customer_id,
+    order_date,
+    total,
+    COUNT(*) FILTER (WHERE total > 1000) OVER (
+        PARTITION BY customer_id
+    ) as high_value_order_count,
+    AVG(total) FILTER (WHERE total < 100) OVER (
+        PARTITION BY customer_id
+    ) as avg_small_order_value
+FROM orders;
+```
+
+## Performance Considerations
+
+```sql
+-- Avoid multiple window passes - combine into one
+-- Bad: Multiple scans
+SELECT
+    product_id,
+    (SELECT AVG(price) FROM products) as avg_price,
+    (SELECT MAX(price) FROM products) as max_price
+FROM products;
+
+-- Good: Single window pass
+SELECT DISTINCT
+    AVG(price) OVER () as avg_price,
+    MAX(price) OVER () as max_price
+FROM products;
+
+-- Materialize expensive windows
+CREATE MATERIALIZED VIEW product_rankings AS
+SELECT
+    product_id,
+    category,
+    sales_count,
+    RANK() OVER (PARTITION BY category ORDER BY sales_count DESC) as category_rank,
+    PERCENT_RANK() OVER (ORDER BY sales_count DESC) as overall_percentile
+FROM product_sales_summary;
+
+CREATE INDEX idx_product_rankings_category ON product_rankings(category, category_rank);
+```
+
+## Common Patterns
+
+1. **Top N per Group**: Use ROW_NUMBER() with WHERE rn <= N
+2. **Running Totals**: SUM() OVER (ORDER BY date)
+3. **Moving Averages**: AVG() with ROWS BETWEEN N PRECEDING
+4. **Session Analysis**: LAG() to detect time gaps
+5. **Deduplication**: ROW_NUMBER() OVER (PARTITION BY key ORDER BY priority) WHERE rn = 1
+6. **Percentiles**: PERCENT_RANK() or PERCENTILE_CONT()
+7. **Year-over-Year**: LAG(value, 12) OVER (ORDER BY month)
+8. **Cohort Analysis**: PARTITION BY cohort_date, aggregate over activity periods

--- a/.claude/skills/test-master/SKILL.md
+++ b/.claude/skills/test-master/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: test-master
+description: Generates test files, creates mocking strategies, analyzes code coverage, designs test architectures, and produces test plans and defect reports across functional, performance, and security testing disciplines. Use when writing unit tests, integration tests, or E2E tests; creating test strategies or automation frameworks; analyzing coverage gaps; performance testing with k6 or Artillery; security testing with OWASP methods; debugging flaky tests; or working on QA, regression, test automation, quality gates, shift-left testing, or test maintenance.
+license: MIT
+metadata:
+  author: https://github.com/Jeffallan
+  version: "1.1.1"
+  domain: quality
+  triggers: test, testing, QA, unit test, integration test, E2E, coverage, performance test, security test, regression, test strategy, test automation, test framework, quality metrics, defect, exploratory, usability, accessibility, localization, manual testing, shift-left, quality gate, flaky test, test maintenance
+  role: specialist
+  scope: testing
+  output-format: report
+  related-skills: fullstack-guardian, playwright-expert, devops-engineer, debugging-wizard, code-reviewer, feature-forge
+---
+
+# Test Master
+
+Comprehensive testing specialist ensuring software quality through functional, performance, and security testing.
+
+## Core Workflow
+
+1. **Define scope** — Identify what to test and which testing types apply
+2. **Create strategy** — Plan the test approach across functional, performance, and security perspectives
+3. **Write tests** — Implement tests with proper assertions (see example below)
+4. **Execute** — Run tests and collect results
+   - If tests fail: classify the failure (assertion error vs. environment/flakiness), fix root cause, re-run
+   - If tests are flaky: isolate ordering dependencies, check async handling, add retry or stabilization logic
+5. **Report** — Document findings with severity ratings and actionable fix recommendations
+   - Verify coverage targets are met before closing; flag gaps explicitly
+
+## Quick-Start Example
+
+A minimal Jest unit test illustrating the key patterns this skill enforces:
+
+```js
+// ✅ Good: meaningful description, specific assertion, isolated dependency
+describe('calculateDiscount', () => {
+  it('applies 10% discount for premium users', () => {
+    const result = calculateDiscount({ price: 100, userTier: 'premium' });
+    expect(result).toBe(90); // specific outcome, not just truthy
+  });
+
+  it('throws on negative price', () => {
+    expect(() => calculateDiscount({ price: -1, userTier: 'standard' }))
+      .toThrow('Price must be non-negative');
+  });
+});
+```
+
+Apply the same structure for pytest (`def test_…`, `assert result == expected`) and other frameworks.
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+<!-- TDD Iron Laws and Testing Anti-Patterns adapted from obra/superpowers by Jesse Vincent (@obra), MIT License -->
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Unit Testing | `references/unit-testing.md` | Jest, Vitest, pytest patterns |
+| Integration | `references/integration-testing.md` | API testing, Supertest |
+| E2E | `references/e2e-testing.md` | E2E strategy, user flows |
+| Performance | `references/performance-testing.md` | k6, load testing |
+| Security | `references/security-testing.md` | Security test checklist |
+| Reports | `references/test-reports.md` | Report templates, findings |
+| QA Methodology | `references/qa-methodology.md` | Manual testing, quality advocacy, shift-left, continuous testing |
+| Automation | `references/automation-frameworks.md` | Framework patterns, scaling, maintenance, team enablement |
+| TDD Iron Laws | `references/tdd-iron-laws.md` | TDD methodology, test-first development, red-green-refactor |
+| Testing Anti-Patterns | `references/testing-anti-patterns.md` | Test review, mock issues, test quality problems |
+
+## Constraints
+
+**MUST DO**
+- Test happy paths AND error/edge cases (e.g., empty input, null, boundary values)
+- Mock external dependencies — never call real APIs or databases in unit tests
+- Use meaningful `it('…')` descriptions that read as plain-English specifications
+- Assert specific outcomes (`expect(result).toBe(90)`), not just truthiness
+- Run tests in CI/CD; document and remediate coverage gaps
+
+**MUST NOT**
+- Skip error-path testing (e.g., don't test only the success branch of a try/catch)
+- Use production data in tests — use fixtures or factories instead
+- Create order-dependent tests — each test must be independently runnable
+- Ignore flaky tests — quarantine and fix them; don't just re-run until green
+- Test implementation details (internal method calls) — test observable behaviour
+
+## Output Templates
+
+When creating test plans, provide:
+1. Test scope and approach
+2. Test cases with expected outcomes
+3. Coverage analysis
+4. Findings with severity (Critical/High/Medium/Low)
+5. Specific fix recommendations
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/test-master/)

--- a/.claude/skills/test-master/references/automation-frameworks.md
+++ b/.claude/skills/test-master/references/automation-frameworks.md
@@ -1,0 +1,294 @@
+# Automation Frameworks
+
+## Advanced Framework Patterns
+
+### Screenplay Pattern
+```typescript
+// Better separation of concerns than POM
+export class Actor {
+  constructor(private page: Page) {}
+  attemptsTo(...tasks: Task[]) {
+    return Promise.all(tasks.map(t => t.performAs(this)));
+  }
+}
+
+class Login implements Task {
+  constructor(private email: string, private password: string) {}
+  async performAs(actor: Actor) {
+    await actor.page.getByLabel('Email').fill(this.email);
+    await actor.page.getByLabel('Password').fill(this.password);
+    await actor.page.getByRole('button', { name: 'Login' }).click();
+  }
+}
+
+// Clear, maintainable test code
+await new Actor(page).attemptsTo(new Login('user@test.com', 'pass'));
+```
+
+### Keyword-Driven Testing
+```typescript
+const keywords = {
+  NAVIGATE: (page, url) => page.goto(url),
+  CLICK: (page, selector) => page.click(selector),
+  TYPE: (page, selector, text) => page.fill(selector, text),
+  VERIFY: (page, selector) => expect(page.locator(selector)).toBeVisible(),
+};
+
+// Data drives execution - ideal for non-technical authors
+const steps = [
+  { keyword: 'NAVIGATE', args: ['/login'] },
+  { keyword: 'TYPE', args: ['#email', 'user@test.com'] },
+  { keyword: 'CLICK', args: ['#submit'] },
+];
+
+for (const step of steps) await keywords[step.keyword](page, ...step.args);
+```
+
+### Model-Based Testing
+```typescript
+// State machine defines valid transitions
+const cartModel = {
+  empty: { addItem: 'hasItems' },
+  hasItems: { addItem: 'hasItems', removeItem: 'hasItems|empty', checkout: 'checkingOut' },
+  checkingOut: { confirm: 'complete', cancel: 'hasItems' },
+};
+
+// Generate comprehensive test paths automatically
+const testPaths = generatePathsFromModel(cartModel);
+```
+
+## Maintenance Strategies
+
+### Self-Healing Locators
+```typescript
+// Multi-strategy finder with automatic fallback
+async function findElement(page: Page, strategies: string[]): Promise<Locator> {
+  for (const selector of strategies) {
+    const el = page.locator(selector);
+    if (await el.count() > 0) return el;
+  }
+  throw new Error(`Not found: ${strategies.join(', ')}`);
+}
+
+// Usage: tries best -> good -> fallback
+const submit = await findElement(page, [
+  '[data-testid="submit"]',     // Best: stable test ID
+  'button:has-text("Submit")',  // Good: semantic
+  'button.primary',             // Fallback: CSS
+]);
+```
+
+### Error Recovery & Smart Retry
+```typescript
+// Auto-retry with recovery actions
+async function clickWithRecovery(page: Page, selector: string, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      await page.click(selector, { timeout: 5000 });
+      return;
+    } catch (e) {
+      if (i === retries - 1) throw e;
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+    }
+  }
+}
+
+// Exponential backoff for flaky operations
+async function retryWithBackoff<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === retries - 1) throw e;
+      await new Promise(r => setTimeout(r, 1000 * Math.pow(2, i)));
+    }
+  }
+}
+```
+
+## Scaling Strategies
+
+### Parallel & Distributed Execution
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  workers: process.env.CI ? 8 : 4,
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  
+  // Shard tests across multiple machines
+  shard: process.env.SHARD ? {
+    current: parseInt(process.env.SHARD_INDEX),
+    total: parseInt(process.env.SHARD_TOTAL),
+  } : undefined,
+});
+```
+
+```yaml
+# GitHub Actions: distribute across 5 workers
+strategy:
+  matrix:
+    shard: [1, 2, 3, 4, 5]
+steps:
+  - run: npx playwright test --shard=${{ matrix.shard }}/5
+```
+
+### Resource Optimization
+```typescript
+// Reuse browser contexts for faster execution
+let browser: Browser;
+let context: BrowserContext;
+
+test.beforeAll(async () => {
+  browser = await chromium.launch();
+  context = await browser.newContext();
+});
+
+test('test 1', async () => {
+  const page = await context.newPage();
+  // Test logic
+  await page.close();
+});
+
+test.afterAll(async () => {
+  await context.close();
+  await browser.close();
+});
+```
+
+## CI/CD Integration
+
+### Complete Pipeline
+```yaml
+name: E2E Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
+    
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      
+      - run: npx playwright test --shard=${{ matrix.shard }}/4
+        env:
+          CI: true
+      
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: report-${{ matrix.shard }}
+          path: playwright-report/
+```
+
+### Test Data Factories
+```typescript
+export class UserFactory {
+  static create(overrides?: Partial<User>): User {
+    return {
+      id: faker.string.uuid(),
+      email: faker.internet.email(),
+      name: faker.person.fullName(),
+      role: 'user',
+      ...overrides,
+    };
+  }
+
+  static createMany(count: number) {
+    return Array.from({ length: count }, () => this.create());
+  }
+}
+
+// Seed test data
+test.beforeEach(async ({ page }) => {
+  await page.request.post('/api/test/seed', {
+    data: { users: UserFactory.createMany(10) },
+  });
+});
+```
+
+## Team Enablement
+
+### Training Program
+```markdown
+**Week 1-2**: Framework basics, page objects, first test
+**Week 3-4**: Data-driven, API integration, CI/CD
+**Week 5-6**: Performance, error handling, scaling
+**Ongoing**: Code reviews, knowledge sharing
+```
+
+### Code Review Checklist
+```markdown
+- [ ] Independent tests (no order dependency)
+- [ ] Semantic locators (getByRole, getByLabel)
+- [ ] Proper waits (no arbitrary timeouts)
+- [ ] Error cases tested
+- [ ] Test data cleanup
+- [ ] Meaningful test names
+- [ ] Page objects updated
+```
+
+## Automation Strategy
+
+### ROI Calculation
+```typescript
+const manual = { timePerRun: 30, runsPerSprint: 10 };
+const automation = { development: 120, maintenance: 5 };
+
+const timeSaved = (manual.timePerRun * manual.runsPerSprint) - automation.maintenance;
+const breakEven = Math.ceil(automation.development / timeSaved);
+const annualSavings = (timeSaved * 26 - automation.development) / 60; // hours
+
+// Example: Break-even in 1 sprint, save 110 hours/year
+```
+
+### Selection Criteria
+```markdown
+**Automate**: Repetitive, stable UI, critical paths, data-driven, positive ROI
+**Don't Automate**: Exploratory, changing UI, one-time, usability, negative ROI
+```
+
+## Reporting & Metrics
+
+### Custom Reporter
+```typescript
+class MetricsReporter implements Reporter {
+  onTestEnd(test: TestCase, result: TestResult) {
+    this.sendMetrics({
+      name: test.title,
+      duration: result.duration,
+      status: result.status,
+      retries: result.retry,
+    });
+  }
+}
+```
+
+## Quick Reference
+
+| Pattern | Best For | Complexity |
+|---------|----------|-----------|
+| Page Object | Reusable components | Medium |
+| Screenplay | Complex workflows | High |
+| Keyword-Driven | Non-tech testers | Low |
+| Model-Based | State machines | High |
+
+| Scaling | Use Case |
+|---------|----------|
+| Parallel | Reduce time |
+| Distributed | Large suites |
+| Cloud | Cross-browser |
+| Resource Reuse | Speed |
+
+| Tool | Category |
+|------|----------|
+| Playwright, Cypress | Web E2E |
+| Appium, Detox | Mobile |
+| k6, Gatling | Performance |

--- a/.claude/skills/test-master/references/e2e-testing.md
+++ b/.claude/skills/test-master/references/e2e-testing.md
@@ -1,0 +1,128 @@
+# E2E Testing
+
+## E2E Test Strategy
+
+```typescript
+// Critical user paths to test
+const criticalPaths = [
+  'User registration and login',
+  'Core product/service workflow',
+  'Payment/checkout flow',
+  'Settings and profile management',
+];
+```
+
+## User Flow Testing
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('User Registration Flow', () => {
+  test('complete registration', async ({ page }) => {
+    await page.goto('/register');
+
+    await page.getByLabel('Email').fill('new@example.com');
+    await page.getByLabel('Password').fill('SecurePass123!');
+    await page.getByLabel('Confirm Password').fill('SecurePass123!');
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    await expect(page).toHaveURL(/dashboard/);
+    await expect(page.getByText('Welcome')).toBeVisible();
+  });
+
+  test('shows validation errors', async ({ page }) => {
+    await page.goto('/register');
+
+    await page.getByLabel('Email').fill('invalid');
+    await page.getByRole('button', { name: 'Register' }).click();
+
+    await expect(page.getByText('Invalid email')).toBeVisible();
+  });
+});
+```
+
+## Checkout Flow
+
+```typescript
+test.describe('Checkout Flow', () => {
+  test('complete purchase', async ({ page }) => {
+    // Add to cart
+    await page.goto('/products/123');
+    await page.getByRole('button', { name: 'Add to Cart' }).click();
+    await expect(page.getByTestId('cart-count')).toHaveText('1');
+
+    // Checkout
+    await page.goto('/cart');
+    await page.getByRole('button', { name: 'Checkout' }).click();
+
+    // Payment
+    await page.getByLabel('Card Number').fill('4242424242424242');
+    await page.getByLabel('Expiry').fill('12/25');
+    await page.getByLabel('CVC').fill('123');
+    await page.getByRole('button', { name: 'Pay' }).click();
+
+    // Confirmation
+    await expect(page).toHaveURL(/order-confirmation/);
+    await expect(page.getByText('Order Confirmed')).toBeVisible();
+  });
+});
+```
+
+## Test Data Management
+
+```typescript
+// fixtures/testData.ts
+export const testUsers = {
+  standard: {
+    email: 'standard@test.com',
+    password: 'TestPass123!',
+  },
+  admin: {
+    email: 'admin@test.com',
+    password: 'AdminPass123!',
+  },
+};
+
+// Test setup
+test.beforeEach(async ({ page }) => {
+  // Seed test data
+  await page.request.post('/api/test/seed');
+});
+
+test.afterEach(async ({ page }) => {
+  // Clean up
+  await page.request.post('/api/test/cleanup');
+});
+```
+
+## Cross-Browser Testing
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 13'] } },
+  ],
+});
+```
+
+## Quick Reference
+
+| Pattern | When to Use |
+|---------|-------------|
+| Happy path | Critical user journeys |
+| Error handling | Form validation, API errors |
+| Edge cases | Empty states, max limits |
+| Cross-browser | Before major releases |
+| Mobile | Responsive features |
+
+| Priority | Test Coverage |
+|----------|---------------|
+| **P0** | Registration, login, core feature |
+| **P1** | Payment, settings, common flows |
+| **P2** | Edge cases, admin features |
+| **P3** | Rare scenarios |

--- a/.claude/skills/test-master/references/integration-testing.md
+++ b/.claude/skills/test-master/references/integration-testing.md
@@ -1,0 +1,120 @@
+# Integration Testing
+
+## API Testing (Supertest)
+
+```typescript
+import request from 'supertest';
+import { app } from '../app';
+
+describe('POST /api/users', () => {
+  it('creates user with valid data', async () => {
+    const response = await request(app)
+      .post('/api/users')
+      .send({ email: 'test@test.com', name: 'Test' })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      email: 'test@test.com',
+      name: 'Test',
+    });
+    expect(response.body.id).toBeDefined();
+  });
+
+  it('returns 400 for invalid email', async () => {
+    const response = await request(app)
+      .post('/api/users')
+      .send({ email: 'invalid', name: 'Test' })
+      .expect(400);
+
+    expect(response.body.error).toContain('email');
+  });
+
+  it('returns 401 without auth token', async () => {
+    await request(app)
+      .get('/api/users/me')
+      .expect(401);
+  });
+});
+```
+
+## Authenticated Requests
+
+```typescript
+describe('Protected endpoints', () => {
+  let authToken: string;
+
+  beforeAll(async () => {
+    const response = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'test@test.com', password: 'password' });
+    authToken = response.body.token;
+  });
+
+  it('accesses protected route', async () => {
+    await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+  });
+});
+```
+
+## Database Testing
+
+```typescript
+import { db } from '../database';
+
+describe('UserRepository', () => {
+  beforeEach(async () => {
+    await db.query('DELETE FROM users');
+  });
+
+  afterAll(async () => {
+    await db.end();
+  });
+
+  it('creates and retrieves user', async () => {
+    const user = await userRepo.create({
+      email: 'test@test.com',
+      name: 'Test',
+    });
+
+    const found = await userRepo.findById(user.id);
+    expect(found).toEqual(user);
+  });
+});
+```
+
+## pytest API Testing
+
+```python
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_create_user(client: AsyncClient):
+    response = await client.post("/api/users/", json={
+        "email": "test@example.com",
+        "name": "Test"
+    })
+    assert response.status_code == 201
+    assert response.json()["email"] == "test@example.com"
+
+@pytest.mark.asyncio
+async def test_invalid_email(client: AsyncClient):
+    response = await client.post("/api/users/", json={
+        "email": "invalid",
+        "name": "Test"
+    })
+    assert response.status_code == 422
+```
+
+## Quick Reference
+
+| Method | Purpose |
+|--------|---------|
+| `.send(body)` | Send request body |
+| `.set(header, value)` | Set header |
+| `.expect(status)` | Assert status code |
+| `.expect('Content-Type', /json/)` | Assert header |
+| `response.body` | Parsed JSON body |

--- a/.claude/skills/test-master/references/performance-testing.md
+++ b/.claude/skills/test-master/references/performance-testing.md
@@ -1,0 +1,118 @@
+# Performance Testing
+
+## k6 Load Test
+
+```javascript
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 20 },   // Ramp up to 20 users
+    { duration: '1m', target: 20 },    // Stay at 20 users
+    { duration: '30s', target: 0 },    // Ramp down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],  // 95% requests under 500ms
+    http_req_failed: ['rate<0.01'],    // <1% errors
+  },
+};
+
+export default function () {
+  const res = http.get('http://localhost:3000/api/users');
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response time < 200ms': (r) => r.timings.duration < 200,
+  });
+
+  sleep(1);
+}
+```
+
+## Stress Test
+
+```javascript
+export const options = {
+  stages: [
+    { duration: '2m', target: 100 },   // Ramp to 100 users
+    { duration: '5m', target: 100 },   // Stay at 100
+    { duration: '2m', target: 200 },   // Push to 200
+    { duration: '5m', target: 200 },   // Stay at 200
+    { duration: '2m', target: 0 },     // Ramp down
+  ],
+};
+```
+
+## Spike Test
+
+```javascript
+export const options = {
+  stages: [
+    { duration: '10s', target: 10 },   // Normal load
+    { duration: '1m', target: 10 },
+    { duration: '10s', target: 200 },  // Spike!
+    { duration: '3m', target: 200 },
+    { duration: '10s', target: 10 },   // Scale down
+    { duration: '3m', target: 10 },
+    { duration: '10s', target: 0 },
+  ],
+};
+```
+
+## API Testing with Auth
+
+```javascript
+import http from 'k6/http';
+
+export function setup() {
+  const loginRes = http.post('http://localhost:3000/api/login', {
+    email: 'test@test.com',
+    password: 'password',
+  });
+  return { token: loginRes.json('token') };
+}
+
+export default function (data) {
+  const params = {
+    headers: { Authorization: `Bearer ${data.token}` },
+  };
+
+  http.get('http://localhost:3000/api/protected', params);
+}
+```
+
+## Thresholds Reference
+
+```javascript
+thresholds: {
+  // Response time
+  http_req_duration: ['p(95)<500', 'p(99)<1000'],
+
+  // Error rate
+  http_req_failed: ['rate<0.01'],
+
+  // Throughput
+  http_reqs: ['rate>100'],
+
+  // Custom metrics
+  'http_req_duration{name:login}': ['p(95)<200'],
+}
+```
+
+## Quick Reference
+
+| Metric | Description |
+|--------|-------------|
+| `http_req_duration` | Response time |
+| `http_req_failed` | Failed requests rate |
+| `http_reqs` | Request rate |
+| `p(95)` | 95th percentile |
+| `rate` | Rate per second |
+
+| Test Type | Purpose |
+|-----------|---------|
+| Load | Normal expected load |
+| Stress | Find breaking point |
+| Spike | Sudden traffic surge |
+| Soak | Long duration stability |

--- a/.claude/skills/test-master/references/qa-methodology.md
+++ b/.claude/skills/test-master/references/qa-methodology.md
@@ -1,0 +1,247 @@
+# QA Methodology
+
+## Manual Testing Types
+
+### Exploratory Testing
+```markdown
+**Charter**: Explore {feature} with focus on {aspect}
+**Duration**: 60-90 min
+**Mission**: Find defects in {specific functionality}
+
+Test Ideas:
+- Boundary conditions & edge cases
+- Error handling & recovery
+- User workflow variations
+- Integration points
+
+Findings:
+1. [HIGH] {Issue + impact}
+2. [MED] {Issue + impact}
+
+Coverage: {Areas explored} | Risks: {Identified risks}
+```
+
+### Usability Testing
+```markdown
+**Task**: Can users complete {action} intuitively?
+**Metrics**: Time to complete, errors made, satisfaction (1-5)
+**Success**: 80% complete without help in <5 min
+
+Observations:
+- Navigation confusing at {step}
+- Users expect {A} but get {B}
+- Positive: {feature feedback}
+```
+
+### Accessibility Testing (WCAG 2.1 AA)
+```typescript
+test('accessibility compliance', async ({ page }) => {
+  // Keyboard navigation
+  await page.keyboard.press('Tab');
+  expect(['A', 'BUTTON', 'INPUT']).toContain(
+    await page.evaluate(() => document.activeElement.tagName)
+  );
+  
+  // ARIA labels
+  expect(await page.getByRole('button').first().getAttribute('aria-label')).toBeTruthy();
+  
+  // Color contrast (axe-core)
+  const violations = await page.evaluate(async () => {
+    const axe = await import('axe-core');
+    return (await axe.run()).violations;
+  });
+  expect(violations).toHaveLength(0);
+});
+```
+
+### Localization Testing
+```markdown
+**Test**: {Feature} in {language/locale}
+- [ ] Text displays without truncation
+- [ ] Date/time/currency formats correct
+- [ ] Right-to-left layout (Arabic, Hebrew)
+- [ ] Character encoding UTF-8
+- [ ] Sort order respects locale
+```
+
+### Compatibility Matrix
+```markdown
+| Browser | Version | OS | Status |
+|---------|---------|----|----- --|
+| Chrome | Latest | Win/Mac | ✓ |
+| Firefox | Latest | Win/Mac | ✓ |
+| Safari | Latest | macOS/iOS | ✓ |
+| Edge | Latest | Windows | ✓ |
+```
+
+## Test Design Techniques
+
+### Pairwise Testing
+```typescript
+// Test all parameter pairs efficiently
+const pairwiseTests = [
+  { browser: 'chrome', os: 'windows', lang: 'en' },
+  { browser: 'firefox', os: 'mac', lang: 'es' },
+  { browser: 'safari', os: 'windows', lang: 'fr' },
+  // Covers all pairs with minimal tests
+];
+```
+
+### Risk-Based Testing
+```markdown
+| Risk | Probability | Impact | Priority | Test Effort |
+|------|-------------|--------|----------|-------------|
+| Critical | High | High | P0 | Exhaustive |
+| High | Med-High | High | P1 | Comprehensive |
+| Medium | Low-Med | Med | P2 | Standard |
+| Low | Low | Low | P3 | Smoke only |
+```
+
+## Defect Management
+
+### Root Cause Analysis (5 Whys)
+```markdown
+1. Why did defect occur? {User input not validated}
+2. Why wasn't it validated? {Validation logic missing}
+3. Why was it missing? {Requirement unclear}
+4. Why was requirement unclear? {Acceptance criteria incomplete}
+5. Why incomplete? {No QA review in planning}
+
+**Root Cause**: QA not involved in requirements phase
+**Prevention**: Add QA to all planning meetings
+```
+
+### Defect Report Template
+```markdown
+## [CRITICAL] {Defect Title}
+
+**Steps to Reproduce**:
+1. {Step 1}
+2. {Step 2}
+
+**Expected**: {Should happen}
+**Actual**: {Actually happens}
+**Impact**: {Business/user impact}
+**Root Cause**: {Why it happened}
+**Fix**: {Recommended solution}
+```
+
+## Quality Metrics
+
+### Key Calculations
+```typescript
+// Defect Removal Efficiency (target: >95%)
+const dre = (defectsInTesting / (defectsInTesting + defectsInProd)) * 100;
+
+// Defect Leakage (target: <5%)
+const leakage = (defectsInProd / totalDefects) * 100;
+
+// Test Effectiveness (target: >90%)
+const effectiveness = (defectsFoundByTests / totalDefects) * 100;
+
+// Automation ROI
+const roi = (timeSaved - maintenanceCost - developmentCost) / developmentCost;
+```
+
+### Quality Dashboard
+```markdown
+| Metric | Target | Actual | Trend | Status |
+|--------|--------|--------|-------|--------|
+| Coverage | >80% | 87% | ↑ | ✓ |
+| Defect Leakage | <5% | 3% | ↓ | ✓ |
+| Automation | >70% | 68% | ↑ | ⚠ |
+| Critical Defects | 0 | 0 | → | ✓ |
+| MTTR | <48h | 36h | ↓ | ✓ |
+```
+
+## Continuous Testing & Shift-Left
+
+### Shift-Left Activities
+```markdown
+**Early Testing**:
+- Review requirements for testability
+- Create test cases during design
+- TDD: unit tests with code
+- Automated tests in CI pipeline
+- Static analysis on commit
+- Security scanning pre-merge
+
+**Benefits**: 10x cheaper defect fixes, faster feedback
+```
+
+### Feedback Cycle Targets
+```typescript
+const feedbackCycle = {
+  unitTests: '< 5 min',       // On save
+  integration: '< 15 min',    // On commit
+  e2e: '< 30 min',            // On PR
+  regression: '< 2 hours',    // Nightly
+};
+```
+
+## Quality Advocacy
+
+### Quality Gates
+```markdown
+## Production Release Gate
+
+**Must Pass (Blockers)**:
+- [ ] Zero critical defects
+- [ ] Coverage >80%
+- [ ] All P0/P1 tests passing
+- [ ] Performance SLA met
+- [ ] Security scan clean
+- [ ] Accessibility WCAG AA
+
+**Decision**: GO | NO-GO | GO with exceptions
+```
+
+### Team Education Program
+```markdown
+**Week 1-2**: Test fundamentals
+**Week 3-4**: Automation basics
+**Week 5-6**: Advanced topics (perf, security, API)
+**Ongoing**: Best practices, tool updates
+```
+
+## Test Planning
+
+### Test Plan Template
+```markdown
+## Test Plan: {Feature}
+
+**Scope**: {What to test}
+**Types**: Unit, Integration, E2E, Perf, Security
+**Resources**: {Team allocation}
+**Dependencies**: {Prerequisites}
+**Schedule**: {Timeline}
+**Entry Criteria**: {Start conditions}
+**Exit Criteria**: {Completion conditions}
+**Risks**: {Identified risks + mitigation}
+```
+
+### Environment Strategy
+```markdown
+| Env | Purpose | Data | Refresh | Access |
+|-----|---------|------|---------|--------|
+| Dev | Development | Synthetic | On-demand | All |
+| Test | QA testing | Test data | Daily | QA |
+| Stage | Pre-prod | Prod-like | Weekly | Limited |
+| Prod | Live | Real | N/A | Ops |
+```
+
+## Quick Reference
+
+| Testing Type | When | Duration |
+|--------------|------|----------|
+| Exploratory | New features | 60-120 min |
+| Usability | UI changes | 2-4 hours |
+| Accessibility | Every release | 1-2 hours |
+| Localization | Multi-region | 1 day/locale |
+
+| Metric | Excellent | Good | Needs Work |
+|--------|-----------|------|------------|
+| Coverage | >90% | 70-90% | <70% |
+| Leakage | <2% | 2-5% | >5% |
+| Automation | >80% | 60-80% | <60% |
+| MTTR | <24h | 24-48h | >48h |

--- a/.claude/skills/test-master/references/security-testing.md
+++ b/.claude/skills/test-master/references/security-testing.md
@@ -1,0 +1,127 @@
+# Security Testing
+
+## Authentication Tests
+
+```typescript
+describe('Authentication Security', () => {
+  it('rejects invalid credentials', async () => {
+    await request(app)
+      .post('/api/login')
+      .send({ email: 'user@test.com', password: 'wrong' })
+      .expect(401);
+  });
+
+  it('rejects expired tokens', async () => {
+    const expiredToken = createExpiredToken();
+    await request(app)
+      .get('/api/protected')
+      .set('Authorization', `Bearer ${expiredToken}`)
+      .expect(401);
+  });
+
+  it('rejects tampered tokens', async () => {
+    const tamperedToken = validToken.slice(0, -5) + 'xxxxx';
+    await request(app)
+      .get('/api/protected')
+      .set('Authorization', `Bearer ${tamperedToken}`)
+      .expect(401);
+  });
+
+  it('enforces rate limiting on login', async () => {
+    for (let i = 0; i < 6; i++) {
+      await request(app)
+        .post('/api/login')
+        .send({ email: 'user@test.com', password: 'wrong' });
+    }
+
+    await request(app)
+      .post('/api/login')
+      .send({ email: 'user@test.com', password: 'correct' })
+      .expect(429);
+  });
+});
+```
+
+## Authorization Tests
+
+```typescript
+describe('Authorization', () => {
+  it('denies access to other users resources', async () => {
+    await request(app)
+      .get('/api/users/other-user-id/data')
+      .set('Authorization', `Bearer ${userAToken}`)
+      .expect(403);
+  });
+
+  it('denies admin routes to regular users', async () => {
+    await request(app)
+      .delete('/api/admin/users/123')
+      .set('Authorization', `Bearer ${regularUserToken}`)
+      .expect(403);
+  });
+});
+```
+
+## Input Validation Tests
+
+```typescript
+describe('Input Validation', () => {
+  it('rejects SQL injection attempts', async () => {
+    await request(app)
+      .get('/api/users')
+      .query({ search: "'; DROP TABLE users; --" })
+      .expect(400);
+  });
+
+  it('rejects XSS in input fields', async () => {
+    const response = await request(app)
+      .post('/api/posts')
+      .send({ title: '<script>alert("xss")</script>' })
+      .expect(201);
+
+    expect(response.body.title).not.toContain('<script>');
+  });
+
+  it('validates file upload types', async () => {
+    await request(app)
+      .post('/api/upload')
+      .attach('file', 'malicious.exe')
+      .expect(400);
+  });
+});
+```
+
+## Security Headers Test
+
+```typescript
+describe('Security Headers', () => {
+  it('sets security headers', async () => {
+    const response = await request(app).get('/');
+
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['x-frame-options']).toBe('DENY');
+    expect(response.headers['strict-transport-security']).toBeDefined();
+  });
+});
+```
+
+## Security Test Checklist
+
+| Category | Tests |
+|----------|-------|
+| **Auth** | Invalid creds, token expiry, tampering |
+| **Input** | SQL injection, XSS, command injection |
+| **Access** | IDOR, privilege escalation |
+| **Rate Limit** | Brute force, API abuse |
+| **Headers** | CSP, HSTS, X-Frame-Options |
+| **Data** | PII exposure, error messages |
+
+## Quick Reference
+
+| Vulnerability | Test Approach |
+|---------------|---------------|
+| SQL Injection | `'; DROP TABLE--` in inputs |
+| XSS | `<script>alert(1)</script>` |
+| IDOR | Access other user's resources |
+| CSRF | Missing/invalid tokens |
+| Auth Bypass | Missing auth, expired tokens |

--- a/.claude/skills/test-master/references/tdd-iron-laws.md
+++ b/.claude/skills/test-master/references/tdd-iron-laws.md
@@ -1,0 +1,174 @@
+# TDD Iron Laws
+
+---
+
+## The Fundamental Principle
+
+> **NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST.**
+
+This is non-negotiable. If you wrote production code before writing a failing test, delete it and start over. No exceptions.
+
+---
+
+## The Three Iron Laws
+
+### Iron Law 1: The Fundamental Rule
+
+> "You shall not write any production code unless it is to make a failing test pass."
+
+Every line of production code must have a corresponding test that:
+1. Was written first
+2. Was observed to fail
+3. Now passes because of that code
+
+### Iron Law 2: Proof Through Observation
+
+> "If you didn't watch the test fail, you don't know if it tests the right thing."
+
+Mandatory verification steps:
+- Write the test
+- Run it and **observe the failure**
+- Verify the failure message is meaningful
+- Only then implement the fix
+
+A test you've never seen fail proves nothing.
+
+### Iron Law 3: The Final Rule
+
+> "Production code exists → A test exists that failed first. Otherwise → It's not TDD."
+
+There is no middle ground. Code written without a prior failing test is not test-driven development, regardless of how many tests exist afterward.
+
+---
+
+## The RED-GREEN-REFACTOR Cycle
+
+### RED: Write One Minimal Failing Test
+
+```typescript
+// Start with the smallest possible failing test
+it('should return 0 for empty array', () => {
+  expect(sum([])).toBe(0);
+});
+// Run: ✗ FAIL - sum is not defined
+```
+
+**Requirements:**
+- One test at a time
+- Minimal scope
+- Clear failure message
+- Observe the red
+
+### GREEN: Implement Simplest Passing Code
+
+```typescript
+// Write only enough code to pass this specific test
+function sum(numbers: number[]): number {
+  return 0;
+}
+// Run: ✓ PASS
+```
+
+**Requirements:**
+- Simplest possible implementation
+- No extra features
+- No optimization
+- Just make it pass
+
+### REFACTOR: Improve While Keeping Tests Green
+
+```typescript
+// Now improve the code while tests stay green
+function sum(numbers: number[]): number {
+  return numbers.reduce((acc, n) => acc + n, 0);
+}
+// Run: ✓ PASS (still)
+```
+
+**Requirements:**
+- Tests must stay green
+- Remove duplication
+- Improve clarity
+- No new functionality
+
+---
+
+## Common Rationalizations to Reject
+
+These thoughts indicate you're about to violate TDD:
+
+| Rationalization | Why It's Wrong |
+|-----------------|----------------|
+| "I can manually test this quickly" | Manual testing doesn't prevent regression |
+| "I'll write tests after to save time" | You'll skip edge cases and test implementation |
+| "This is too simple to need a test" | Simple code changes; tests document expectations |
+| "I've already written the code, I can't delete it now" | Sunk cost fallacy; delete it |
+| "I know this works, I've done it before" | Your memory isn't documentation |
+| "We're in a hurry" | Technical debt costs more than TDD |
+
+---
+
+## Practical Application
+
+### Starting a New Feature
+
+```typescript
+// 1. RED: Write failing test for simplest behavior
+describe('UserValidator', () => {
+  it('should reject empty email', () => {
+    expect(validateEmail('')).toBe(false);
+  });
+});
+
+// 2. GREEN: Implement minimal passing code
+function validateEmail(email: string): boolean {
+  return email.length > 0;
+}
+
+// 3. RED: Add next failing test
+it('should reject email without @', () => {
+  expect(validateEmail('invalid')).toBe(false);
+});
+
+// 4. GREEN: Extend to pass both tests
+function validateEmail(email: string): boolean {
+  return email.length > 0 && email.includes('@');
+}
+
+// Continue cycle...
+```
+
+### Fixing a Bug
+
+```typescript
+// 1. RED: Write test that exposes the bug
+it('should handle negative numbers in sum', () => {
+  expect(sum([-1, -2, -3])).toBe(-6);
+});
+// Run: ✗ FAIL - got 0 instead of -6
+
+// 2. GREEN: Fix the bug
+function sum(numbers: number[]): number {
+  return numbers.reduce((acc, n) => acc + n, 0);
+}
+// Run: ✓ PASS
+
+// Bug is now fixed AND protected against regression
+```
+
+---
+
+## Verification Checklist
+
+Before claiming any code is complete:
+
+- [ ] Every production function has corresponding tests
+- [ ] Each test was written before its implementation
+- [ ] Each test was observed to fail first
+- [ ] Tests verify behavior, not implementation
+- [ ] Refactoring kept all tests green
+- [ ] No production code exists without a test
+
+---
+
+*Content adapted from [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (@obra), MIT License.*

--- a/.claude/skills/test-master/references/test-reports.md
+++ b/.claude/skills/test-master/references/test-reports.md
@@ -1,0 +1,104 @@
+# Test Reports
+
+## Test Report Template
+
+```markdown
+# Test Report: {Feature Name}
+
+**Date**: YYYY-MM-DD
+**Tester**: {Name}
+**Version**: {App Version}
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total Tests | X |
+| Passed | X |
+| Failed | X |
+| Skipped | X |
+| Coverage | X% |
+
+## Test Scope
+
+- [x] Unit tests
+- [x] Integration tests
+- [x] E2E tests
+- [ ] Performance tests
+- [ ] Security tests
+
+## Findings
+
+### [CRITICAL] {Issue Title}
+- **Location**: src/api/users.ts:45
+- **Steps to Reproduce**:
+  1. Send POST to /api/users without auth
+  2. Request succeeds with 201
+- **Expected**: 401 Unauthorized
+- **Actual**: 201 Created
+- **Impact**: Unauthorized user creation
+- **Fix**: Add auth middleware
+
+### [HIGH] {Issue Title}
+- **Location**: src/services/orders.ts:123
+- **Description**: N+1 query in order list
+- **Impact**: 3s response time with 100 orders
+- **Fix**: Add eager loading for order items
+
+### [MEDIUM] {Issue Title}
+- **Details**: ...
+
+### [LOW] {Issue Title}
+- **Details**: ...
+
+## Coverage Analysis
+
+| Module | Lines | Branches | Functions |
+|--------|-------|----------|-----------|
+| api/ | 85% | 78% | 90% |
+| services/ | 92% | 85% | 95% |
+| utils/ | 100% | 100% | 100% |
+
+### Coverage Gaps
+- `src/api/admin.ts` - 0% (no tests)
+- `src/services/payment.ts:45-60` - Error handling untested
+
+## Recommendations
+
+1. **Immediate**: Add auth middleware to admin routes
+2. **High Priority**: Optimize order queries
+3. **Medium Priority**: Add tests for payment error handling
+4. **Low Priority**: Increase branch coverage in api/
+
+## Performance Results
+
+| Endpoint | p50 | p95 | p99 |
+|----------|-----|-----|-----|
+| GET /users | 45ms | 120ms | 250ms |
+| POST /orders | 150ms | 400ms | 800ms |
+
+## Sign-off
+
+- [ ] All critical issues addressed
+- [ ] Coverage meets threshold (80%)
+- [ ] Performance meets SLA
+```
+
+## Severity Definitions
+
+| Severity | Criteria |
+|----------|----------|
+| **CRITICAL** | Security vulnerability, data loss, system crash |
+| **HIGH** | Major functionality broken, severe performance |
+| **MEDIUM** | Feature partially working, workaround exists |
+| **LOW** | Minor issue, cosmetic, edge case |
+
+## Quick Reference
+
+| Section | Content |
+|---------|---------|
+| Summary | High-level metrics |
+| Findings | Issues by severity |
+| Coverage | Code coverage analysis |
+| Recommendations | Prioritized actions |
+| Sign-off | Approval criteria |

--- a/.claude/skills/test-master/references/testing-anti-patterns.md
+++ b/.claude/skills/test-master/references/testing-anti-patterns.md
@@ -1,0 +1,231 @@
+# Testing Anti-Patterns
+
+---
+
+## Core Principle
+
+> **"Test what the code does, not what the mocks do."**
+
+When tests verify mock behavior instead of actual functionality, they provide false confidence while catching zero real bugs.
+
+---
+
+## The Five Anti-Patterns
+
+### Anti-Pattern 1: Testing Mock Behavior
+
+**The Problem:** Verifying that mocks exist and were called, rather than testing actual component output.
+
+```typescript
+// ❌ BAD: Testing the mock, not the behavior
+it('should call the API', () => {
+  const mockApi = jest.fn().mockResolvedValue({ data: 'test' });
+  const service = new UserService(mockApi);
+
+  service.getUser(1);
+
+  expect(mockApi).toHaveBeenCalledWith(1); // Testing mock, not result
+});
+```
+
+```typescript
+// ✅ GOOD: Testing actual behavior
+it('should return user data from API', async () => {
+  const mockApi = jest.fn().mockResolvedValue({ id: 1, name: 'Alice' });
+  const service = new UserService(mockApi);
+
+  const user = await service.getUser(1);
+
+  expect(user.name).toBe('Alice'); // Testing actual output
+});
+```
+
+**Solution:** Test the genuine component output. If you can only verify mock calls, reconsider whether the test adds value.
+
+---
+
+### Anti-Pattern 2: Test-Only Methods in Production
+
+**The Problem:** Adding methods to production classes solely for test setup or cleanup.
+
+```typescript
+// ❌ BAD: Production code polluted with test concerns
+class UserCache {
+  private cache: Map<number, User> = new Map();
+
+  getUser(id: number): User | undefined {
+    return this.cache.get(id);
+  }
+
+  // This method exists ONLY for tests
+  _resetForTesting(): void {
+    this.cache.clear();
+  }
+}
+```
+
+```typescript
+// ✅ GOOD: Test utilities separate from production
+// production/UserCache.ts
+class UserCache {
+  private cache: Map<number, User> = new Map();
+
+  getUser(id: number): User | undefined {
+    return this.cache.get(id);
+  }
+}
+
+// test/helpers.ts
+function createFreshCache(): UserCache {
+  return new UserCache(); // Fresh instance per test
+}
+```
+
+**Solution:** Relocate cleanup logic to test utility functions. Use fresh instances per test instead of reset methods.
+
+---
+
+### Anti-Pattern 3: Mocking Without Understanding
+
+**The Problem:** Over-mocking without grasping side effects, leading to tests that pass but hide real issues.
+
+```typescript
+// ❌ BAD: Mocking everything without understanding
+it('should process order', async () => {
+  jest.mock('./inventory');
+  jest.mock('./payment');
+  jest.mock('./shipping');
+  jest.mock('./notifications');
+
+  const result = await processOrder(order);
+
+  expect(result.success).toBe(true); // What did we actually test?
+});
+```
+
+```typescript
+// ✅ GOOD: Strategic mocking with real components where possible
+it('should process order with real inventory check', async () => {
+  // Real inventory service against test database
+  const inventory = new InventoryService(testDb);
+
+  // Mock only external services
+  const payment = mockPaymentGateway();
+
+  const processor = new OrderProcessor(inventory, payment);
+  const result = await processor.process(order);
+
+  expect(result.success).toBe(true);
+  expect(await inventory.getStock(order.itemId)).toBe(originalStock - 1);
+});
+```
+
+**Solution:** Run tests with real implementations first to understand behavior. Then mock at the appropriate level - external services, not internal logic.
+
+---
+
+### Anti-Pattern 4: Incomplete Mocks
+
+**The Problem:** Partial mock responses missing downstream fields that production code expects.
+
+```typescript
+// ❌ BAD: Incomplete mock response
+const mockUserApi = jest.fn().mockResolvedValue({
+  id: 1,
+  name: 'Test User'
+  // Missing: email, createdAt, permissions, settings...
+});
+
+// Test passes, but production crashes when accessing user.email
+```
+
+```typescript
+// ✅ GOOD: Complete mock matching real API response
+const mockUserApi = jest.fn().mockResolvedValue({
+  id: 1,
+  name: 'Test User',
+  email: 'test@example.com',
+  createdAt: '2024-01-01T00:00:00Z',
+  permissions: ['read', 'write'],
+  settings: {
+    theme: 'light',
+    notifications: true
+  }
+});
+
+// Or use a factory
+const mockUserApi = jest.fn().mockResolvedValue(
+  createMockUser({ name: 'Test User' }) // Factory fills defaults
+);
+```
+
+**Solution:** Mirror complete real API response structure. Use factories to generate complete mock objects with sensible defaults.
+
+---
+
+### Anti-Pattern 5: Integration Tests as Afterthought
+
+**The Problem:** Treating testing as optional follow-up work rather than integral to development.
+
+```typescript
+// ❌ BAD: "We'll add tests later"
+// Day 1: Write 500 lines of code
+// Day 2: Write 500 more lines
+// Day 3: "We need to ship, tests can wait"
+// Day 30: Catastrophic bug in production
+// Day 31: "Why didn't we have tests?"
+```
+
+```typescript
+// ✅ GOOD: Tests are part of implementation
+// Write failing test
+it('should reject duplicate usernames', async () => {
+  await createUser({ username: 'alice' });
+
+  await expect(createUser({ username: 'alice' }))
+    .rejects.toThrow('Username already exists');
+});
+
+// Make it pass
+async function createUser(data: UserInput): Promise<User> {
+  const existing = await db.users.findByUsername(data.username);
+  if (existing) {
+    throw new Error('Username already exists');
+  }
+  return db.users.create(data);
+}
+
+// Feature AND test ship together
+```
+
+**Solution:** Follow TDD - testing is implementation, not documentation. No feature is "done" without tests.
+
+---
+
+## Detection Checklist
+
+Review your tests for these warning signs:
+
+| Warning Sign | Anti-Pattern |
+|-------------|--------------|
+| `expect(mock).toHaveBeenCalled()` without testing output | Testing mock behavior |
+| Methods starting with `_` or `ForTesting` in production | Test-only methods |
+| Every dependency is mocked | Mocking without understanding |
+| Mocks return `{ success: true }` only | Incomplete mocks |
+| Test files added weeks after feature ships | Tests as afterthought |
+
+---
+
+## Quick Reference
+
+| Anti-Pattern | Symptom | Fix |
+|-------------|---------|-----|
+| Testing mocks | Only mock assertions, no behavior tests | Assert on actual output |
+| Test-only methods | `_reset()`, `_setForTest()` in prod | Use fresh instances |
+| Over-mocking | 10+ mocks per test | Test with real deps first |
+| Incomplete mocks | Minimal stub responses | Use factories, match reality |
+| Tests as afterthought | Features ship untested | TDD from the start |
+
+---
+
+*Content adapted from [obra/superpowers](https://github.com/obra/superpowers) by Jesse Vincent (@obra), MIT License.*

--- a/.claude/skills/test-master/references/unit-testing.md
+++ b/.claude/skills/test-master/references/unit-testing.md
@@ -1,0 +1,113 @@
+# Unit Testing
+
+## Jest/Vitest Pattern
+
+```typescript
+describe('UserService', () => {
+  let service: UserService;
+  let mockRepo: jest.Mocked<UserRepository>;
+
+  beforeEach(() => {
+    mockRepo = { findById: jest.fn(), save: jest.fn() } as any;
+    service = new UserService(mockRepo);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('getUser', () => {
+    it('returns user when found', async () => {
+      const user = { id: '1', name: 'Test' };
+      mockRepo.findById.mockResolvedValue(user);
+
+      const result = await service.getUser('1');
+
+      expect(result).toEqual(user);
+      expect(mockRepo.findById).toHaveBeenCalledWith('1');
+    });
+
+    it('throws NotFoundError when user not found', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      await expect(service.getUser('1')).rejects.toThrow(NotFoundError);
+    });
+  });
+});
+```
+
+## pytest Pattern
+
+```python
+import pytest
+from unittest.mock import Mock, AsyncMock
+
+class TestUserService:
+    @pytest.fixture
+    def mock_repo(self):
+        return Mock()
+
+    @pytest.fixture
+    def service(self, mock_repo):
+        return UserService(mock_repo)
+
+    async def test_get_user_returns_user(self, service, mock_repo):
+        mock_repo.find_by_id = AsyncMock(return_value={"id": "1", "name": "Test"})
+
+        result = await service.get_user("1")
+
+        assert result == {"id": "1", "name": "Test"}
+        mock_repo.find_by_id.assert_called_once_with("1")
+
+    async def test_get_user_raises_not_found(self, service, mock_repo):
+        mock_repo.find_by_id = AsyncMock(return_value=None)
+
+        with pytest.raises(NotFoundError):
+            await service.get_user("1")
+```
+
+## Mocking Patterns
+
+```typescript
+// Mock functions
+const mockFn = jest.fn();
+mockFn.mockReturnValue('value');
+mockFn.mockResolvedValue('async value');
+mockFn.mockRejectedValue(new Error('error'));
+
+// Mock modules
+jest.mock('./database', () => ({
+  query: jest.fn(),
+}));
+
+// Spy on existing methods
+jest.spyOn(console, 'log').mockImplementation(() => {});
+```
+
+## Test Organization
+
+```typescript
+describe('Feature', () => {
+  describe('happy path', () => {
+    it('does expected behavior', () => {});
+  });
+
+  describe('edge cases', () => {
+    it('handles empty input', () => {});
+    it('handles max values', () => {});
+  });
+
+  describe('error cases', () => {
+    it('throws on invalid input', () => {});
+  });
+});
+```
+
+## Quick Reference
+
+| Pattern | Use Case |
+|---------|----------|
+| `describe()` | Group related tests |
+| `it()` / `test()` | Single test case |
+| `beforeEach()` | Setup before each test |
+| `jest.fn()` | Create mock function |
+| `mockResolvedValue()` | Mock async return |
+| `expect().toThrow()` | Assert exception |

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,5 +2,5 @@
   "config": {
     "line-length": false
   },
-  "ignores": [".venv/**"]
+  "ignores": [".venv/**", ".claude/skills/**"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+extend-exclude = [".claude"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "B", "UP"]


### PR DESCRIPTION
Closes #10

Option 2 validée sur l'issue : **vendoring sélectif** plutôt que le plugin marketplace entier.

- **`.claude/skills/`** — les 8 skills retenues, copiées depuis [jeffallan/claude-skills](https://github.com/jeffallan/claude-skills) : `fastapi-expert`, `python-pro`, `test-master`, `api-designer`, `code-reviewer`, `debugging-wizard`, `security-reviewer`, `sql-pro` (SKILL.md + références, ~516 Ko). Le catalogue de session reste minimal au lieu d'embarquer les 67 skills du plugin
- **`.claude/settings.json`** — active les 3 plugins officiels validés : `pyright-lsp`, `code-simplifier`, `superpowers` (tous `@claude-plugins-official`, aucun marketplace externe à déclarer)
- **markdownlint** — `.claude/skills/**` exclu du lint : contenu vendored aux conventions upstream, pas les nôtres

Toute session Claude sur ce repo chargera automatiquement ces skills et plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_