### PR TITLE
Assert the Brevo request at the transport layer

### DIFF
--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -1,58 +1,82 @@
+import json
 import logging
-from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from brevo.core.api_error import ApiError
 
 from app import mail
 from app.config import Settings
 
+BREVO_ENDPOINT = "https://api.brevo.com/v3/smtp/email"
+ACCEPTED_RESPONSE = {"messageId": "<202608191600.12345@smtp-relay.brevo.com>"}
+REJECTED_RESPONSE = {"code": "invalid_parameter", "message": "sender is not valid"}
+
 
 @pytest.fixture
-def brevo(monkeypatch):
-    client_class = MagicMock()
-    monkeypatch.setattr(mail, "Brevo", client_class)
-    return client_class
+def brevo_responds():
+    def install(monkeypatch, handler):
+        requests = []
+
+        def handle_request(
+            transport: httpx.HTTPTransport, request: httpx.Request
+        ) -> httpx.Response:
+            requests.append(request)
+            return handler(request)
+
+        monkeypatch.setattr(httpx.HTTPTransport, "handle_request", handle_request)
+        return requests
+
+    return install
 
 
-def test_send_email_is_a_logged_no_op_without_api_key(brevo, monkeypatch, caplog):
+def accepted(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(201, json=ACCEPTED_RESPONSE)
+
+
+def test_send_email_is_a_logged_no_op_without_api_key(brevo_responds, monkeypatch, caplog):
+    requests = brevo_responds(monkeypatch, accepted)
     monkeypatch.setattr(mail.settings, "brevo_api_key", "")
 
     with caplog.at_level(logging.INFO, logger=mail.logger.name):
         mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")
 
-    brevo.assert_not_called()
+    assert requests == []
     assert "invitee@example.com" in caplog.text
 
 
-def test_send_email_calls_brevo_with_the_configured_sender(brevo, monkeypatch):
+def test_send_email_posts_the_documented_payload_to_brevo(brevo_responds, monkeypatch):
+    requests = brevo_responds(monkeypatch, accepted)
     monkeypatch.setattr(mail.settings, "brevo_api_key", "test-key")
     monkeypatch.setattr(mail.settings, "mail_from_email", "hello@tout-pris.app")
     monkeypatch.setattr(mail.settings, "mail_from_name", "Tout Pris")
 
     mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")
 
-    brevo.assert_called_once()
-    http_client = brevo.call_args.kwargs["httpx_client"]
-    assert brevo.call_args.kwargs["api_key"] == "test-key"
-    assert http_client.timeout.read == mail.BREVO_TIMEOUT_SECONDS
-    assert http_client.is_closed
-    send = brevo.return_value.transactional_emails.send_transac_email
-    send.assert_called_once()
-    payload = send.call_args.kwargs
-    assert payload["sender"].email == "hello@tout-pris.app"
-    assert payload["sender"].name == "Tout Pris"
-    assert [item.email for item in payload["to"]] == ["invitee@example.com"]
-    assert payload["subject"] == "Welcome"
-    assert payload["html_content"] == "<p>Hello</p>"
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == "POST"
+    assert str(request.url) == BREVO_ENDPOINT
+    assert request.headers["api-key"] == "test-key"
+    assert json.loads(request.content) == {
+        "sender": {"email": "hello@tout-pris.app", "name": "Tout Pris"},
+        "to": [{"email": "invitee@example.com"}],
+        "subject": "Welcome",
+        "htmlContent": "<p>Hello</p>",
+    }
 
 
-def test_send_email_logs_api_errors_instead_of_raising(brevo, monkeypatch, caplog):
+def test_send_email_applies_the_timeout_to_the_request(brevo_responds, monkeypatch):
+    requests = brevo_responds(monkeypatch, accepted)
     monkeypatch.setattr(mail.settings, "brevo_api_key", "test-key")
-    brevo.return_value.transactional_emails.send_transac_email.side_effect = ApiError(
-        status_code=400, body="invalid sender"
-    )
+
+    mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")
+
+    assert requests[0].extensions["timeout"]["read"] == mail.BREVO_TIMEOUT_SECONDS
+
+
+def test_send_email_logs_a_rejection_instead_of_raising(brevo_responds, monkeypatch, caplog):
+    brevo_responds(monkeypatch, lambda request: httpx.Response(400, json=REJECTED_RESPONSE))
+    monkeypatch.setattr(mail.settings, "brevo_api_key", "test-key")
 
     with caplog.at_level(logging.ERROR, logger=mail.logger.name):
         mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")
@@ -60,11 +84,26 @@ def test_send_email_logs_api_errors_instead_of_raising(brevo, monkeypatch, caplo
     assert "invitee@example.com" in caplog.text
 
 
-def test_send_email_logs_unexpected_failures_instead_of_raising(brevo, monkeypatch, caplog):
+def test_send_email_logs_a_transport_failure_instead_of_raising(
+    brevo_responds, monkeypatch, caplog
+):
+    def time_out(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("brevo took too long", request=request)
+
+    brevo_responds(monkeypatch, time_out)
     monkeypatch.setattr(mail.settings, "brevo_api_key", "test-key")
-    brevo.return_value.transactional_emails.send_transac_email.side_effect = httpx.ReadTimeout(
-        "brevo took too long"
-    )
+
+    with caplog.at_level(logging.ERROR, logger=mail.logger.name):
+        mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")
+
+    assert "invitee@example.com" in caplog.text
+
+
+def test_send_email_logs_an_unparsable_response_instead_of_raising(
+    brevo_responds, monkeypatch, caplog
+):
+    brevo_responds(monkeypatch, lambda request: httpx.Response(201, text="not json at all"))
+    monkeypatch.setattr(mail.settings, "brevo_api_key", "test-key")
 
     with caplog.at_level(logging.ERROR, logger=mail.logger.name):
         mail.send_email("invitee@example.com", "Welcome", "<p>Hello</p>")


### PR DESCRIPTION
Suite de #33 : on descend le mock du niveau « classe du SDK » au niveau HTTP, et on construit de vraies réponses Brevo. **La PR ne touche que `tests/test_mail.py`**, aucune ligne de production.

## Le problème

`monkeypatch.setattr(mail, "Brevo", MagicMock())` remplaçait la classe du SDK. Or un `MagicMock` accepte **n'importe quel nom d'argument** : un paramètre renommé dans le SDK, une mauvaise URL, un header `api-key` absent — tout restait vert pendant que la production cassait. Le mock était posé au-dessus de tout ce qui méritait d'être testé.

## Ce que les tests vérifient maintenant

`httpx.HTTPTransport.handle_request` est patchée le temps du test. Le **vrai code du SDK s'exécute** — sérialisation, URL, header d'authentification, parsing de la réponse — et les assertions portent sur la requête HTTP que Brevo reçoit réellement :

```
POST https://api.brevo.com/v3/smtp/email
api-key: <clé>
{"sender": {...}, "to": [{"email": ...}], "subject": ..., "htmlContent": "<p>Hello</p>"}
```

Noter le `htmlContent` en camelCase : c'est exactement le genre de champ qu'un `MagicMock` ne pouvait pas vérifier. La requête observée et le corps `201 {"messageId": ...}` ont été **capturés depuis le SDK lui-même**, pas devinés.

## Pourquoi pas d'injection de transport

Une première version passait par une couture `build_transport()` dans `app/mail.py`, pour injecter un `httpx.MockTransport`. L'argument avancé était qu'un test oubliant la fixture recevrait alors un transport visiblement réel plutôt que de partir sur le réseau. **Ce raisonnement était faux** : `build_transport()` renvoie un vrai `HTTPTransport`, donc un oubli atteint le réseau dans les deux cas. La couture ne garantissait rien et mettait du code de test en production. Elle est supprimée.

Les deux approches interceptent d'ailleurs au même endroit : `MockTransport` **est** une classe dont `handle_request` appelle votre fonction.

Sur la portée du patch : pytest l'annule au teardown de chaque test, rien ne fuit sur le reste de la suite ; et `TestClient` de FastAPI utilise son propre `_TestClientTransport`, donc les tests d'API ne croisent jamais celui-ci.

## Chaque test a été muté pour vérifier qu'il mord

| Mutation introduite | Résultat |
| --- | --- |
| `subject="oops"` au lieu du sujet transmis | ❌ échoue |
| `api_key="wrong-key"` | ❌ échoue |
| `timeout=` retiré du client httpx | ❌ échoue |
| `except Exception` restreint à `except ApiError` | ❌ échoue |

Les quatre mutations font tomber la suite. C'était le point de la manœuvre : des tests qui ne détectent rien sont pires qu'absents.

## Chemins d'échec couverts par de vraies réponses

Un **400** portant le corps d'erreur de Brevo, un **timeout** au niveau transport, et un **201 dont le corps n'est pas du JSON** — ce dernier étant le cas `ParsingError` qui avait motivé l'élargissement du `except` dans #33, et qui n'était jusqu'ici couvert par rien de réaliste.

## Vérifications

`30 passed`, couverture **100 %** (`app/mail.py` 17/17), ruff propre.

## Limite connue

Rien n'empêche structurellement un futur test d'oublier la fixture et de partir sur le réseau — ni cette version, ni celle avec la couture. Seule une lib comme `pytest-httpx` ou `respx`, qui échoue explicitement sur une requête non mockée, apporterait cette garantie. À arbitrer séparément.

## Ce que ça ne remplace pas

Ces tests valident **notre** requête, pas le comportement de Brevo. Pour ça il faudra un appel réel en mode sandbox (`X-Sib-Sandbox: drop`), qui valide authentification, structure du payload et **configuration de l'expéditeur** sans rien délivrer — c'est le seul moyen d'attraper le point 3 de ta revue de #33, l'expéditeur non validé. Hors suite, dans une cible dédiée, quand l'expéditeur réel existera.