### PR TITLE
Authenticate accounts with an email, a password and rotating JWT sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 .DEFAULT_GOAL := help
 
+export SECRET_KEY ?= change-me-this-development-key-is-not-secret
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |  awk 'BEGIN {FS = ":.*?## "} {printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}'
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,21 @@ The production settings live in `docker-compose.prod.yml`: the database is store
 ## API
 
 - `GET /health`
+- `POST /auth/register` — create an account (`{"email": "...", "password": "..."}`)
+- `POST /auth/login` — exchange credentials for an access and a refresh token
+- `POST /auth/refresh` — rotate a refresh token
+- `POST /auth/logout` — revoke a refresh token
+- `GET /auth/me` — read the authenticated account (bearer required)
 - `POST /stufflists` — create a stufflist (`{"name": "..."}`)
 - `GET /stufflists` — list stufflists
 - `GET /stufflists/{id}` — get one
 - `DELETE /stufflists/{id}` — delete one
 
 Data is stored in SQLite (`tout_pris.db` by default, override with `DATABASE_URL`).
+
+The HTTP conventions (status codes, household scoping, pagination) and the rationale behind the authentication stack are documented in [`docs/api/`](docs/api/README.md).
+
+Authentication settings are read from the environment: `SECRET_KEY` (**required**, no default), `ACCESS_TOKEN_TTL_MINUTES` (15) and `REFRESH_TOKEN_TTL_DAYS` (30).
 
 ## Transactional emails
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,29 @@ erDiagram
     VARCHAR name "Display name given by the members"
   }
 
+  identities {
+    INTEGER id PK "Surrogate primary key"
+    INTEGER user_id FK "Account the identity signs in as,indexed"
+    DATETIME created_at "Link timestamp"
+    ENUM provider "Authentication provider vouching for the identity"
+    VARCHAR provider_uid "Email address for the password provider, provider account id otherwise"
+    VARCHAR secret "Argon2 hash of the password for the password provider, NULL otherwise,nullable"
+  }
+
   persons {
     INTEGER id PK "Surrogate primary key"
     INTEGER household_id FK "Household the person belongs to,indexed"
     INTEGER user_id FK "Account of the person when they have one,nullable,indexed"
     VARCHAR name "Display name shown in every 'who is it for' picker"
+  }
+
+  refresh_tokens {
+    INTEGER id PK "Surrogate primary key"
+    INTEGER user_id FK "Account whose session the token extends,indexed"
+    DATETIME created_at "Issue timestamp"
+    DATETIME expires_at "Moment past which the token is refused"
+    DATETIME revoked_at "Moment the token was rotated or logged out, NULL while it is usable,nullable"
+    VARCHAR token_hash UK "SHA-256 hex digest of the token, the token itself is never stored,indexed"
   }
 
   stufflist {
@@ -104,8 +122,10 @@ erDiagram
 
   households ||--o{ household_members : household_id
   users ||--o{ household_members : user_id
+  users ||--o{ identities : user_id
   households ||--o{ persons : household_id
   users ||--o{ persons : user_id
+  users ||--o{ refresh_tokens : user_id
 
 ```
 <!-- END_SQLALCHEMY_DOCS -->

--- a/alembic/versions/0003_create_identities_and_refresh_tokens.py
+++ b/alembic/versions/0003_create_identities_and_refresh_tokens.py
@@ -1,0 +1,60 @@
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "identities",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "provider",
+            sa.Enum("password", "google", "facebook", "github", name="identity_provider"),
+            nullable=False,
+        ),
+        sa.Column("provider_uid", sa.String(), nullable=False),
+        sa.Column("secret", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("provider", "provider_uid", name="uq_identities_provider_uid"),
+    )
+    op.create_index(op.f("ix_identities_user_id"), "identities", ["user_id"], unique=False)
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_refresh_tokens_token_hash"), "refresh_tokens", ["token_hash"], unique=True
+    )
+    op.create_index(op.f("ix_refresh_tokens_user_id"), "refresh_tokens", ["user_id"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_refresh_tokens_user_id"), table_name="refresh_tokens")
+    op.drop_index(op.f("ix_refresh_tokens_token_hash"), table_name="refresh_tokens")
+    op.drop_table("refresh_tokens")
+    op.drop_index(op.f("ix_identities_user_id"), table_name="identities")
+    op.drop_table("identities")

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,0 +1,49 @@
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.auth.tokens import read_access_token_subject
+from app.database import get_db
+from app.models import Household, HouseholdMember, User
+
+bearer_scheme = HTTPBearer(auto_error=False, description="Access token returned by /auth/login")
+
+DbSession = Annotated[Session, Depends(get_db)]
+BearerCredentials = Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_scheme)]
+
+
+def get_current_user(db: DbSession, credentials: BearerCredentials) -> User:
+    unauthenticated = HTTPException(
+        status_code=401,
+        detail="Invalid credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    if credentials is None:
+        raise unauthenticated
+    user_id = read_access_token_subject(credentials.credentials)
+    if user_id is None:
+        raise unauthenticated
+    user = db.get(User, user_id)
+    if user is None:
+        raise unauthenticated
+    return user
+
+
+CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+def get_current_household(household_id: int, db: DbSession, user: CurrentUser) -> Household:
+    household = db.scalar(
+        select(Household)
+        .join(HouseholdMember, HouseholdMember.household_id == Household.id)
+        .where(Household.id == household_id, HouseholdMember.user_id == user.id)
+    )
+    if household is None:
+        raise HTTPException(status_code=404, detail="Household not found")
+    return household
+
+
+CurrentHousehold = Annotated[Household, Depends(get_current_household)]

--- a/app/auth/passwords.py
+++ b/app/auth/passwords.py
@@ -3,7 +3,7 @@ import secrets
 from pwdlib import PasswordHash
 from pwdlib.hashers.argon2 import Argon2Hasher
 
-password_hash = PasswordHash((Argon2Hasher(),))
+password_hash = PasswordHash((Argon2Hasher(memory_cost=19456, time_cost=2, parallelism=1),))
 
 
 def hash_password(password: str) -> str:

--- a/app/auth/passwords.py
+++ b/app/auth/passwords.py
@@ -1,0 +1,21 @@
+import secrets
+
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
+
+password_hash = PasswordHash((Argon2Hasher(),))
+
+
+def hash_password(password: str) -> str:
+    return password_hash.hash(password)
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    return password_hash.verify(password, hashed_password)
+
+
+UNMATCHABLE_HASH = hash_password(secrets.token_urlsafe(32))
+
+
+def equalize_verification_time(password: str) -> None:
+    verify_password(password, UNMATCHABLE_HASH)

--- a/app/auth/tokens.py
+++ b/app/auth/tokens.py
@@ -1,0 +1,66 @@
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import RefreshToken, User
+
+ACCESS_TOKEN_ALGORITHM = "HS256"
+REFRESH_TOKEN_BYTES = 32
+
+
+def as_utc(moment: datetime) -> datetime:
+    return moment if moment.tzinfo is not None else moment.replace(tzinfo=UTC)
+
+
+def create_access_token(user_id: int) -> str:
+    issued_at = datetime.now(UTC)
+    payload = {
+        "sub": str(user_id),
+        "iat": issued_at,
+        "exp": issued_at + timedelta(minutes=settings.access_token_ttl_minutes),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm=ACCESS_TOKEN_ALGORITHM)
+
+
+def read_access_token_subject(token: str) -> int | None:
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[ACCESS_TOKEN_ALGORITHM])
+        return int(payload["sub"])
+    except (jwt.InvalidTokenError, KeyError, TypeError, ValueError):
+        return None
+
+
+def hash_refresh_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def create_refresh_token(db: Session, user: User) -> str:
+    token = secrets.token_urlsafe(REFRESH_TOKEN_BYTES)
+    db.add(
+        RefreshToken(
+            user_id=user.id,
+            token_hash=hash_refresh_token(token),
+            expires_at=datetime.now(UTC) + timedelta(days=settings.refresh_token_ttl_days),
+        )
+    )
+    return token
+
+
+def find_usable_refresh_token(db: Session, token: str) -> RefreshToken | None:
+    stored = db.scalar(
+        select(RefreshToken).where(RefreshToken.token_hash == hash_refresh_token(token))
+    )
+    if stored is None or stored.revoked_at is not None:
+        return None
+    if as_utc(stored.expires_at) <= datetime.now(UTC):
+        return None
+    return stored
+
+
+def revoke_refresh_token(stored: RefreshToken) -> None:
+    stored.revoked_at = datetime.now(UTC)

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,9 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    secret_key: str = "change-me-in-production"
+    access_token_ttl_minutes: int = 15
+    refresh_token_ttl_days: int = 30
     brevo_api_key: str = ""
     mail_from_email: str = "no-reply@tout-pris.app"
     mail_from_name: str = "Tout Pris"

--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    secret_key: str = "change-me-in-production"
+    secret_key: str = "development-secret-key-not-for-production-use"
     access_token_ttl_minutes: int = 15
     refresh_token_ttl_days: int = 30
     brevo_api_key: str = ""

--- a/app/config.py
+++ b/app/config.py
@@ -1,8 +1,9 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    secret_key: str
+    secret_key: str = Field(min_length=1)
     access_token_ttl_minutes: int = 15
     refresh_token_ttl_days: int = 30
     brevo_api_key: str = ""

--- a/app/config.py
+++ b/app/config.py
@@ -2,7 +2,7 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    secret_key: str = "development-secret-key-not-for-production-use"
+    secret_key: str
     access_token_ttl_minutes: int = 15
     refresh_token_ttl_days: int = 30
     brevo_api_key: str = ""

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from alembic import command
 from alembic.config import Config
 from fastapi import FastAPI
 
-from app.routers import stufflists
+from app.routers import auth, stufflists
 
 
 @asynccontextmanager
@@ -20,6 +20,7 @@ app = FastAPI(
     version=version("tout-pris-back"),
     lifespan=lifespan,
 )
+app.include_router(auth.router)
 app.include_router(stufflists.router)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,11 +1,15 @@
 from app.models.household import Household, HouseholdMember, HouseholdRole, Person, User
+from app.models.identity import Identity, IdentityProvider, RefreshToken
 from app.models.stufflist import StuffList
 
 __all__ = [
     "Household",
     "HouseholdMember",
     "HouseholdRole",
+    "Identity",
+    "IdentityProvider",
     "Person",
+    "RefreshToken",
     "StuffList",
     "User",
 ]

--- a/app/models/household.py
+++ b/app/models/household.py
@@ -1,10 +1,14 @@
 import enum
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime, Enum, ForeignKey, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.identity import Identity, RefreshToken
 
 
 class HouseholdRole(enum.StrEnum):
@@ -25,6 +29,12 @@ class User(Base):
     )
 
     memberships: Mapped[list["HouseholdMember"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    identities: Mapped[list["Identity"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    refresh_tokens: Mapped[list["RefreshToken"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )
 

--- a/app/models/identity.py
+++ b/app/models/identity.py
@@ -1,0 +1,74 @@
+import enum
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+from app.models.household import User
+
+
+class IdentityProvider(enum.StrEnum):
+    password = "password"
+    google = "google"
+    facebook = "facebook"
+    github = "github"
+
+
+class Identity(Base):
+    __tablename__ = "identities"
+    __table_args__ = (
+        UniqueConstraint("provider", "provider_uid", name="uq_identities_provider_uid"),
+        {"comment": "A way of signing in as an account, one row per provider"},
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, comment="Surrogate primary key")
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        comment="Account the identity signs in as",
+    )
+    provider: Mapped[IdentityProvider] = mapped_column(
+        Enum(IdentityProvider, name="identity_provider"),
+        comment="Authentication provider vouching for the identity",
+    )
+    provider_uid: Mapped[str] = mapped_column(
+        comment="Email address for the password provider, provider account id otherwise"
+    )
+    secret: Mapped[str | None] = mapped_column(
+        comment="Argon2 hash of the password for the password provider, NULL otherwise"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), comment="Link timestamp"
+    )
+
+    user: Mapped[User] = relationship(back_populates="identities")
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+    __table_args__ = {"comment": "A revocable opaque token exchangeable for a fresh access token"}
+
+    id: Mapped[int] = mapped_column(primary_key=True, comment="Surrogate primary key")
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        comment="Account whose session the token extends",
+    )
+    token_hash: Mapped[str] = mapped_column(
+        unique=True,
+        index=True,
+        comment="SHA-256 hex digest of the token, the token itself is never stored",
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), comment="Moment past which the token is refused"
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        comment="Moment the token was rotated or logged out, NULL while it is usable",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), comment="Issue timestamp"
+    )
+
+    user: Mapped[User] = relationship(back_populates="refresh_tokens")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.auth.dependencies import CurrentUser, DbSession
@@ -42,9 +43,6 @@ def find_password_identity(db: Session, email: str) -> Identity | None:
     summary="Create an account from an email and a password",
 )
 def register(payload: UserCreate, db: DbSession) -> TokenPair:
-    if find_password_identity(db, payload.email) is not None:
-        raise HTTPException(status_code=409, detail="Email already registered")
-
     user = User(email=payload.email)
     user.identities.append(
         Identity(
@@ -54,7 +52,11 @@ def register(payload: UserCreate, db: DbSession) -> TokenPair:
         )
     )
     db.add(user)
-    db.flush()
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Email already registered") from None
     tokens = issue_token_pair(db, user)
     db.commit()
     return tokens

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -11,6 +11,7 @@ from app.auth.tokens import (
     find_usable_refresh_token,
     revoke_refresh_token,
 )
+from app.config import settings
 from app.models import Identity, IdentityProvider, User
 from app.schemas import RefreshTokenRequest, TokenPair, UserCreate, UserLogin, UserRead
 
@@ -24,6 +25,7 @@ def issue_token_pair(db: Session, user: User) -> TokenPair:
     return TokenPair(
         access_token=create_access_token(user.id),
         refresh_token=create_refresh_token(db, user),
+        expires_in=settings.access_token_ttl_minutes * 60,
     )
 
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.auth.dependencies import CurrentUser, DbSession
+from app.auth.passwords import equalize_verification_time, hash_password, verify_password
+from app.auth.tokens import (
+    create_access_token,
+    create_refresh_token,
+    find_usable_refresh_token,
+    revoke_refresh_token,
+)
+from app.models import Identity, IdentityProvider, User
+from app.schemas import RefreshTokenRequest, TokenPair, UserCreate, UserLogin, UserRead
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+INVALID_CREDENTIALS = "Invalid credentials"
+INVALID_REFRESH_TOKEN = "Invalid refresh token"
+
+
+def issue_token_pair(db: Session, user: User) -> TokenPair:
+    return TokenPair(
+        access_token=create_access_token(user.id),
+        refresh_token=create_refresh_token(db, user),
+    )
+
+
+def find_password_identity(db: Session, email: str) -> Identity | None:
+    return db.scalar(
+        select(Identity).where(
+            Identity.provider == IdentityProvider.password,
+            Identity.provider_uid == email,
+        )
+    )
+
+
+@router.post(
+    "/register",
+    response_model=TokenPair,
+    status_code=201,
+    summary="Create an account from an email and a password",
+)
+def register(payload: UserCreate, db: DbSession) -> TokenPair:
+    if find_password_identity(db, payload.email) is not None:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
+    user = User(email=payload.email)
+    user.identities.append(
+        Identity(
+            provider=IdentityProvider.password,
+            provider_uid=payload.email,
+            secret=hash_password(payload.password),
+        )
+    )
+    db.add(user)
+    db.flush()
+    tokens = issue_token_pair(db, user)
+    db.commit()
+    return tokens
+
+
+@router.post("/login", response_model=TokenPair, summary="Exchange credentials for a token pair")
+def login(payload: UserLogin, db: DbSession) -> TokenPair:
+    identity = find_password_identity(db, payload.email)
+    if identity is None or identity.secret is None:
+        equalize_verification_time(payload.password)
+        raise HTTPException(status_code=401, detail=INVALID_CREDENTIALS)
+    if not verify_password(payload.password, identity.secret):
+        raise HTTPException(status_code=401, detail=INVALID_CREDENTIALS)
+
+    tokens = issue_token_pair(db, identity.user)
+    db.commit()
+    return tokens
+
+
+@router.post("/refresh", response_model=TokenPair, summary="Rotate a refresh token")
+def refresh(payload: RefreshTokenRequest, db: DbSession) -> TokenPair:
+    stored = find_usable_refresh_token(db, payload.refresh_token)
+    if stored is None:
+        raise HTTPException(status_code=401, detail=INVALID_REFRESH_TOKEN)
+
+    revoke_refresh_token(stored)
+    tokens = issue_token_pair(db, stored.user)
+    db.commit()
+    return tokens
+
+
+@router.post("/logout", status_code=204, summary="Revoke a refresh token")
+def logout(payload: RefreshTokenRequest, db: DbSession) -> None:
+    stored = find_usable_refresh_token(db, payload.refresh_token)
+    if stored is not None:
+        revoke_refresh_token(stored)
+        db.commit()
+
+
+@router.get("/me", response_model=UserRead, summary="Get the authenticated account")
+def read_me(user: CurrentUser) -> User:
+    return user

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,10 +1,12 @@
 from datetime import datetime
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, StringConstraints
 
 PASSWORD_MIN_LENGTH = 8
 PASSWORD_MAX_LENGTH = 128
+
+NormalizedEmail = Annotated[EmailStr, StringConstraints(to_lower=True)]
 
 
 class StuffListCreate(BaseModel):
@@ -19,12 +21,12 @@ class StuffListRead(BaseModel):
 
 
 class UserCreate(BaseModel):
-    email: EmailStr
+    email: NormalizedEmail
     password: str = Field(min_length=PASSWORD_MIN_LENGTH, max_length=PASSWORD_MAX_LENGTH)
 
 
 class UserLogin(BaseModel):
-    email: EmailStr
+    email: NormalizedEmail
     password: str = Field(max_length=PASSWORD_MAX_LENGTH)
 
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -46,3 +46,4 @@ class TokenPair(BaseModel):
     access_token: str
     refresh_token: str
     token_type: Literal["bearer"] = "bearer"
+    expires_in: int

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,10 @@
-from pydantic import BaseModel, ConfigDict
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+PASSWORD_MIN_LENGTH = 8
+PASSWORD_MAX_LENGTH = 128
 
 
 class StuffListCreate(BaseModel):
@@ -10,3 +16,31 @@ class StuffListRead(BaseModel):
 
     id: int
     name: str
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=PASSWORD_MIN_LENGTH, max_length=PASSWORD_MAX_LENGTH)
+
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str = Field(max_length=PASSWORD_MAX_LENGTH)
+
+
+class UserRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    email: EmailStr
+    created_at: datetime
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenPair(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: Literal["bearer"] = "bearer"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: sqlite:////data/tout_pris.db
-      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required in production}
+      SECRET_KEY: ${SECRET_KEY:-change-me-this-production-key-is-not-secret}
       ACCESS_TOKEN_TTL_MINUTES: ${ACCESS_TOKEN_TTL_MINUTES:-15}
       REFRESH_TOKEN_TTL_DAYS: ${REFRESH_TOKEN_TTL_DAYS:-30}
       BREVO_API_KEY: ${BREVO_API_KEY:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,9 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: sqlite:////data/tout_pris.db
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required in production}
+      ACCESS_TOKEN_TTL_MINUTES: ${ACCESS_TOKEN_TTL_MINUTES:-15}
+      REFRESH_TOKEN_TTL_DAYS: ${REFRESH_TOKEN_TTL_DAYS:-30}
       BREVO_API_KEY: ${BREVO_API_KEY:-}
       MAIL_FROM_EMAIL: ${MAIL_FROM_EMAIL:-no-reply@tout-pris.app}
       MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Tout Pris}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - /app/.venv
     environment:
       DATABASE_URL: sqlite:///./tout_pris.db
+      SECRET_KEY: ${SECRET_KEY:-change-me-this-development-key-is-not-secret}
       BREVO_API_KEY: ${BREVO_API_KEY:-}
       MAIL_FROM_EMAIL: ${MAIL_FROM_EMAIL:-no-reply@tout-pris.app}
       MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Tout Pris}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -50,6 +50,10 @@ Le SHA-256 suffit ici, là où le mot de passe exige argon2 : un jeton de 256 bi
 
 La limitation de débit sur `/auth/login`, la détection de réutilisation d'un jeton de rafraîchissement déjà tourné (révocation de toute la famille), la vérification d'email et la réinitialisation de mot de passe ne sont pas implémentées. Elles viendront dans leurs propres lots.
 
+`/auth/refresh` ne verrouille pas la ligne qu'il fait tourner : deux appels simultanés portant le même jeton peuvent réussir tous les deux et repartir avec deux paires valides. C'est le même trou que la détection de réutilisation doit couvrir, et il se ferme au même endroit — un `SELECT ... FOR UPDATE` ou une révocation conditionnelle rendant la rotation atomique.
+
+`refresh_tokens` ne se purge jamais : chaque connexion et chaque rotation ajoute une ligne, révoquée mais conservée. De l'ordre de quelques dizaines de milliers de lignes par an et par compte actif, ce que l'index sur `token_hash` absorbe sans peine. C'est de l'hygiène à traiter un jour, pas un problème de tenue en charge.
+
 `SECRET_KEY` n'a **aucune valeur par défaut dans l'application** : `Settings()` lève `Field required` au démarrage si la variable d'environnement est absente. Une clé de signature publiée dans le dépôt serait exploitable par quiconque lit le code, quel que soit le mode de déploiement. Les deux fichiers compose et le `Makefile` fournissent un placeholder `change-me-...` pour le développement et les tests ; en production la variable doit porter au moins 32 octets aléatoires, longueur en dessous de laquelle PyJWT émet un avertissement.
 
 ## Pourquoi pas fastapi-users

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,82 @@
+# Conventions de l'API
+
+## Codes HTTP
+
+| Code | Quand |
+| --- | --- |
+| `200` | Lecture ou action réussie qui renvoie un corps |
+| `201` | Création d'une ressource |
+| `204` | Action réussie sans corps (suppression, révocation) |
+| `401` | Requête non authentifiée : bearer absent, illisible, expiré, ou compte disparu |
+| `404` | Ressource inexistante **ou** appartenant à un autre foyer |
+| `409` | Conflit avec une ressource existante (email déjà inscrit) |
+| `422` | Corps invalide au sens des schémas Pydantic |
+
+Le `403` n'est jamais renvoyé. Une ressource qui existe mais que l'appelant n'a pas le droit de voir répond `404`, exactement comme si elle n'existait pas : distinguer les deux cas révélerait l'existence de foyers, de personnes ou de voyages à un tiers. La dépendance `get_current_household` implémente cette règle par une seule requête qui joint `household_members` sur l'utilisateur courant — une ligne absente et un foyer inexistant produisent la même réponse.
+
+Les routes du domaine sont donc portées par le chemin du foyer : `/households/{household_id}/persons`, `/households/{household_id}/trips`, etc. Le cloisonnement est appliqué par la dépendance, pas par chaque route.
+
+## Corps et schémas
+
+Toutes les entrées et sorties sont en JSON, y compris l'authentification : le client est une application mobile, pas un navigateur, et n'a aucune raison de passer par le formulaire `application/x-www-form-urlencoded` d'OAuth2.
+
+Un schéma Pydantic par opération : `XCreate`, `XUpdate`, `XRead`. Jamais un schéma fourre-tout partagé entre l'entrée et la sortie — c'est ce qui laisse fuiter un jour un hash de mot de passe dans une réponse, ou accepter un `id` fourni par le client.
+
+## Collections
+
+Les collections sont renvoyées comme des tableaux JSON nus, sans enveloppe ni pagination. C'est volontairement provisoire : aucune collection actuelle ne peut croître sans borne (les personnes d'un foyer, ses voyages). La pagination sera ajoutée quand une collection le justifiera — vraisemblablement les objets d'une liste — et pas avant, pour ne pas imposer dès maintenant une enveloppe à tous les appelants.
+
+## Authentification
+
+L'accès est un jeton porteur : `Authorization: Bearer <access_token>`.
+
+- `POST /auth/register` — `{email, password}` puis `201` avec une paire de jetons. Crée un `User` et son `Identity` de fournisseur `password`. Ne crée aucun foyer.
+- `POST /auth/login` — `{email, password}` puis `200` avec une paire de jetons.
+- `POST /auth/refresh` — `{refresh_token}` puis `200` avec une nouvelle paire. Le jeton présenté est révoqué au passage.
+- `POST /auth/logout` — `{refresh_token}` puis `204`. Révoque la ligne, et répond `204` même si elle était déjà révoquée ou inconnue.
+- `GET /auth/me` — `200` avec le compte authentifié.
+
+Un échec de connexion renvoie toujours `Invalid credentials`, que l'email soit inconnu ou le mot de passe faux, et le temps de réponse est égalisé en vérifiant le mot de passe fourni contre un hash impossible à satisfaire quand aucune identité ne correspond. Sans cela, la durée de la réponse suffirait à énumérer les comptes.
+
+### Deux jetons, deux natures
+
+L'`access_token` est un JWT HS256 court (15 minutes par défaut) portant `sub`, `iat` et `exp`. Il n'est pas révocable : sa durée de vie est sa seule limite, et c'est assumé.
+
+Le `refresh_token` est au contraire opaque — 32 octets aléatoires — et n'existe en base que sous forme de condensat SHA-256. Il est donc révocable, ce qui est toute la raison de ne pas en faire un JWT : une déconnexion doit réellement fermer la session. Il est aussi tourné à chaque rafraîchissement, l'ancien étant révoqué au moment où le nouveau est émis, ce qui borne la fenêtre d'exploitation d'un jeton volé.
+
+Le SHA-256 suffit ici, là où le mot de passe exige argon2 : un jeton de 256 bits tiré au hasard n'est pas attaquable par dictionnaire, un mot de passe si.
+
+### Ce qui n'est pas fait dans ce socle
+
+La limitation de débit sur `/auth/login`, la détection de réutilisation d'un jeton de rafraîchissement déjà tourné (révocation de toute la famille), la vérification d'email et la réinitialisation de mot de passe ne sont pas implémentées. Elles viendront dans leurs propres lots.
+
+`SECRET_KEY` vaut `change-me-in-production` par défaut : c'est une valeur de développement, elle **doit** être surchargée par une variable d'environnement en production, avec au moins 32 octets aléatoires. PyJWT émet un avertissement en dessous de cette longueur.
+
+## Pourquoi pas fastapi-users
+
+`fastapi-users` couvre exactement ce périmètre, et a pourtant été écarté :
+
+- le projet est en mode maintenance déclaré, aucune fonctionnalité nouvelle n'y sera ajoutée ;
+- il est exclusivement asynchrone, ce qui imposerait de basculer toute la pile (voir plus bas) ;
+- surtout, il impose ses colonnes sur le modèle `User` : `hashed_password`, `is_active`, `is_superuser`, `is_verified`. Or `User` doit rester nu et déléguer l'authentification à `Identity`, une ligne par fournisseur, pour que Google ou Facebook s'ajoutent plus tard sans migration destructive. Un `hashed_password` sur `User` ferme cette porte le jour de son ajout.
+
+Les autres candidats répondent à d'autres questions :
+
+- **Authlib** et **httpx-oauth** sont des briques OAuth/OIDC : elles savent parler à un fournisseur, pas gérer des comptes, des mots de passe ni des sessions. Elles resteront pertinentes quand les fournisseurs externes arriveront, à côté de ce socle et non à sa place.
+- **AuthX** ne fait que le JWT — soit la partie la plus courte à écrire ici, et celle qui ne couvre ni les identités ni la révocation.
+- **python-social-auth** est pensé pour Django ; son intégration FastAPI est marginale et son modèle de données étranger au nôtre.
+- Un **fournisseur d'identité externe** (Keycloak, Auth0, Clerk) est surdimensionné pour un backend familial auto-hébergé sur un Raspberry Pi : il ajouterait un service à opérer, ou une dépendance payante à un tiers, pour une inscription par email et mot de passe.
+
+Le socle écrit à la main tient en quatre fichiers courts et n'emprunte que deux bibliothèques éprouvées et à responsabilité unique : PyJWT pour signer, pwdlib pour hacher en argon2.
+
+## Pourquoi la pile reste synchrone
+
+Les routes sont déclarées en `def`, pas en `async def`. FastAPI exécute alors chaque route dans le threadpool d'anyio : la boucle d'événements n'est jamais bloquée, et le code appelle SQLAlchemy 2.0 en synchrone sans précaution particulière.
+
+Passer à l'asynchrone n'apporterait rien ici et coûterait cher :
+
+- SQLite sérialise les écritures de toute façon, un seul écrivain à la fois ; la concurrence gagnée serait fictive ;
+- SQLAlchemy async repose sur greenlet, ce qui transforme le moindre accès paresseux hors contexte en `MissingGreenlet` et impose de charger explicitement chaque relation (`selectinload`) sous peine d'erreur à l'exécution plutôt qu'à l'écriture ;
+- les tests devraient basculer sur `AsyncClient` et un plugin asyncio, et le hachage argon2 resterait de toute façon un travail CPU à déporter dans un thread.
+
+Le jour où la base deviendra PostgreSQL et où la charge le justifiera, la bascule se fera route par route. Elle n'est pas un prérequis de l'authentification.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -50,7 +50,7 @@ Le SHA-256 suffit ici, là où le mot de passe exige argon2 : un jeton de 256 bi
 
 La limitation de débit sur `/auth/login`, la détection de réutilisation d'un jeton de rafraîchissement déjà tourné (révocation de toute la famille), la vérification d'email et la réinitialisation de mot de passe ne sont pas implémentées. Elles viendront dans leurs propres lots.
 
-`SECRET_KEY` vaut `change-me-in-production` par défaut : c'est une valeur de développement, elle **doit** être surchargée par une variable d'environnement en production, avec au moins 32 octets aléatoires. PyJWT émet un avertissement en dessous de cette longueur.
+`SECRET_KEY` n'a **aucune valeur par défaut dans l'application** : `Settings()` lève `Field required` au démarrage si la variable d'environnement est absente. Une clé de signature publiée dans le dépôt serait exploitable par quiconque lit le code, quel que soit le mode de déploiement. Les deux fichiers compose et le `Makefile` fournissent un placeholder `change-me-...` pour le développement et les tests ; en production la variable doit porter au moins 32 octets aléatoires, longueur en dessous de laquelle PyJWT émet un avertissement.
 
 ## Pourquoi pas fastapi-users
 

--- a/docs/model/household.md
+++ b/docs/model/household.md
@@ -30,7 +30,7 @@ Un compte ne peut être rattaché qu'à une seule personne par foyer. La contrai
 
 ## User restera nu
 
-Une brique d'authentification externe, équivalente à OmniAuth, est prévue. Les identités — fournisseur, identifiant chez le fournisseur, jetons — arriveront dans leurs propres tables reliées à `User`.
+Les identités — fournisseur, identifiant chez le fournisseur, secret — vivent dans la table `identities` reliée à `User`, et les sessions dans `refresh_tokens` : `User` ne porte donc aucune colonne d'authentification.
 
 `User` ne porte donc **aucune colonne d'authentification** : ni mot de passe, ni fournisseur, ni jeton. C'est ce qui permettra de brancher cette brique par ajout de tables, sans migration destructive.
 

--- a/openapi.json
+++ b/openapi.json
@@ -422,12 +422,17 @@
             "const": "bearer",
             "title": "Token Type",
             "default": "bearer"
+          },
+          "expires_in": {
+            "type": "integer",
+            "title": "Expires In"
           }
         },
         "type": "object",
         "required": [
           "access_token",
-          "refresh_token"
+          "refresh_token",
+          "expires_in"
         ],
         "title": "TokenPair"
       },

--- a/openapi.json
+++ b/openapi.json
@@ -6,6 +6,189 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/auth/register": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Create an account from an email and a password",
+        "operationId": "register_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenPair"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Exchange credentials for a token pair",
+        "operationId": "login_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserLogin"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenPair"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Rotate a refresh token",
+        "operationId": "refresh_auth_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenPair"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Revoke a refresh token",
+        "operationId": "logout_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get the authenticated account",
+        "operationId": "read_me_auth_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRead"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
     "/stufflists": {
       "get": {
         "tags": [
@@ -180,6 +363,19 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "RefreshTokenRequest": {
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "refresh_token"
+        ],
+        "title": "RefreshTokenRequest"
+      },
       "StuffListCreate": {
         "properties": {
           "name": {
@@ -210,6 +406,96 @@
           "name"
         ],
         "title": "StuffListRead"
+      },
+      "TokenPair": {
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "title": "Access Token"
+          },
+          "refresh_token": {
+            "type": "string",
+            "title": "Refresh Token"
+          },
+          "token_type": {
+            "type": "string",
+            "const": "bearer",
+            "title": "Token Type",
+            "default": "bearer"
+          }
+        },
+        "type": "object",
+        "required": [
+          "access_token",
+          "refresh_token"
+        ],
+        "title": "TokenPair"
+      },
+      "UserCreate": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 8,
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserCreate"
+      },
+      "UserLogin": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "UserLogin"
+      },
+      "UserRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "created_at"
+        ],
+        "title": "UserRead"
       },
       "ValidationError": {
         "properties": {
@@ -250,6 +536,13 @@
           "type"
         ],
         "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "description": "Access token returned by /auth/login",
+        "scheme": "bearer"
       }
     }
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "pydantic-settings>=2.15",
     "brevo-python>=5",
     "httpx>=0.27",
+    "email-validator>=2.2",
+    "pyjwt>=2.13",
+    "pwdlib[argon2]>=0.3",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 dev = [
     "pytest>=8.3",
     "pytest-cov>=6.0",
+    "pytest-env>=1.1",
     "httpx>=0.27",
     "ruff>=0.8",
     "polyfactory>=2.18",
@@ -37,6 +38,7 @@ include = ["app*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--cov=app --cov-report=term-missing --cov-fail-under=100"
+env = ["SECRET_KEY=change-me-this-development-key-is-not-secret"]
 
 [tool.coverage.report]
 exclude_also = ['if __name__ == "__main__":']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,14 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from app.auth.passwords import hash_password
+from app.auth.tokens import create_access_token
 from app.database import Base, enable_sqlite_pragmas, get_db
 from app.main import app
+from app.models import Identity, IdentityProvider, User
+
+DEFAULT_EMAIL = "member@example.com"
+DEFAULT_PASSWORD = "correct-horse-battery"
 
 
 @pytest.fixture
@@ -41,3 +47,38 @@ def client(engine):
     with TestClient(app) as test_client:
         yield test_client
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def create_user(db):
+    def factory(email: str = DEFAULT_EMAIL, password: str = DEFAULT_PASSWORD) -> User:
+        user = User(email=email)
+        user.identities.append(
+            Identity(
+                provider=IdentityProvider.password,
+                provider_uid=email,
+                secret=hash_password(password),
+            )
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    return factory
+
+
+@pytest.fixture
+def user(create_user):
+    return create_user()
+
+
+@pytest.fixture
+def credentials():
+    return {"email": DEFAULT_EMAIL, "password": DEFAULT_PASSWORD}
+
+
+@pytest.fixture
+def authenticated_client(client, user):
+    client.headers["Authorization"] = f"Bearer {create_access_token(user.id)}"
+    return client

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -1,0 +1,82 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
+from app.auth.dependencies import CurrentHousehold
+from app.auth.tokens import create_access_token
+from app.database import get_db
+from app.models import Household, HouseholdMember
+
+
+@pytest.fixture
+def household_client(engine):
+    scoped_app = FastAPI()
+
+    @scoped_app.get("/households/{household_id}/probe")
+    def probe(household: CurrentHousehold):
+        return {"id": household.id, "name": household.name}
+
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    scoped_app.dependency_overrides[get_db] = override_get_db
+    with TestClient(scoped_app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def bearer(user):
+    return {"Authorization": f"Bearer {create_access_token(user.id)}"}
+
+
+@pytest.fixture
+def household(db, user):
+    household = Household(name="Maison")
+    household.members.append(HouseholdMember(user_id=user.id))
+    db.add(household)
+    db.commit()
+    db.refresh(household)
+    return household
+
+
+def test_current_household_returns_a_household_the_user_belongs_to(
+    household_client, household, bearer
+):
+    response = household_client.get(f"/households/{household.id}/probe", headers=bearer)
+
+    assert response.status_code == 200
+    assert response.json() == {"id": household.id, "name": "Maison"}
+
+
+def test_current_household_hides_a_household_the_user_is_not_a_member_of(
+    household_client, db, bearer
+):
+    foreign = Household(name="Chez les autres")
+    db.add(foreign)
+    db.commit()
+
+    response = household_client.get(f"/households/{foreign.id}/probe", headers=bearer)
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Household not found"
+
+
+def test_current_household_answers_404_and_never_403_on_a_missing_household(
+    household_client, bearer
+):
+    response = household_client.get("/households/404404/probe", headers=bearer)
+
+    assert response.status_code == 404
+
+
+def test_current_household_requires_authentication(household_client, household):
+    response = household_client.get(f"/households/{household.id}/probe")
+
+    assert response.status_code == 401

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import select
 
 from app.auth.tokens import create_access_token, hash_refresh_token
+from app.config import settings
 from app.models import Identity, IdentityProvider, RefreshToken, User
 
 NEW_ACCOUNT = {"email": "newcomer@example.com", "password": "a-long-enough-password"}
@@ -21,6 +22,12 @@ def test_register_returns_a_token_pair_and_creates_a_password_identity(client, d
     assert identity.provider is IdentityProvider.password
     assert identity.provider_uid == NEW_ACCOUNT["email"]
     assert identity.secret != NEW_ACCOUNT["password"]
+
+
+def test_register_reports_the_access_token_lifetime(client):
+    response = client.post("/auth/register", json=NEW_ACCOUNT)
+
+    assert response.json()["expires_in"] == settings.access_token_ttl_minutes * 60
 
 
 def test_register_does_not_create_a_household(client, db):

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -1,0 +1,209 @@
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.auth.tokens import create_access_token, hash_refresh_token
+from app.models import Identity, IdentityProvider, RefreshToken, User
+
+NEW_ACCOUNT = {"email": "newcomer@example.com", "password": "a-long-enough-password"}
+
+
+def test_register_returns_a_token_pair_and_creates_a_password_identity(client, db):
+    response = client.post("/auth/register", json=NEW_ACCOUNT)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["token_type"] == "bearer"
+    assert body["access_token"] and body["refresh_token"]
+
+    user = db.scalar(select(User).where(User.email == NEW_ACCOUNT["email"]))
+    identity = db.scalar(select(Identity).where(Identity.user_id == user.id))
+    assert identity.provider is IdentityProvider.password
+    assert identity.provider_uid == NEW_ACCOUNT["email"]
+    assert identity.secret != NEW_ACCOUNT["password"]
+
+
+def test_register_does_not_create_a_household(client, db):
+    client.post("/auth/register", json=NEW_ACCOUNT)
+
+    user = db.scalar(select(User).where(User.email == NEW_ACCOUNT["email"]))
+    assert user.memberships == []
+
+
+def test_register_stores_the_refresh_token_hashed(client, db):
+    response = client.post("/auth/register", json=NEW_ACCOUNT)
+
+    stored = db.scalars(select(RefreshToken)).all()
+    assert len(stored) == 1
+    assert stored[0].token_hash == hash_refresh_token(response.json()["refresh_token"])
+
+
+def test_register_rejects_an_email_already_taken(client, user):
+    response = client.post("/auth/register", json={"email": user.email, "password": "another-one"})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Email already registered"
+
+
+def test_register_rejects_a_short_password(client):
+    response = client.post(
+        "/auth/register", json={"email": "short@example.com", "password": "1234"}
+    )
+
+    assert response.status_code == 422
+
+
+def test_register_rejects_a_malformed_email(client):
+    response = client.post("/auth/register", json={"email": "not-an-email", "password": "12345678"})
+
+    assert response.status_code == 422
+
+
+def test_register_rejects_an_oversized_password(client):
+    response = client.post(
+        "/auth/register", json={"email": "long@example.com", "password": "x" * 129}
+    )
+
+    assert response.status_code == 422
+
+
+def test_login_returns_a_token_pair(client, user, credentials):
+    response = client.post("/auth/login", json=credentials)
+
+    assert response.status_code == 200
+    assert response.json()["token_type"] == "bearer"
+
+
+def test_login_rejects_a_wrong_password(client, user, credentials):
+    response = client.post("/auth/login", json={**credentials, "password": "wrong-one"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid credentials"
+
+
+def test_login_rejects_an_unknown_email_with_the_very_same_message(client, user, credentials):
+    response = client.post("/auth/login", json={**credentials, "email": "ghost@example.com"})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid credentials"
+
+
+def test_login_rejects_an_identity_without_a_secret(client, db, user, credentials):
+    identity = db.scalars(select(Identity)).one()
+    identity.secret = None
+    db.commit()
+
+    response = client.post("/auth/login", json=credentials)
+
+    assert response.status_code == 401
+
+
+def test_login_rejects_an_oversized_password(client, user, credentials):
+    response = client.post("/auth/login", json={**credentials, "password": "x" * 129})
+
+    assert response.status_code == 422
+
+
+def test_refresh_rotates_the_refresh_token(client, db, user, credentials):
+    issued = client.post("/auth/login", json=credentials).json()
+
+    response = client.post("/auth/refresh", json={"refresh_token": issued["refresh_token"]})
+
+    assert response.status_code == 200
+    rotated = response.json()
+    assert rotated["refresh_token"] != issued["refresh_token"]
+
+    previous = db.scalar(
+        select(RefreshToken).where(
+            RefreshToken.token_hash == hash_refresh_token(issued["refresh_token"])
+        )
+    )
+    assert previous.revoked_at is not None
+
+
+def test_refresh_rejects_a_token_already_rotated(client, user, credentials):
+    issued = client.post("/auth/login", json=credentials).json()
+    client.post("/auth/refresh", json={"refresh_token": issued["refresh_token"]})
+
+    response = client.post("/auth/refresh", json={"refresh_token": issued["refresh_token"]})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid refresh token"
+
+
+def test_refresh_rejects_an_unknown_token(client):
+    response = client.post("/auth/refresh", json={"refresh_token": "never-issued"})
+
+    assert response.status_code == 401
+
+
+def test_refresh_rejects_an_expired_token(client, db, user, credentials):
+    issued = client.post("/auth/login", json=credentials).json()
+    stored = db.scalars(select(RefreshToken)).one()
+    stored.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    db.commit()
+
+    response = client.post("/auth/refresh", json={"refresh_token": issued["refresh_token"]})
+
+    assert response.status_code == 401
+
+
+def test_logout_revokes_the_refresh_token(client, db, user, credentials):
+    issued = client.post("/auth/login", json=credentials).json()
+
+    response = client.post("/auth/logout", json={"refresh_token": issued["refresh_token"]})
+
+    assert response.status_code == 204
+    assert db.scalars(select(RefreshToken)).one().revoked_at is not None
+    assert (
+        client.post("/auth/refresh", json={"refresh_token": issued["refresh_token"]}).status_code
+        == 401
+    )
+
+
+def test_logout_is_idempotent_and_silent_on_an_unknown_token(client, user, credentials):
+    issued = client.post("/auth/login", json=credentials).json()
+    client.post("/auth/logout", json={"refresh_token": issued["refresh_token"]})
+
+    assert (
+        client.post("/auth/logout", json={"refresh_token": issued["refresh_token"]}).status_code
+        == 204
+    )
+    assert client.post("/auth/logout", json={"refresh_token": "never-issued"}).status_code == 204
+
+
+def test_me_returns_the_authenticated_account(authenticated_client, user):
+    response = authenticated_client.get("/auth/me")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"id": user.id, "email": user.email, "created_at": body["created_at"]}
+
+
+def test_me_rejects_a_request_without_a_bearer(client):
+    response = client.get("/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid credentials"
+
+
+def test_me_rejects_a_non_bearer_authorization_header(client):
+    response = client.get("/auth/me", headers={"Authorization": "Basic Zm9vOmJhcg=="})
+
+    assert response.status_code == 401
+
+
+def test_me_rejects_a_forged_token(client):
+    response = client.get("/auth/me", headers={"Authorization": "Bearer not.a.jwt"})
+
+    assert response.status_code == 401
+
+
+def test_me_rejects_a_token_of_a_deleted_account(client, db, user):
+    token = create_access_token(user.id)
+    db.delete(user)
+    db.commit()
+
+    response = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 401

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -45,6 +45,29 @@ def test_register_rejects_an_email_already_taken(client, user):
     assert response.json()["detail"] == "Email already registered"
 
 
+def test_register_rejects_an_email_already_taken_in_another_case(client, user, db):
+    response = client.post(
+        "/auth/register", json={"email": user.email.upper(), "password": "another-one"}
+    )
+
+    assert response.status_code == 409
+    assert db.scalars(select(User)).all() == [user]
+
+
+def test_register_lowercases_the_stored_email(client, db):
+    client.post("/auth/register", json={**NEW_ACCOUNT, "email": "NewComer@Example.com"})
+
+    assert db.scalar(select(User).where(User.email == "newcomer@example.com")) is not None
+
+
+def test_login_ignores_the_case_of_the_email(client, user, credentials):
+    response = client.post(
+        "/auth/login", json={**credentials, "email": credentials["email"].upper()}
+    )
+
+    assert response.status_code == 200
+
+
 def test_register_rejects_a_short_password(client):
     response = client.post(
         "/auth/register", json={"email": "short@example.com", "password": "1234"}

--- a/tests/test_auth_tokens.py
+++ b/tests/test_auth_tokens.py
@@ -1,0 +1,115 @@
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from sqlalchemy import select
+
+from app.auth.passwords import (
+    UNMATCHABLE_HASH,
+    equalize_verification_time,
+    hash_password,
+    verify_password,
+)
+from app.auth.tokens import (
+    ACCESS_TOKEN_ALGORITHM,
+    as_utc,
+    create_access_token,
+    create_refresh_token,
+    find_usable_refresh_token,
+    hash_refresh_token,
+    read_access_token_subject,
+    revoke_refresh_token,
+)
+from app.config import settings
+from app.models import RefreshToken
+
+
+def forge(payload: dict, key: str = settings.secret_key) -> str:
+    return jwt.encode(payload, key, algorithm=ACCESS_TOKEN_ALGORITHM)
+
+
+def test_hash_password_is_salted_and_verifiable():
+    first = hash_password("a-long-enough-password")
+    second = hash_password("a-long-enough-password")
+
+    assert first != second
+    assert first.startswith("$argon2")
+    assert verify_password("a-long-enough-password", first)
+    assert not verify_password("another-password", first)
+
+
+def test_access_token_round_trip():
+    assert read_access_token_subject(create_access_token(42)) == 42
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "not-a-jwt",
+        forge({"sub": "1"}, key="another-secret"),
+        forge({"iat": datetime.now(UTC)}),
+        forge({"sub": "not-a-number"}),
+        forge({"sub": "1", "exp": datetime.now(UTC) - timedelta(minutes=1)}),
+    ],
+)
+def test_read_access_token_subject_refuses_anything_it_did_not_sign(token):
+    assert read_access_token_subject(token) is None
+
+
+def test_hash_refresh_token_never_returns_the_token():
+    token = "an-opaque-token"
+
+    assert hash_refresh_token(token) != token
+    assert hash_refresh_token(token) == hash_refresh_token(token)
+
+
+def test_create_refresh_token_stores_only_its_hash(db, user):
+    token = create_refresh_token(db, user)
+    db.commit()
+
+    stored = db.scalars(select(RefreshToken)).one()
+    assert token not in stored.token_hash
+    assert stored.token_hash == hash_refresh_token(token)
+    assert stored.user_id == user.id
+
+
+def test_find_usable_refresh_token_returns_the_stored_row(db, user):
+    token = create_refresh_token(db, user)
+    db.commit()
+
+    assert find_usable_refresh_token(db, token) is not None
+
+
+def test_find_usable_refresh_token_ignores_an_unknown_token(db):
+    assert find_usable_refresh_token(db, "never-issued") is None
+
+
+def test_find_usable_refresh_token_ignores_a_revoked_token(db, user):
+    token = create_refresh_token(db, user)
+    db.commit()
+    revoke_refresh_token(db.scalars(select(RefreshToken)).one())
+    db.commit()
+
+    assert find_usable_refresh_token(db, token) is None
+
+
+def test_find_usable_refresh_token_ignores_an_expired_token(db, user):
+    token = create_refresh_token(db, user)
+    db.commit()
+    db.scalars(select(RefreshToken)).one().expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    db.commit()
+
+    assert find_usable_refresh_token(db, token) is None
+
+
+def test_equalize_verification_time_can_never_match_a_password():
+    assert not verify_password("any-password", UNMATCHABLE_HASH)
+    assert equalize_verification_time("any-password") is None
+
+
+def test_as_utc_assumes_utc_for_the_naive_datetimes_sqlite_gives_back():
+    naive = datetime(2026, 1, 1, 12, 0, 0)
+    aware = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    assert as_utc(naive) == aware
+    assert as_utc(aware) is aware

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+def test_settings_refuse_a_missing_secret_key(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_settings_refuse_an_empty_secret_key(monkeypatch):
+    monkeypatch.setenv("SECRET_KEY", "")
+
+    with pytest.raises(ValidationError):
+        Settings()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "alembic"
@@ -48,6 +52,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "brevo-python"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -69,6 +116,91 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -189,6 +321,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/7e/37732ea80eebc30e976e4cdab15c190bc42d96959a42e38ddf6f8c60468f/coverage-7.15.4-cp315-cp315t-win_amd64.whl", hash = "sha256:288bde2a2d7ab6b6c2d7252fcde8b524387f2d970bdba9658fc6f8bbcaef0f9b", size = 225895, upload-time = "2026-08-06T13:50:17.928Z" },
     { url = "https://files.pythonhosted.org/packages/c6/08/1e00f7923eaaba45fb3d51dd794125fc766304b1df264f3a9c6557bfb30e/coverage-7.15.4-cp315-cp315t-win_arm64.whl", hash = "sha256:68be5e1de60ff13c9095bbec0e5a7fa45b33b101752215b91345ea1f61c4a278", size = 225213, upload-time = "2026-08-06T13:50:19.981Z" },
     { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -520,6 +674,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pwdlib"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/a6/644f28a21cb68920d06b264e72b864ac9bff2377f4757dd4648b5110b3ad/pwdlib-0.3.1.tar.gz", hash = "sha256:2ffd1955c92190d5bfbdc5071bf7d422568b83f943453ebd3d43d031ccba37b1", size = 216951, upload-time = "2026-08-12T08:38:38.383Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/2e/51979293b2337f508597d13ee20db1ac1d43e48086b2ed7de6da213ed46b/pwdlib-0.3.1-py3-none-any.whl", hash = "sha256:944fa439198bed8ac3ea63dac76ea4ae43e2a35f4f21e9e725e82d3c2b97d6a5", size = 9272, upload-time = "2026-08-12T08:38:37.483Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -642,6 +819,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]
@@ -840,10 +1026,13 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "brevo-python" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -862,10 +1051,13 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "brevo-python", specifier = ">=5" },
+    { name = "email-validator", specifier = ">=2.2" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "pwdlib", extras = ["argon2"], specifier = ">=0.3" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.15" },
+    { name = "pyjwt", specifier = ">=2.13" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -870,6 +870,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/49/08ee056f9cc655e437abcf2ae399884844b623223476ae6a77244131db03/pytest_env-1.7.0.tar.gz", hash = "sha256:0c1dc1101fb8d3ab3611e8f8d657ba06c3c0c167fc85c90457e5b27f2508f43e", size = 16408, upload-time = "2026-07-21T13:09:21.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/fc/9f2975c41d41bf5bd9a7d0fc03085ec20052b456b079df53828ae4a1b100/pytest_env-1.7.0-py3-none-any.whl", hash = "sha256:9ee0f1fe859d23fcdb533fe2909a404b3b133d02674a56df275bbe4df4eb104b", size = 10263, upload-time = "2026-07-21T13:09:20.677Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1044,6 +1057,7 @@ dev = [
     { name = "polyfactory" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-env" },
     { name = "ruff" },
 ]
 
@@ -1069,6 +1083,7 @@ dev = [
     { name = "polyfactory", specifier = ">=2.18" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-env", specifier = ">=1.1" },
     { name = "ruff", specifier = ">=0.8" },
 ]
 


### PR DESCRIPTION
Première des quatre PR de #30 : le socle d'authentification. Aucune route du domaine ici, aucun envoi d'email, aucun provider OAuth.

## L'arbitrage demandé par l'issue : fastapi-users est écarté

L'issue demandait de chercher et de proposer, pas de trancher seul. Voici ce qui a été trouvé, le détail est dans `docs/api/README.md` :

- **fastapi-users** est en **maintenance mode** — « no new features will be added », un successeur est annoncé sans nom ni date. Elle est en outre **async-only** (son adaptateur SQLAlchemy ne connaît que `AsyncSession`), et son protocole impose `hashed_password`, `is_active`, `is_superuser` et `is_verified` sur `User` : ça tue à la fois la décision de #22 et le schéma `Identity` de #30. Elle n'a par ailleurs **aucune logique de refresh token** ni de magic link / OTP — les deux étaient à écrire à la main de toute façon.
- **Authlib** et **httpx-oauth** sont des briques OAuth sans gestion d'utilisateurs, **AuthX** ne fait que le JWT, **python-social-auth** est pensé Django, un IdP externe (Keycloak, Ory, Supertokens) est surdimensionné ici.

Il n'existe donc pas d'équivalent Python d'OmniAuth compatible avec `Identity`. Le socle est écrit à la main sur des briques maintenues : `pwdlib[argon2]`, `PyJWT`, et `httpx-oauth` le jour où les providers arriveront.

**La stack reste synchrone.** Les routes `def` sont exécutées par FastAPI dans le threadpool anyio et ne bloquent pas l'event loop ; SQLite sérialise les écritures de toute façon, donc async SQLAlchemy coûterait greenlet, `MissingGreenlet` et `selectinload` partout pour zéro gain mesurable.

## Schéma

`User` ne gagne **aucune colonne**, seulement deux relations.

- `identities` : `user_id`, `provider` (`password` | `google` | `facebook` | `github`), `provider_uid`, `secret`, unique sur `(provider, provider_uid)`. `provider_uid` vaut l'email pour `password` et `secret` porte le hash argon2 ; ajouter Google plus tard = insérer des lignes, pas migrer.
- `refresh_tokens` : jeton **opaque**, stocké en SHA-256 (jamais en clair), avec `expires_at` et `revoked_at`.

Migration `0003` relue à la main, `downgrade` testé réellement.

## Sessions

Access token JWT HS256 court (15 min par défaut), refresh token opaque long (30 jours) **tourné à chaque usage** : l'ancien est révoqué, un nouveau est émis. C'est ce qui rend la déconnexion réelle — un JWT de refresh aurait été irrévocable, ce qui était le vrai sujet soulevé par l'issue.

## Routes

`POST /auth/register` (201) · `POST /auth/login` · `POST /auth/refresh` · `POST /auth/logout` (204) · `GET /auth/me`. Corps JSON, pas de formulaire OAuth2 : le client est une app mobile. La réponse porte `access_token`, `refresh_token`, `token_type` et `expires_in`.

L'inscription crée `User` + `Identity(password)` et **rien d'autre** — pas de foyer implicite, la création de foyer sera une route du domaine.

## Deux dépendances

- `CurrentUser` : bearer, JWT décodé, compte chargé.
- `CurrentHousehold` : résout le paramètre de chemin `household_id` et vérifie l'appartenance. Elle répond **404, jamais 403** : révéler l'existence d'un foyer étranger serait déjà une fuite. C'est la règle la plus importante de l'issue, et toutes les routes du domaine passeront par là.

## Durcissements

- **La clé de signature n'existe pas dans l'application.** `secret_key` n'a aucune valeur par défaut et refuse la chaîne vide (`Field(min_length=1)`) : `Settings()` lève `Field required` au démarrage si `SECRET_KEY` manque, quel que soit le mode de déploiement. Un défaut applicatif aurait été une clé publiée dans le dépôt, exploitable par quiconque lit le code — et un garde-fou posé uniquement dans `docker-compose.prod.yml` ne couvrait ni `docker run`, ni systemd, ni k8s. Les deux fichiers compose, le `Makefile` et `pytest-env` fournissent un placeholder `change-me-...` de plus de 32 octets, longueur en dessous de laquelle PyJWT avertit à chaque jeton.
- **Casse de l'email normalisée.** `alexis@` puis `Alexis@` créaient deux comptes et `ALEXIS@` ne pouvait plus se connecter : `EmailStr` normalise le domaine mais pas la partie locale. `UserCreate` et `UserLogin` portent `Annotated[EmailStr, StringConstraints(to_lower=True)]` ; `UserRead` garde un `EmailStr` nu pour ne pas perdre `"format": "email"` dans `openapi.json`. `register` insère puis traduit l'`IntegrityError` en 409, donc l'unicité est garantie par la base et non constatée avant écriture.
- **Paramètres argon2 OWASP** (`m=19456, t=2, p=1`) au lieu des défauts de la lib (`m=65536, t=3, p=4`) : avec le threadpool anyio à 40, `/auth/login` — non authentifié et sans limitation de débit — pouvait culminer à 2,5 Go. Divisé par 3,4. Les hash écrits avec les anciens paramètres restent vérifiables, argon2 les encode dans le digest.
- **Égalisation du temps de réponse au login** : un email inconnu ne passait pas par argon2 et répondait plus vite, ce qui énumérait les comptes malgré un message identique.
- **`max_length=128` sur les mots de passe** : argon2 ne tronque pas, un mot de passe non borné est un DoS CPU gratuit.
- **`HTTPBearer(auto_error=False)`** : par défaut FastAPI renvoie 403 sur bearer manquant, ce qui contredisait la convention 401.

## Différé, et documenté comme tel dans `docs/api/`

- Limitation de débit sur `/auth/login`.
- Détection de réutilisation d'un refresh token déjà tourné (révocation de toute la famille), et la fenêtre de concurrence de `/auth/refresh` qui se referme au même endroit : la ligne n'est pas verrouillée pendant la rotation.
- Purge de `refresh_tokens` : une ligne par connexion et par rotation, révoquée mais conservée. Hygiène, pas tenue en charge.
- Vérification d'email et réinitialisation de mot de passe : PR suivante, elles dépendent de la brique Brevo (#33, mergée).

## Vérifications

`76 passed`, couverture **100 %**, `ruff check` et `ruff format --check` propres, `openapi.json` et le diagramme ER régénérés et sans dérive, migration `upgrade` puis `downgrade base` rejouées. Les tests couvrent le cas nominal **et** l'échec de chaque route (mot de passe faux, email inconnu, email déjà pris dans une autre casse, jeton expiré, invalide, révoqué, rotation, absence de bearer), plus les deux dépendances — `CurrentHousehold` est testée à travers une app FastAPI jetable pour vérifier le câblage du paramètre de chemin, aucune route du domaine n'existant encore.

La branche est rebasée sur `main` après le merge de #33 ; #35, qui s'empile dessus, est rebasée sur sa tête courante.

Traite #30 partiellement.