### PR TITLE
Generate the README ER diagram from the models with paracelsus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - run: git diff --exit-code openapi.json
 
+      - run: uv run paracelsus inject README.md --check
+
       - uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           globs: '**/*.md'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - `make test` : pytest
 - `make lint` / `make fmt` : ruff check+format (vérification / correction)
 - `make openapi` : régénère `openapi.json` (obligatoire après tout changement de routes ou de schémas, la CI vérifie qu'il est à jour)
+- `make erd` : régénère le diagramme ER du README (obligatoire après tout changement de modèle, la CI vérifie qu'il est à jour)
 - `make migration m="description"` : génère une migration Alembic (autogenerate), relis toujours le fichier généré
 - `make migrate` : applique les migrations sans démarrer le serveur
 - `make db-init` / `make db-seed` / `make db-reset` / `make db-drop` : cycle de vie de la base de dev (équivalents `rails db:*`)
@@ -53,6 +54,15 @@ Backend FastAPI du projet Tout Pris. Soit extrêmement concis.
 - Si et seulement si tu ne peux pas démarrer de conteneur (déjà dans un conteneur, Docker indisponible), ignore les cibles Docker du Makefile et installe un environnement local
 - Utilise uv, c'est uv ou rien : `uv sync`, puis `uv run pytest`, `uv run ruff check .`, `uv run ruff format .`, `uv run uvicorn app.main:app --reload`
 - Dans tous les autres cas, passe par le Makefile
+
+## Documentation du schéma
+
+- Le diagramme ER du README est généré par paracelsus depuis les métadonnées SQLAlchemy : régénère-le avec `make erd` après tout changement de modèle, la CI échoue s'il dérive
+- Toute colonne doit porter son `comment=` dans `mapped_column` : c'est la source unique des descriptions, reprise telle quelle dans le diagramme
+- Une relation n'a pas de commentaire propre : documente-la sur la colonne de clé étrangère (paracelsus étiquette la flèche avec le nom de la FK)
+- Un `__table_args__ = {"comment": ...}` documente la table dans les métadonnées, mais paracelsus ne l'affiche pas dans le diagramme
+- Sur SQLite les commentaires ne sont pas persistés : `alembic check` ne les voit pas et un changement de `comment` seul ne génère donc pas de migration (ce serait le cas sur Postgres)
+- La prose qui dépasse le schéma (sémantique métier des relations) va dans le README autour du diagramme, jamais dans la zone générée entre les marqueurs
 
 ## Migrations
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up down logs test lint fmt openapi migrate migration db-init db-seed db-drop db-reset
+.PHONY: help build up down logs test lint fmt erd openapi migrate migration db-init db-seed db-drop db-reset
 
 .DEFAULT_GOAL := help
 
@@ -27,6 +27,9 @@ lint: ## Check lint and formatting
 fmt: ## Fix lint and format the code
 	uv run ruff check --fix .
 	uv run ruff format .
+
+erd: ## Regenerate the ER diagram in the README
+	uv run paracelsus inject README.md
 
 openapi: ## Regenerate openapi.json
 	uv run python -c "import json; from app.main import app; print(json.dumps(app.openapi(), indent=2))" > openapi.json

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ The schema is also committed as [`openapi.json`](openapi.json) and regenerated w
 
 Schema migrations are managed with [Alembic](https://alembic.sqlalchemy.org) and run automatically when the app starts. After changing a SQLAlchemy model, generate a migration with `make migration m="describe the change"` and review the generated file; `make migrate` applies migrations without starting the server.
 
+## Database schema
+
+Generated from the SQLAlchemy models with [paracelsus](https://github.com/tedivm/paracelsus); regenerate with `make erd` after any model change (CI fails if it drifts). Column descriptions come from the `comment=` metadata on the models.
+
+<!-- BEGIN_SQLALCHEMY_DOCS -->
+```mermaid
+erDiagram
+  stufflist {
+    INTEGER id PK "Surrogate primary key"
+    VARCHAR name "Display name given by the user,indexed"
+  }
+
+
+```
+<!-- END_SQLALCHEMY_DOCS -->
+
 ## Dev database lifecycle
 
 The database is never versioned in git — rebuild it at will, Rails style:

--- a/app/models.py
+++ b/app/models.py
@@ -5,6 +5,7 @@ from app.database import Base
 
 class StuffList(Base):
     __tablename__ = "stufflist"
+    __table_args__ = {"comment": "A list of stuff the user wants to keep track of"}
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    name: Mapped[str] = mapped_column(index=True)
+    id: Mapped[int] = mapped_column(primary_key=True, comment="Surrogate primary key")
+    name: Mapped[str] = mapped_column(index=True, comment="Display name given by the user")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "httpx>=0.27",
     "ruff>=0.8",
     "polyfactory>=2.18",
+    "paracelsus>=0.10",
 ]
 
 [build-system]
@@ -33,6 +34,10 @@ addopts = "--cov=app --cov-report=term-missing --cov-fail-under=100"
 
 [tool.coverage.report]
 exclude_also = ['if __name__ == "__main__":']
+
+[tool.paracelsus]
+base = "app.database:Base"
+imports = ["app.models"]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -438,12 +450,36 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "paracelsus"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pydot" },
+    { name = "sqlalchemy" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/cc/d545a19967c3bdeba92ca1d8a736576b96b4610154f3bd6dbf01a198e2c3/paracelsus-0.15.0.tar.gz", hash = "sha256:b850b56417eef7b5e301b09ba7d44655f3c76de8681699b93ef6ae410afeb278", size = 92053, upload-time = "2026-01-04T21:38:25.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/70/3fa8dad530ae181b0a30f9874bababaa3d3781f9ef6c87aeaeed79b3c954/paracelsus-0.15.0-py3-none-any.whl", hash = "sha256:0ed0f97fb5ec09e379e45c1a95e280b1c40ee42af3c77f59f03998477a73fde2", size = 19606, upload-time = "2026-01-04T21:38:24.284Z" },
 ]
 
 [[package]]
@@ -559,12 +595,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -653,6 +710,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
@@ -675,6 +745,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
     { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
     { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -740,6 +819,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "paracelsus" },
     { name = "polyfactory" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -758,10 +838,26 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27" },
+    { name = "paracelsus", specifier = ">=0.10" },
     { name = "polyfactory", specifier = ">=2.18" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "typer"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #20

Diagramme ER Mermaid généré depuis les métadonnées SQLAlchemy et injecté dans le README entre marqueurs, maintenu synchrone exactement comme `openapi.json`.

- **`paracelsus`** en dep dev, configuré dans `pyproject.toml` (`[tool.paracelsus]` base + imports) — les commandes n'ont donc aucun argument à répéter
- **`make erd`** régénère le diagramme en place
- **CI** : `paracelsus inject README.md --check`, qui sort en erreur si le diagramme committé dérive des modèles. Vérifié **dans les deux sens** en local (exit 1 sur dérive introduite volontairement, exit 0 une fois restauré) — un gate qui ne détecte rien serait pire qu'inutile
- **Commentaires** : `comment=` sur les colonnes de `stufflist` (rendus comme descriptions dans le diagramme) + commentaire de table dans `__table_args__`

Rendu actuel :

```mermaid
erDiagram
  stufflist {
    INTEGER id PK "Surrogate primary key"
    VARCHAR name "Display name given by the user,indexed"
  }
```

**Méthodologie documentée dans le CLAUDE.md** (nouvelle section « Documentation du schéma ») : `comment=` comme source unique des descriptions, relations documentées sur leur colonne FK, régénération obligatoire après changement de modèle.

**Deux limites constatées et documentées honnêtement**, dont une qui corrige ce que j'avais affirmé plus tôt dans notre discussion :

1. le commentaire de table est bien stocké dans les métadonnées mais **paracelsus ne l'affiche pas** dans le diagramme
2. sur **SQLite**, les commentaires ne sont pas persistés par le dialecte : `alembic check` ne les voit pas, donc un changement de `comment` seul ne génère **pas** de migration ici (contrairement à ce que j'avais annoncé — ce serait vrai sur Postgres)

Validé : ruff, markdownlint, YAML, 13 tests verts à 100 % de couverture, `openapi.json` inchangé. Branche vérifiée à jour de `main` avant push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_