### PR TITLE
Ignore the agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 *.db-*
 .env
 staticfiles/
+.claude/worktrees/


### PR DESCRIPTION
Une ligne dans `.gitignore`.

Claude Code crée un worktree git par agent de fond, sous `.claude/worktrees/`. C'est de l'échafaudage — une copie de travail d'une branche qui existe déjà sur le distant — et le committer reviendrait à committer une copie du dépôt dans lui-même.

Sans cette ligne, le répertoire apparaît en non suivi à chaque agent lancé, ce qui déclenche une alerte à chaque tour et noie les vrais fichiers oubliés. Un garde-fou qui crie tout le temps ne garde plus rien.

Le reste de `.claude/` reste suivi : `skills/` et `settings.json` sont de la configuration de projet et ont leur place dans le dépôt.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RBNgfdm8tutduveKxWnYL)_