### PR TITLE
Require a regression test for every reproduced bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Backend Django du projet Tout Pris. Soit extrêmement concis.
 - Lance uniquement les tests pertinents, pas toute la suite
 - Lance toute la suite (`uv run pytest`) une fois que tu penses avoir fini
 - Utilise la TDD quand c'est pertinent, demande si nécessaire
+- Tout bug que tu parviens à reproduire devient un cas de test **avant** d'être corrigé : le test doit d'abord échouer sur le bug, puis passer avec le correctif, et il reste dans la suite. C'est à la fois le garde-fou anti-régression et la documentation du bug — une reproduction dans un script jetable ne laisse aucune trace
+- Le nom du test décrit le comportement attendu, pas le numéro de l'issue : c'est lui qu'on lira le jour où il repassera au rouge
 - Django crée une base de test isolée : ne touche jamais à la base de dev dans les tests
 - Couverture de 100 % exigée sur le code applicatif (pytest-cov, seuil dans `pyproject.toml`) : `uv run pytest` échoue en dessous, en local comme en CI
 


### PR DESCRIPTION
Deux lignes dans la section « Tests » du `CLAUDE.md`.

## La règle

> Tout bug que tu parviens à reproduire devient un cas de test **avant** d'être corrigé : le test doit d'abord échouer sur le bug, puis passer avec le correctif, et il reste dans la suite.

Et son corollaire de nommage : le nom du test décrit le comportement attendu, pas le numéro de l'issue — c'est lui qu'on lira le jour où il repassera au rouge.

## Pourquoi

Un bug reproduit dans un script jetable ne laisse rien derrière lui : la personne suivante n'a aucun moyen de savoir que le piège a existé, et rien n'empêche le correctif d'être défait. Voir le test échouer **d'abord** est ce qui prouve qu'il teste le bug et non la formulation de son assertion — un test écrit après coup peut très bien passer pour de mauvaises raisons.

## Vérifié plutôt qu'affirmé

La règle a été appliquée rétroactivement au bug qui l'a motivée — deux comptes créés pour un même email écrit dans une casse différente — en annulant son correctif :

```
FAILED test_register_rejects_an_email_already_taken_in_another_case
FAILED test_register_lowercases_the_stored_email
FAILED test_login_ignores_the_case_of_the_email
3 failed, 24 passed
```

Correctif restauré : `27 passed`. Les trois tests mordaient réellement — mais ça a été constaté après coup, ce que la règle interdit désormais.

## Note

Cette PR est antérieure à la migration vers Django et vient d'être rebasée sur `main`. Le bug cité en exemple appartient à la pile FastAPI abandonnée, ce qui ne retire rien à la règle : elle ne dépend d'aucun framework. La résolution du conflit n'a gardé que les deux lignes nouvelles, les autres ayant été corrigées entre-temps par la migration — le diff face à `main` est exactement de deux lignes ajoutées.