### PR TITLE
Publish the image for linux/arm64 alongside linux/amd64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Build dev image
@@ -56,6 +58,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.prod
+          platforms: linux/amd64,linux/arm64
           push: false
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
@@ -69,6 +72,8 @@ jobs:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-back
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -93,6 +98,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.prod
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A devcontainer is provided (`.devcontainer/`) based on the compose `api` service
 
 The production image is built from `Dockerfile.prod` (multi-stage, [uv recommended practices](https://github.com/astral-sh/uv-docker-example)): uv builds the venv from `uv.lock` in a builder stage, and the final image contains neither uv nor pip and runs as a non-root user.
 
-CI publishes it to Docker Hub: every merge on `main` pushes the `dev` tag, and every git tag pushes the matching semver tags plus `latest`.
+CI publishes it to Docker Hub for `linux/amd64` and `linux/arm64` (Raspberry Pi and other ARMv8 boards): every merge on `main` pushes the `dev` tag, and every git tag pushes the matching semver tags plus `latest`.
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
Closes #28

**Diagnostic confirmé** en interrogeant le registre : le manifeste du tag `dev` ne contient que `linux/amd64` (l'autre entrée est l'attestation de provenance buildx, pas une plateforme) — d'où le `no matching manifest for linux/arm64/v8` sur Raspberry Pi.

- **QEMU** (`docker/setup-qemu-action`) + `platforms: linux/amd64,linux/arm64` sur le build de production : les tags poussés deviennent de vraies manifest lists multi-arch
- **Le job `build-image` build aussi les deux plateformes** : un build arm64 cassé fait échouer la PR au lieu d'apparaître au moment de publier — la leçon de #27, où la publication n'était vérifiable qu'après merge
- **L'image dev reste mono-plateforme** : elle ne tourne que sur la machine du dev, la builder en arm64 serait du temps CI gratuit

**Vérifications faites avant de pousser** (pas de daemon Docker ici, donc pas de build local possible — j'ai validé ce qui l'était) :

- les deux images de base fournissent bien arm64 : `ghcr.io/astral-sh/uv:python3.12-trixie-slim` (amd64, arm64) et `python:3.12-slim-trixie` (dont arm64/v8)
- **les 47 dépendances du lock sont sûres pour aarch64** : 39 wheels universels + 8 wheels natifs qui publient tous une variante aarch64 (`pydantic-core`, `uvloop`, `httptools`, `greenlet`, `pyyaml`, `markupsafe`, `watchfiles`, `ruff`). **Zéro** paquet devant compiler depuis les sources sous émulation — c'était le vrai risque de lenteur/échec
- workflow passé à actionlint (0 erreur), YAML et markdownlint propres, ruff et 13 tests verts

**Effet de bord attendu** : le job `build-image` sera plus lent (le build arm64 passe par l'émulation). Pas de compilation native à faire, donc ça devrait rester de l'ordre de la minute supplémentaire — la CI de cette PR le mesurera concrètement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYZtUkSx2aRoAqH3G3EFWb)_