### PR TITLE
Publish the dev image tag on every merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   release-docker:
     name: Build & Push Docker image
     needs: [lint-and-test, build-image]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-back
@@ -77,7 +77,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Compute image tags
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -86,7 +86,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=dev,enable={{is_default_branch}}
 
       - uses: docker/build-push-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ A devcontainer is provided (`.devcontainer/`) based on the compose `api` service
 
 ## Production image
 
-The production image is built from `Dockerfile.prod` (multi-stage, [uv recommended practices](https://github.com/astral-sh/uv-docker-example)): uv builds the venv from `uv.lock` in a builder stage, and the final image contains neither uv nor pip and runs as a non-root user. This is the image published to Docker Hub on tags.
+The production image is built from `Dockerfile.prod` (multi-stage, [uv recommended practices](https://github.com/astral-sh/uv-docker-example)): uv builds the venv from `uv.lock` in a builder stage, and the final image contains neither uv nor pip and runs as a non-root user.
+
+CI publishes it to Docker Hub: every merge on `main` pushes the `dev` tag, and every git tag pushes the matching semver tags plus `latest`.
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
Closes #26

Le job de publication ne tournait que sur les tags git — rien n'était donc publié entre deux releases. Il tourne maintenant aussi sur les push `main` et publie le tag `dev`.

- **Condition du job** : `push` sur `refs/heads/main` **ou** sur un tag. Le `github.event_name == 'push'` évite qu'un `workflow_dispatch` manuel publie par accident
- **Tags calculés** par `docker/metadata-action` : `latest` conditionné aux tags git, `dev` conditionné à `is_default_branch` — les deux ne peuvent pas se marcher dessus
- Le `needs: [lint-and-test, build-image]` est conservé : un `main` rouge ne publie rien

| Événement | Tags poussés |
| --- | --- |
| merge sur `main` | `dev` |
| tag `v1.2.3` | `1.2.3`, `1.2`, `1`, `latest` |

**Ce que la CI de cette PR ne prouvera pas** : le job `release-docker` ne s'exécute que sur `push`, donc il restera `skipped` ici — la première vraie publication aura lieu **au merge**. J'ai validé ce qui pouvait l'être hors CI : workflow passé à **actionlint** (expressions `if:` et `${{ }}` incluses, zéro erreur), YAML et markdownlint propres, ruff et 13 tests verts.

**Prérequis** : les secrets `DOCKERHUB_USERNAME` et `DOCKERHUB_ACCESS_TOKEN` doivent être configurés sur le repo — sinon le job échouera au premier merge (l'étape de login). À vérifier avant de merger si ce n'est pas déjà fait.

Note : l'issue dit « master », la branche par défaut du repo est `main` — c'est elle que j'ai câblée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_