### PR TITLE
Add a Rails-style dev database lifecycle seeded with polyfactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ venv/
 .ruff_cache/
 .coverage
 *.db
+*.db-*
 .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - Alembic pour les migrations de schéma, exécutées automatiquement au démarrage de l'app (lifespan)
 - Dépendances gérées par uv (`uv sync`, groupe `dev` dans `pyproject.toml`, lock dans `uv.lock`)
 - pytest + httpx pour les tests, ruff pour lint et format
+- polyfactory sur les schémas Pydantic pour les factories (seed et tests) — choix aligné avec l'arrivée prévue de PydanticAI, pas de factory_boy
 - Docker + docker compose, devcontainer basé sur le service `api`
 - Deux Dockerfiles (pratiques uv officielles) : `Dockerfile` dev (uv, deps dev, reload, monté sur `/app`), `Dockerfile.prod` multistage (image finale sans uv ni pip, non-root, base dans le volume `/data`)
 
@@ -29,6 +30,8 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - `app/database.py` : engine, session, `Base`, dépendance `get_db`
 - `app/models.py` : modèles SQLAlchemy (table `stufflist`)
 - `app/schemas.py` : schémas Pydantic
+- `app/factories.py` : factories polyfactory construites sur les schémas Pydantic
+- `app/seed.py` : seed reproductible de la base de dev via les factories
 - `app/routers/` : un fichier par ressource
 - `tests/` : fixtures dans `conftest.py` (client avec SQLite in-memory)
 - `alembic/` : migrations (`env.py`, `versions/`), config dans `alembic.ini`
@@ -42,6 +45,8 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - `make openapi` : régénère `openapi.json` (obligatoire après tout changement de routes ou de schémas, la CI vérifie qu'il est à jour)
 - `make migration m="description"` : génère une migration Alembic (autogenerate), relis toujours le fichier généré
 - `make migrate` : applique les migrations sans démarrer le serveur
+- `make db-init` / `make db-seed` / `make db-reset` / `make db-drop` : cycle de vie de la base de dev (équivalents `rails db:*`)
+- La base n'est jamais versionnée dans git (`*.db` et sidecars WAL `*.db-*` ignorés) : une base de dev se reconstruit avec `make db-reset`
 
 ## Sans Docker (fallback)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down logs test lint fmt openapi migrate migration
+.PHONY: help build up down logs test lint fmt openapi migrate migration db-init db-seed db-drop db-reset
 
 .DEFAULT_GOAL := help
 
@@ -36,3 +36,14 @@ migrate: ## Apply Alembic migrations
 
 migration: ## Generate a migration (make migration m="description")
 	uv run alembic revision --autogenerate -m "$(m)"
+
+db-init: ## Create the dev database and apply migrations
+	uv run alembic upgrade head
+
+db-seed: ## Fill the dev database with factory data
+	uv run python -m app.seed
+
+db-drop: ## Delete the dev database and its WAL sidecars
+	rm -f tout_pris.db tout_pris.db-wal tout_pris.db-shm
+
+db-reset: db-drop db-init db-seed ## Drop, recreate, migrate and seed the dev database

--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ The schema is also committed as [`openapi.json`](openapi.json) and regenerated w
 ## Migrations
 
 Schema migrations are managed with [Alembic](https://alembic.sqlalchemy.org) and run automatically when the app starts. After changing a SQLAlchemy model, generate a migration with `make migration m="describe the change"` and review the generated file; `make migrate` applies migrations without starting the server.
+
+## Dev database lifecycle
+
+The database is never versioned in git — rebuild it at will, Rails style:
+
+```bash
+make db-init   # create the database and apply migrations
+make db-seed   # fill it with factory data (polyfactory on the Pydantic schemas)
+make db-reset  # drop + init + seed
+make db-drop   # delete the SQLite file and its WAL sidecars
+```
+
+Seeding is reproducible (fixed random seed) and reuses the factories from `app/factories.py`.

--- a/app/factories.py
+++ b/app/factories.py
@@ -1,0 +1,7 @@
+from polyfactory.factories.pydantic_factory import ModelFactory
+
+from app.schemas import StuffListCreate
+
+
+class StuffListCreateFactory(ModelFactory[StuffListCreate]):
+    __model__ = StuffListCreate

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,0 +1,26 @@
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.factories import StuffListCreateFactory
+from app.models import StuffList
+
+SEED_STUFFLIST_COUNT = 10
+SEED_RANDOM_SEED = 0
+
+
+def seed(db: Session, count: int = SEED_STUFFLIST_COUNT) -> list[StuffList]:
+    StuffListCreateFactory.seed_random(SEED_RANDOM_SEED)
+    stufflists = [StuffList(**StuffListCreateFactory.build().model_dump()) for _ in range(count)]
+    db.add_all(stufflists)
+    db.commit()
+    return stufflists
+
+
+def main() -> None:
+    with SessionLocal() as db:
+        created = seed(db)
+    print(f"Seeded {len(created)} stufflists")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "pytest-cov>=6.0",
     "httpx>=0.27",
     "ruff>=0.8",
+    "polyfactory>=2.18",
 ]
 
 [build-system]
@@ -29,6 +30,9 @@ include = ["app*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=app --cov-report=term-missing --cov-fail-under=100"
+
+[tool.coverage.report]
+exclude_also = ['if __name__ == "__main__":']
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,42 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app import seed as seed_module
+from app.database import Base
+from app.models import StuffList
+from app.seed import main, seed
+
+
+def in_memory_session_factory():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def test_seed_inserts_the_requested_count():
+    session_factory = in_memory_session_factory()
+    with session_factory() as db:
+        created = seed(db, count=5)
+        assert len(created) == 5
+        assert db.query(StuffList).count() == 5
+        assert all(stufflist.name for stufflist in created)
+
+
+def test_seed_is_reproducible():
+    first_factory = in_memory_session_factory()
+    second_factory = in_memory_session_factory()
+    with first_factory() as first_db, second_factory() as second_db:
+        first_names = [stufflist.name for stufflist in seed(first_db)]
+        second_names = [stufflist.name for stufflist in seed(second_db)]
+    assert first_names == second_names
+
+
+def test_main_seeds_through_the_session_factory(monkeypatch, capsys):
+    monkeypatch.setattr(seed_module, "SessionLocal", in_memory_session_factory())
+    main()
+    assert "Seeded 10 stufflists" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "40.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
@@ -441,6 +453,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polyfactory"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faker" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/68/7717bd9e63ed254617a7d3dc9260904fb736d6ea203e58ffddcb186c64e4/polyfactory-3.3.0.tar.gz", hash = "sha256:237258b6ff43edf362ffd1f68086bb796466f786adfa002b0ac256dbf2246e9a", size = 348668, upload-time = "2026-02-22T09:46:28.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl", hash = "sha256:686abcaa761930d3df87b91e95b26b8d8cb9fdbbbe0b03d5f918acff5c72606e", size = 62707, upload-time = "2026-02-22T09:46:25.985Z" },
 ]
 
 [[package]]
@@ -715,6 +740,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "polyfactory" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -732,6 +758,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "polyfactory", specifier = ">=2.18" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.8" },
@@ -756,6 +783,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #17

Selon ta décision : **polyfactory sur les schémas Pydantic** (pas factory_boy), en anticipation de PydanticAI — documenté dans le CLAUDE.md.

- **`app/factories.py`** — `StuffListCreateFactory` construite sur le schéma `StuffListCreate`
- **`app/seed.py`** — seed **reproductible** (graine aléatoire fixe) qui insère les données des factories via l'ORM ; exécutable avec `python -m app.seed`
- **Makefile** — le cycle de vie façon Rails : `make db-init` (migrations), `make db-seed`, `make db-drop` (fichier + sidecars WAL), `make db-reset` (drop + init + seed)
- **`.gitignore`** — ajout de `*.db-*` : depuis le passage en WAL, SQLite crée `tout_pris.db-wal`/`-shm` que `*.db` ne couvrait pas
- **Couverture** — `seed` et les factories sont testés (comptage, reproductibilité, entrée CLI) ; le garde `if __name__ == "__main__"` est exclu de la mesure via `[tool.coverage.report]` (pratique standard) ; gate 100 % au vert avec 13 tests

**Correction honnête vs mon commentaire d'analyse sur l'issue** : `tout_pris.db` n'a en réalité **jamais** été tracké dans git — j'avais mal lu la sortie d'une commande composée (le `ls` local, pas `git ls-files`). Il n'y avait donc rien à dé-versionner ; le vrai trou était les sidecars WAL, corrigé ici.

Validé en local : cycle db-drop/init/seed exercé de bout en bout (10 lignes reproductibles), ruff propre, markdownlint OK, 13 tests verts à 100 % de couverture. Branche vérifiée à jour de `main` avant push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_