### PR TITLE
Read the development emails in Mailpit, or on the console

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ __pycache__
 .ruff_cache
 *.egg-info
 .python-version
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# Copy to .env, which git ignores. docker compose reads it automatically.
+
+# Database, parsed by dj-database-url.
+DATABASE_URL=sqlite:///tout_pris.db
+
+# Django secret key. Mandatory in production, where a key starting with
+# django-insecure- is refused.
+DJANGO_SECRET_KEY=django-insecure-development-only-secret-key
+
+# Debug mode. Never true in production.
+DJANGO_DEBUG=true
+
+# Comma-separated list of allowed hosts.
+DJANGO_ALLOWED_HOSTS=*
+
+# Base URL of the Svelte front. The email links point to it.
+FRONTEND_URL=http://localhost:5173
+
+# Brevo API key. Set it and every email goes through Brevo, in development too.
+BREVO_API_KEY=
+
+# SMTP collector, used only when BREVO_API_KEY is empty. docker compose already
+# points the api service at the mailpit service, so leave this empty unless you
+# run the server on the host and start mailpit yourself.
+EMAIL_HOST=
+EMAIL_PORT=1025
+
+# Sender of the transactional emails. The address must be validated in Brevo.
+MAIL_FROM_EMAIL=no-reply@tout-pris.app
+MAIL_FROM_NAME=Tout Pris

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           DJANGO_DEBUG: "false"
           DJANGO_SECRET_KEY: ci-only-secret-key-long-enough-to-satisfy-the-deployment-checks
           DJANGO_ALLOWED_HOSTS: tout-pris.example
+          BREVO_API_KEY: ci-only-brevo-key
 
       - run: uv run python manage.py spectacular --file openapi.yaml
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Backend Django du projet Tout Pris. Soit extrêmement concis.
 - Dépendances gérées par uv (`uv sync`, groupe `dev` dans `pyproject.toml`, lock dans `uv.lock`)
 - pytest-django pour les tests, ruff pour lint et format
 - Docker + docker compose, devcontainer basé sur le service `api`
+- Le mailer est choisi dans `settings.py` : clé Brevo, Brevo ; hôte SMTP, ce serveur (Mailpit en dev) ; ni l'un ni l'autre, la console. La branche console garantit que le lien de vérification est lisible sans aucune configuration. Les variables s'appellent `EMAIL_HOST` et `EMAIL_PORT` mais sont stockées en minuscules : Django refuse de démarrer si ces deux *settings* existent à côté de `MAILERS`
 - Deux Dockerfiles (pratiques uv officielles) : `Dockerfile` dev (uv, deps dev, `runserver`, monté sur `/app`), `Dockerfile.prod` multistage (image finale sans uv ni pip, non-root, gunicorn, base dans le volume `/data`)
 
 ## Structure
@@ -34,6 +35,7 @@ Backend Django du projet Tout Pris. Soit extrêmement concis.
 - `tout_pris/urls.py` : URLconf racine, admin sur `/admin/`, API sur `/api/`, schéma et doc servis par drf-spectacular
 - `tout_pris/views.py` : vues DRF du projet, dont `/api/health/`
 - `tout_pris/mail.py` : envoi transactionnel via Brevo, exposé comme mailer Django
+- `.env.example` : toutes les variables d'environnement avec une valeur de développement
 - `accounts/` : app du `User` custom, référencé par `AUTH_USER_MODEL` dès la migration initiale
 - `households/` : app du domaine foyer — `Household`, `HouseholdMember`, `Person` — son admin, la création implicite du foyer à l'inscription, et la commande `seed`
 - `tests/` : suite pytest-django, une base de test isolée fournie par Django
@@ -57,6 +59,7 @@ Backend Django du projet Tout Pris. Soit extrêmement concis.
 - `uv run python manage.py spectacular --file openapi.yaml` : régénère `openapi.yaml` (obligatoire après tout changement de routes ou de schémas, la CI vérifie qu'il est à jour)
 - `npx markdownlint-cli2 "**/*.md"` : lint markdown, comme la CI
 - `docker compose -f docker-compose.prod.yml up -d` : image de production
+- Mailpit est démarré par `docker compose up` : les emails de dev se lisent sur <http://localhost:8025>, c'est là qu'on clique le lien de vérification
 
 ## Sans Docker (fallback)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ uv run python manage.py graph_models accounts households --no-inheritance --excl
 
 Rendering needs the `dot` binary from graphviz — installed in the dev image, therefore in the devcontainer too, and `apt install graphviz` or `brew install graphviz` on a host running without Docker.
 
-**Nothing checks that the image still matches the models.** Regenerate it by hand after a model change, in the same pull request as the migration. CI deliberately stays out of it: the intermediate `.dot` carries its generation timestamp in a header comment, and the rendered image depends on the graphviz version, so a drift check would fail on runs where no model has moved. The `openapi.yaml` check is a different story and stays in place — that file is deterministic.
+CI regenerates the intermediate `docs/model/schema.dot` and fails if it drifts from the models. Its only unstable line is the `// Created:` timestamp, stripped by the `grep -v` above, so the committed file carries none. **The image itself is not checked**, because two versions of graphviz render the same schema differently: regenerate it by hand after a model change, in the same pull request as the migration, or it silently falls behind the `.dot`.
 
 The diagram shows field names and types, never the `help_text` descriptions. They keep serving the admin and the generated OpenAPI, but the schema documentation no longer displays them.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker compose up -d   # start the API on http://localhost:8000 (docs at /api/do
 docker compose down    # stop it
 ```
 
-Migrations are applied by the container entrypoint on every start, so the database is always up to date.
+Migrations are applied by the container entrypoint on every start, so the database is always up to date. Alongside the API, compose starts [Mailpit](https://mailpit.axllent.org) on <http://localhost:8025>: every email the application sends lands there, rendered, with its links clickable. That is where a signup is completed in development.
 
 ## Commands
 
@@ -26,6 +26,7 @@ docker compose up -d              # start the API in the background
 docker compose down               # stop it
 docker compose logs -f api        # follow the API logs
 docker compose exec api sh        # open a shell in the running container
+docker compose logs -f mailpit    # follow the mail collector logs
 ```
 
 ### Server
@@ -128,7 +129,7 @@ The diagram shows field names and types, never the `help_text` descriptions. The
 
 ## Configuration
 
-Settings are read from the environment.
+Settings are read from the environment. [`.env.example`](.env.example) lists every variable with a development value — copy it to `.env`, which git ignores and docker compose reads on its own.
 
 | Variable | Default | Role |
 | --- | --- | --- |
@@ -137,7 +138,9 @@ Settings are read from the environment.
 | `DJANGO_DEBUG` | `true` | Debug mode. Set it to `false` in production. |
 | `DJANGO_ALLOWED_HOSTS` | `*` | Comma-separated list of allowed hosts. |
 | `FRONTEND_URL` | `http://localhost:5173` | Base URL of the Svelte front, used to build the email verification and password reset links. |
-| `BREVO_API_KEY` | empty | Brevo API key. When empty, `send_email` logs the subject and the recipient, and sends nothing: that is the dev and test mode, no network call is ever made. |
+| `BREVO_API_KEY` | empty | Brevo API key. When set, every email goes through Brevo, in development too. Mandatory in production. |
+| `EMAIL_HOST` | empty | SMTP host the emails go to when `BREVO_API_KEY` is empty. Compose sets it to `mailpit`. |
+| `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
 
@@ -147,7 +150,21 @@ The Brevo key and the Django secret key are secrets: never commit them, pass the
 
 Transactional emails (email verification, password reset, account notifications) are sent through [Brevo](https://developers.brevo.com) with the synchronous `brevo-python` client, from `tout_pris/mail.py`.
 
-`BrevoEmailBackend` exposes it as a Django mailer (`MAILERS["default"]`), so django-allauth and any other application code send mail through `django.core.mail` without knowing about Brevo. Tests never reach the network: Django swaps the mailer for its in-memory one.
+`BrevoEmailBackend` exposes it as a Django mailer, so django-allauth and any other application code send mail through `django.core.mail` without knowing about Brevo.
+
+Which mailer `MAILERS["default"]` holds is decided in `settings.py` from the environment, and reads out loud: a real key, Brevo; an SMTP host, that host; neither, the console.
+
+| Context | Mailer | Where the email is read |
+| --- | --- | --- |
+| Tests | in-memory, imposed by Django | `django.core.mail.outbox` |
+| Development with docker | SMTP to Mailpit | the web interface on <http://localhost:8025> |
+| Development with a Brevo key | Brevo | the real inbox |
+| Off docker, CI, agent | console | standard output |
+| Production | Brevo | — |
+
+The console branch is what makes the verification link readable with no configuration at all, so a fresh clone can complete a signup. It is a development branch only: Django's deployment checks reject the console mailer once `DJANGO_DEBUG` is off, so a production start without a Brevo key fails loudly instead of printing the emails into the logs. Tests never reach the network whatever the environment holds: Django swaps every mailer for its in-memory one.
+
+The environment variables are named `EMAIL_HOST` and `EMAIL_PORT`, but `settings.py` stores them in lowercase names: Django refuses to start when those two settings are defined next to `MAILERS`, since they are the deprecated way of configuring the same thing.
 
 ## Production image
 
@@ -163,6 +180,7 @@ The production settings live in `docker-compose.prod.yml`: the database is store
 - `tout_pris/` — project package: `settings.py`, `urls.py` (admin, and the API mounted on `/api/`), `views.py`, `mail.py`, `wsgi.py`, `asgi.py`
 - `accounts/` — the custom `User` model, referenced by `AUTH_USER_MODEL` since the initial migration
 - `households/` — the household domain: `Household`, `HouseholdMember` and `Person`, their admin, the implicit creation of a household at signup, and the `seed` command
+- `.env.example` — every environment variable with a development value
 - `tests/` — pytest-django test suite
 - `docs/api/` — the API conventions: status codes, household scoping, schemas, collections
 - `docs/model/` — the functional need behind the data model, independent of the framework, and the generated schema diagram

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ uv run python manage.py graph_models accounts households --no-inheritance --excl
 
 Rendering needs the `dot` binary from graphviz — installed in the dev image, therefore in the devcontainer too, and `apt install graphviz` or `brew install graphviz` on a host running without Docker.
 
-CI regenerates the intermediate `docs/model/schema.dot` and fails if it drifts from the models. Its only unstable line is the `// Created:` timestamp, stripped by the `grep -v` above, so the committed file carries none. **The image itself is not checked**, because two versions of graphviz render the same schema differently: regenerate it by hand after a model change, in the same pull request as the migration, or it silently falls behind the `.dot`.
+CI regenerates the intermediate `docs/model/schema.dot` and fails if it drifts from the models. Its only unstable line is the `// Created:` timestamp, stripped by the `grep -v` above, so the committed file carries none. **The image itself is not checked**, because two versions of graphviz render the same schema differently.
+
+So the `.dot` is the reference: it is the file CI compares to the models, and when the two disagree the image is the stale one. The two commands above are one gesture, not two — run them together after a model change, in the same pull request as the migration, or the diagram the README displays quietly falls behind the schema it claims to draw.
 
 The diagram shows field names and types, never the `help_text` descriptions. They keep serving the admin and the generated OpenAPI, but the schema documentation no longer displays them.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@ services:
       DJANGO_DEBUG: "false"
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:?set a secret key}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:?set the domains that serve the API}
-      BREVO_API_KEY: ${BREVO_API_KEY:-}
+      BREVO_API_KEY: ${BREVO_API_KEY:?set the Brevo key, without it the emails are only printed}
       MAIL_FROM_EMAIL: ${MAIL_FROM_EMAIL:-no-reply@tout-pris.app}
       MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Tout Pris}
       FRONTEND_URL: ${FRONTEND_URL:?set the public URL of the front, it is what the email links point to}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,10 @@ services:
       MAIL_FROM_EMAIL: ${MAIL_FROM_EMAIL:-no-reply@tout-pris.app}
       MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Tout Pris}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+      EMAIL_HOST: mailpit
+      EMAIL_PORT: "1025"
+
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "8025:8025"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -46,3 +46,26 @@ def test_development_leaves_the_transport_settings_alone(monkeypatch):
     settings = load_settings(monkeypatch, DJANGO_DEBUG="true")
 
     assert not hasattr(settings, "SECURE_SSL_REDIRECT")
+
+
+def test_a_brevo_key_sends_the_emails_through_brevo(monkeypatch):
+    settings = load_settings(monkeypatch, BREVO_API_KEY="a-real-key", EMAIL_HOST="mailpit")
+
+    assert settings.MAILERS["default"]["BACKEND"] == "tout_pris.mail.BrevoEmailBackend"
+
+
+def test_an_smtp_host_sends_the_emails_to_the_local_collector(monkeypatch):
+    settings = load_settings(monkeypatch, BREVO_API_KEY="", EMAIL_HOST="mailpit", EMAIL_PORT="1025")
+
+    assert settings.MAILERS["default"] == {
+        "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+        "OPTIONS": {"host": "mailpit", "port": 1025},
+    }
+
+
+def test_without_any_mail_configuration_the_emails_are_printed(monkeypatch):
+    settings = load_settings(monkeypatch, BREVO_API_KEY="", EMAIL_HOST="")
+
+    assert (
+        settings.MAILERS["default"]["BACKEND"] == "django.core.mail.backends.console.EmailBackend"
+    )

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -124,9 +124,23 @@ HEADLESS_FRONTEND_URLS = {
     "account_signup": f"{FRONTEND_URL}/account/signup",
 }
 
-MAILERS = {"default": {"BACKEND": "tout_pris.mail.BrevoEmailBackend"}}
-
 BREVO_API_KEY = os.environ.get("BREVO_API_KEY", "")
+
+smtp_host = os.environ.get("EMAIL_HOST", "")
+
+smtp_port = int(os.environ.get("EMAIL_PORT", "1025"))
+
+if BREVO_API_KEY:
+    MAILERS = {"default": {"BACKEND": "tout_pris.mail.BrevoEmailBackend"}}
+elif smtp_host:
+    MAILERS = {
+        "default": {
+            "BACKEND": "django.core.mail.backends.smtp.EmailBackend",
+            "OPTIONS": {"host": smtp_host, "port": smtp_port},
+        }
+    }
+else:
+    MAILERS = {"default": {"BACKEND": "django.core.mail.backends.console.EmailBackend"}}
 
 MAIL_FROM_EMAIL = os.environ.get("MAIL_FROM_EMAIL", "no-reply@tout-pris.app")
 


### PR DESCRIPTION
Closes #48

## Ce que ça change

Le mailer est choisi dans `settings.py` depuis l'environnement, et la règle se lit à voix haute : vraie clé Brevo, Brevo ; hôte SMTP, ce serveur ; ni l'un ni l'autre, la console.

| Contexte | Mailer | Où l'on lit l'email |
| --- | --- | --- |
| Tests | mémoire, imposé par Django | `django.core.mail.outbox` |
| Développement avec docker | SMTP vers Mailpit | l'interface web sur le port 8025 |
| Développement avec une clé Brevo | Brevo | la vraie boîte |
| Hors docker, CI, agent | console | sortie standard |
| Production | Brevo | — |

Mailpit est ajouté au compose de développement et le service `api` pointe dessus. C'est bien un conteneur de plus au démarrage : image `axllent/mailpit`, pas de volume, pas de configuration, un port publié. `.env.example` liste les dix variables d'environnement que le code lit, avec une valeur de développement ; `.env` reste ignoré par git et rejoint `.dockerignore`.

## Vérifié de bout en bout

Une inscription complète sans aucune configuration, sur une base jetable :

- `POST /auth/signup` imprime l'email de confirmation, lien inclus
- la clé extraite de cette sortie fait répondre `200` à `POST /auth/email/verify`
- la réponse porte l'utilisateur authentifié, et le foyer implicite a bien été créé

## Deux choses trouvées en route

**Django refuse `EMAIL_HOST` et `EMAIL_PORT` comme settings dès que `MAILERS` est défini** — ce sont les noms dépréciés de la même configuration. Les variables d'environnement gardent ces noms, `settings.py` les stocke en minuscules. C'est écrit dans le README et dans le CLAUDE.md, parce que le prochain qui essaiera de les remonter en majuscules perdra un moment.

**`check --deploy` rejette le mailer console dès que `DEBUG` est à `false`.** La garde que je cherchais existait déjà dans le framework : une production sans clé Brevo ne peut plus imprimer les emails dans les logs, elle refuse de démarrer. L'étape de déploiement de la CI reçoit donc une clé factice, et `docker-compose.prod.yml` exige une vraie clé au lieu de laisser la variable vide par défaut.

## Suite de la relecture

- **Le `.dot` fait foi.** Le README le dit maintenant noir sur blanc : c'est le fichier que la CI compare aux modèles, donc quand les deux divergent c'est l'image qui est périmée, et les deux commandes sont un seul geste. Le trou relevé était réel — un `.dot` à jour à côté d'une image périmée passe la CI, et c'est l'image que le README affiche.
- **Onze variables annoncées, dix réellement.** C'était la prose qui comptait mal, pas le fichier. Corrigé ici et dans le message de commit, qui portait la même erreur.

## Deux commits hors sujet, assumés

Le premier et le dernier corrigent la documentation du diagramme de schéma : le README affirmait encore que la CI ne le contrôle pas, et ne disait pas lequel du `.dot` ou du PNG fait foi. Séparés du reste.

## Hors périmètre

Le câblage de `FRONTEND_URL` dans les composes est déjà en place ; `GOOGLE_OAUTH_CLIENT_ID` et `GOOGLE_OAUTH_SECRET` n'existent plus depuis que #45 a cessé de configurer un fournisseur que personne n'a créé, donc `.env.example` ne les invente pas.

## Contrôles

`ruff check` et `ruff format --check` propres, `markdownlint` propre, `manage.py check` et `check --deploy` propres, `openapi.yaml` et `docs/model/schema.dot` sans dérive, 60 tests, couverture 100 %.