### PR TITLE
Expose persons, members and shared households

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 
 - `GET /api/health` — health check
 - `GET /api/households/` — the households the caller belongs to, their personal one first
+- `POST /api/households/` — create a shared household, joined as its owner
+- `/api/households/{household_id}/` — rename or delete a shared household
+- `/api/households/{household_id}/persons/` — the people of a household, created, renamed and deleted
+- `/api/households/{household_id}/members/` — who has access to a shared household, and removing one of them
 - `/api/households/{household_id}/invitations/` — invite an address into a shared household, list the pending invitations, cancel one
 - `POST /api/invitations/accept/` — join a household with the token received by email
 - `/api/auth/browser/v1/` — headless authentication: signup, login, session, email verification, password reset, external providers

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,9 +23,35 @@ Le porteur de cette règle est `HouseholdScopedView`, dont dérivent les vues du
 
 Les routes du domaine sont donc portées par le chemin du foyer — `/api/households/{household_id}/persons`, `/api/households/{household_id}/trips` — et le cloisonnement est appliqué une fois pour toutes par la couche qui résout le foyer courant, jamais réécrit dans chaque route.
 
-Cette règle n'a pas encore de porteur dans le code : `GET /api/households/` est la première route du domaine, et elle n'est imbriquée sous aucun foyer. Elle s'applique dès la première ressource qui l'est.
+Les foyers eux-mêmes échappent à cette imbrication : `/api/households/` est la racine du domaine, et sa collection est cloisonnée par l'appartenance de l'appelant plutôt que par un foyer de chemin.
+
+## Foyers
 
 `GET /api/households/` liste les foyers dont l'appelant est membre : son foyer personnel et ceux qu'on lui a partagés. C'est l'écran de sélection décrit dans [`docs/model/household.md`](../model/household.md). Chaque entrée porte `personal`, un booléen, plutôt qu'un nom à afficher pour le foyer personnel : ce nom existe en base pour l'admin, et l'interface écrit « Personnel ».
+
+`POST /api/households/` crée un foyer partagé et répond `201`. Le créateur y est inscrit comme membre `owner` et la `Person` qui le représente est créée dans la même transaction, exactement comme l'inscription le fait pour le foyer personnel : sans elle, il serait membre d'un foyer où il n'existe pour personne. Le corps ne porte que le nom — un foyer personnel ne se crée qu'à l'inscription, et aucun client ne désigne son `personal_of`.
+
+C'est cette route qui débloque le partage : inviter exige un foyer partagé, et rien d'autre n'en produit.
+
+`PATCH` et `DELETE /api/households/{household_id}/` renomment et suppriment un foyer partagé, et supprimer emporte ses membres, ses personnes et ses invitations. Le foyer personnel répond `404` sur les deux : son nom n'est jamais affiché, donc jamais renommé, et il ne disparaît qu'avec le compte dont il est l'espace privé.
+
+## Personnes
+
+CRUD complet sous le foyer : `GET` et `POST /api/households/{household_id}/persons/`, puis `GET`, `PATCH` et `DELETE /api/households/{household_id}/persons/{id}/`. Tous les foyers en ont, le foyer personnel compris.
+
+Le corps ne porte que le nom. Le compte lié est en lecture seule dans le schéma : il est rempli par l'inscription ou par l'acceptation d'une invitation, jamais par un client qui désignerait un compte à rattacher.
+
+Supprimer une personne dont le compte est encore membre du foyer répond `409` : ça retirerait sa représentation à quelqu'un qui a toujours accès, et chaque écran « pour qui » se retrouverait sans lui. Retirer le membre d'abord délie la personne et rend sa suppression possible.
+
+## Membres
+
+`GET /api/households/{household_id}/members/` liste qui a accès au foyer, avec l'adresse et le rôle de chaque compte. `DELETE /api/households/{household_id}/members/{id}/` retire un membre ; se retirer soi-même, c'est quitter le foyer, il n'y a pas de route « quitter » distincte pour la même écriture.
+
+Retirer un membre **conserve sa `Person` et vide son compte**, comme le fait déjà la suppression d'un compte. `Person.user` pointe vers un compte et non vers une appartenance : le laisser rempli rattacherait un non-membre à une personne du foyer. Les affaires de « Papa » restent dans les listes, seul le lien vers le compte disparaît.
+
+Le dernier membre ne peut pas quitter un foyer partagé : la route répond `409`. Le laisser partir abandonnerait en base un foyer que plus personne ne peut ni lire ni supprimer, avec ses personnes et ses futures listes ; supprimer le foyer d'un `DELETE` explicite dit ce que ça détruit, et évite de le détruire par accident en quittant.
+
+Comme pour les invitations, un foyer personnel répond `404` sur ces deux routes, y compris à son propriétaire : la collection n'existe pas, il n'a pas d'autre membre possible que lui.
 
 ## Invitations
 
@@ -54,6 +80,8 @@ Rien du corps ne porte d'identité : les identifiants de ressource viennent du c
 ## Écriture partielle
 
 `PATCH`, pas `PUT`. Le client édite un champ à la fois ; un `PUT` l'obligerait à réémettre une représentation complète, donc à écraser des champs qu'il ne connaît pas. Un champ absent et un `null` explicite laissent tous deux la valeur inchangée, et un corps vide est une requête valide sans effet.
+
+La règle est portée par `PartialWriteSerializer`, dont dérivent les serializers `XUpdate` : il retire du corps les champs à `null` avant la validation, plutôt que de laisser chaque route s'en souvenir.
 
 ## Collections
 

--- a/docs/model/household.md
+++ b/docs/model/household.md
@@ -66,7 +66,17 @@ Le membre créé porte le rôle `owner`. Aucun droit n'en découle aujourd'hui �
 
 La vérification de l'adresse email est obligatoire et intervient **après** cette création : le compte, son foyer et sa personne existent dès l'inscription, alors que la session ne s'ouvre qu'une fois l'adresse confirmée. Un compte jamais confirmé laisse donc un foyer vide en base, sans aucune conséquence fonctionnelle.
 
-Le second membre d'un foyer partagé arrive par l'invitation, qui reste à construire. Un foyer personnel, lui, n'en a jamais qu'un.
+Le second membre d'un foyer partagé arrive par l'invitation. Un foyer personnel, lui, n'en a jamais qu'un.
+
+## Cycle de vie d'un foyer partagé
+
+Un foyer partagé se crée à la demande, et son créateur y entre par le même chemin qu'un compte dans son foyer personnel : le foyer, l'appartenance `owner` et la personne qui le représente sont écrits dans la même transaction. C'est la seule création de foyer que l'API expose ; le foyer personnel, lui, n'est créé que par l'inscription.
+
+On le quitte en retirant son appartenance, et retirer celle de quelqu'un d'autre est la même écriture — aucun droit ne les distingue tant que le rôle ne porte rien.
+
+Le retrait **délie la personne sans la supprimer** : son `user` retombe à `NULL` et elle reste dans le foyer, exactement comme lors de la suppression d'un compte. La différence est que l'ORM ne peut rien en dire ici, il n'y a pas de ligne supprimée dont une clé étrangère dépendrait : c'est le code du retrait qui délie, et un test qui le garde.
+
+Le dernier membre ne peut pas partir. Un foyer partagé sans membre ne serait plus lisible par personne, et ses personnes comme ses futures listes resteraient en base sans porte d'entrée ; supprimer le foyer reste possible et dit clairement ce qu'il emporte.
 
 ## Suppressions
 

--- a/households/invitations.py
+++ b/households/invitations.py
@@ -8,8 +8,8 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from accounts.models import User
+from households.memberships import display_name_of
 from households.models import HouseholdMember, Invitation, Person
-from households.signals import display_name_of
 
 
 def hashed(token):

--- a/households/memberships.py
+++ b/households/memberships.py
@@ -1,0 +1,21 @@
+from django.db import transaction
+
+from households.models import Household, HouseholdMember, HouseholdRole, Person
+
+
+def display_name_of(user):
+    return user.get_full_name().strip() or user.email.partition("@")[0]
+
+
+@transaction.atomic
+def create_household(name, owner, personal_of=None):
+    household = Household.objects.create(name=name, personal_of=personal_of)
+    HouseholdMember.objects.create(household=household, user=owner, role=HouseholdRole.OWNER)
+    Person.objects.create(household=household, user=owner, name=display_name_of(owner))
+    return household
+
+
+@transaction.atomic
+def remove_member(member):
+    Person.objects.filter(household=member.household_id, user=member.user_id).update(user=None)
+    member.delete()

--- a/households/serializers.py
+++ b/households/serializers.py
@@ -1,7 +1,14 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from households.models import Household, Invitation
+from households.models import Household, HouseholdMember, Invitation, Person
+
+
+class PartialWriteSerializer(serializers.ModelSerializer):
+    def to_internal_value(self, data):
+        return super().to_internal_value(
+            {field: value for field, value in data.items() if value is not None}
+        )
 
 
 class HouseholdSerializer(serializers.ModelSerializer):
@@ -14,6 +21,46 @@ class HouseholdSerializer(serializers.ModelSerializer):
     @extend_schema_field(serializers.BooleanField)
     def get_personal(self, household):
         return household.personal_of_id is not None
+
+
+class HouseholdCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Household
+        fields = ["name"]
+
+
+class HouseholdUpdateSerializer(PartialWriteSerializer):
+    class Meta:
+        model = Household
+        fields = ["name"]
+
+
+class PersonSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Person
+        fields = ["id", "name", "user"]
+        read_only_fields = ["user"]
+
+
+class PersonCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Person
+        fields = ["name"]
+
+
+class PersonUpdateSerializer(PartialWriteSerializer):
+    class Meta:
+        model = Person
+        fields = ["name"]
+
+
+class MemberSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField(source="user.email", read_only=True)
+
+    class Meta:
+        model = HouseholdMember
+        fields = ["id", "user", "email", "role"]
+        read_only_fields = ["user", "role"]
 
 
 class InvitationSerializer(serializers.ModelSerializer):

--- a/households/serializers.py
+++ b/households/serializers.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -6,9 +8,9 @@ from households.models import Household, HouseholdMember, Invitation, Person
 
 class PartialWriteSerializer(serializers.ModelSerializer):
     def to_internal_value(self, data):
-        return super().to_internal_value(
-            {field: value for field, value in data.items() if value is not None}
-        )
+        if isinstance(data, Mapping):
+            data = {field: value for field, value in data.items() if value is not None}
+        return super().to_internal_value(data)
 
 
 class HouseholdSerializer(serializers.ModelSerializer):

--- a/households/signals.py
+++ b/households/signals.py
@@ -1,18 +1,9 @@
 from allauth.account.signals import user_signed_up
-from django.db import transaction
 from django.dispatch import receiver
 
-from households.models import Household, HouseholdMember, HouseholdRole, Person
+from households.memberships import create_household, display_name_of
 
 
 @receiver(user_signed_up)
-@transaction.atomic
 def create_household_for_new_account(sender, request, user, **kwargs):
-    display_name = display_name_of(user)
-    household = Household.objects.create(name=display_name, personal_of=user)
-    HouseholdMember.objects.create(household=household, user=user, role=HouseholdRole.OWNER)
-    Person.objects.create(household=household, user=user, name=display_name)
-
-
-def display_name_of(user):
-    return user.get_full_name().strip() or user.email.partition("@")[0]
+    create_household(display_name_of(user), user, personal_of=user)

--- a/households/urls.py
+++ b/households/urls.py
@@ -1,14 +1,32 @@
 from django.urls import path
 
 from households.views import (
-    HouseholdListView,
+    HouseholdDetailView,
+    HouseholdListCreateView,
     InvitationAcceptView,
     InvitationDestroyView,
     InvitationListCreateView,
+    MemberDestroyView,
+    MemberListView,
+    PersonDetailView,
+    PersonListCreateView,
 )
 
 urlpatterns = [
-    path("households/", HouseholdListView.as_view(), name="households"),
+    path("households/", HouseholdListCreateView.as_view(), name="households"),
+    path("households/<int:household_id>/", HouseholdDetailView.as_view(), name="household"),
+    path("households/<int:household_id>/persons/", PersonListCreateView.as_view(), name="persons"),
+    path(
+        "households/<int:household_id>/persons/<int:pk>/",
+        PersonDetailView.as_view(),
+        name="person",
+    ),
+    path("households/<int:household_id>/members/", MemberListView.as_view(), name="members"),
+    path(
+        "households/<int:household_id>/members/<int:pk>/",
+        MemberDestroyView.as_view(),
+        name="member",
+    ),
     path(
         "households/<int:household_id>/invitations/",
         InvitationListCreateView.as_view(),

--- a/households/views.py
+++ b/households/views.py
@@ -3,24 +3,40 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.functional import cached_property
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import generics
+from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from households.invitations import accept, invite, pending_invitation
+from households.memberships import create_household, remove_member
 from households.models import Household, Invitation
 from households.serializers import (
+    HouseholdCreateSerializer,
     HouseholdSerializer,
+    HouseholdUpdateSerializer,
     InvitationAcceptSerializer,
     InvitationCreateSerializer,
     InvitationSerializer,
+    MemberSerializer,
+    PersonCreateSerializer,
+    PersonSerializer,
+    PersonUpdateSerializer,
 )
 
 
-class HouseholdListView(generics.ListAPIView):
-    serializer_class = HouseholdSerializer
+class Conflict(APIException):
+    status_code = 409
+
+
+@extend_schema_view(
+    post=extend_schema(request=HouseholdCreateSerializer, responses={201: HouseholdSerializer})
+)
+class HouseholdListCreateView(generics.ListCreateAPIView):
+    def get_serializer_class(self):
+        return HouseholdCreateSerializer if self.request.method == "POST" else HouseholdSerializer
 
     def get_queryset(self):
         return (
@@ -28,6 +44,12 @@ class HouseholdListView(generics.ListAPIView):
             .alias(personal=Q(personal_of__isnull=False))
             .order_by("-personal", "created_at")
         )
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        household = create_household(serializer.validated_data["name"], request.user)
+        return Response(HouseholdSerializer(household).data, status=201)
 
 
 class HouseholdScopedView(generics.GenericAPIView):
@@ -44,6 +66,77 @@ class SharedHouseholdScopedView(HouseholdScopedView):
         return super().household_queryset().filter(personal_of__isnull=True)
 
 
+class HouseholdDetailView(SharedHouseholdScopedView):
+    serializer_class = HouseholdUpdateSerializer
+
+    @extend_schema(request=HouseholdUpdateSerializer, responses={200: HouseholdSerializer})
+    def patch(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.household, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        return Response(HouseholdSerializer(serializer.save()).data)
+
+    @extend_schema(responses={204: None})
+    def delete(self, request, *args, **kwargs):
+        self.household.delete()
+        return Response(status=204)
+
+
+@extend_schema_view(
+    post=extend_schema(request=PersonCreateSerializer, responses={201: PersonSerializer})
+)
+class PersonListCreateView(HouseholdScopedView, generics.ListCreateAPIView):
+    def get_serializer_class(self):
+        return PersonCreateSerializer if self.request.method == "POST" else PersonSerializer
+
+    def get_queryset(self):
+        return self.household.persons.order_by("id")
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        person = serializer.save(household=self.household)
+        return Response(PersonSerializer(person).data, status=201)
+
+
+class PersonDetailView(HouseholdScopedView, generics.RetrieveDestroyAPIView):
+    def get_serializer_class(self):
+        return PersonUpdateSerializer if self.request.method == "PATCH" else PersonSerializer
+
+    def get_queryset(self):
+        return self.household.persons.all()
+
+    @extend_schema(request=PersonUpdateSerializer, responses={200: PersonSerializer})
+    def patch(self, request, *args, **kwargs):
+        serializer = self.get_serializer(self.get_object(), data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        return Response(PersonSerializer(serializer.save()).data)
+
+    def perform_destroy(self, person):
+        if person.user_id and self.household.members.filter(user=person.user_id).exists():
+            raise Conflict("A person whose account is still a member cannot be deleted.")
+        person.delete()
+
+
+class MemberListView(SharedHouseholdScopedView, generics.ListAPIView):
+    serializer_class = MemberSerializer
+
+    def get_queryset(self):
+        return self.household.members.select_related("user").order_by("id")
+
+
+class MemberDestroyView(SharedHouseholdScopedView, generics.DestroyAPIView):
+    serializer_class = MemberSerializer
+
+    def get_queryset(self):
+        return self.household.members.all()
+
+    def perform_destroy(self, member):
+        if self.household.members.count() == 1:
+            raise Conflict("The last member cannot leave, delete the household instead.")
+        remove_member(member)
+
+
+@extend_schema_view(post=extend_schema(request=InvitationCreateSerializer, responses={204: None}))
 class InvitationListCreateView(SharedHouseholdScopedView, generics.ListCreateAPIView):
     throttle_scope = "invitations"
 
@@ -61,7 +154,6 @@ class InvitationListCreateView(SharedHouseholdScopedView, generics.ListCreateAPI
             household=self.household, accepted_at=None, expires_at__gt=timezone.now()
         ).order_by("created_at")
 
-    @extend_schema(request=InvitationCreateSerializer, responses={204: None})
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/households/views.py
+++ b/households/views.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.functional import cached_property
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import generics
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response
@@ -98,6 +98,16 @@ class PersonListCreateView(HouseholdScopedView, generics.ListCreateAPIView):
         return Response(PersonSerializer(person).data, status=201)
 
 
+@extend_schema_view(
+    delete=extend_schema(
+        responses={
+            204: None,
+            409: OpenApiResponse(
+                description="The account of that person is still a member of the household."
+            ),
+        }
+    )
+)
 class PersonDetailView(HouseholdScopedView, generics.RetrieveDestroyAPIView):
     def get_serializer_class(self):
         return PersonUpdateSerializer if self.request.method == "PATCH" else PersonSerializer
@@ -124,6 +134,16 @@ class MemberListView(SharedHouseholdScopedView, generics.ListAPIView):
         return self.household.members.select_related("user").order_by("id")
 
 
+@extend_schema_view(
+    delete=extend_schema(
+        responses={
+            204: None,
+            409: OpenApiResponse(
+                description="The last member cannot leave, the household is deleted instead."
+            ),
+        }
+    )
+)
 class MemberDestroyView(SharedHouseholdScopedView, generics.DestroyAPIView):
     serializer_class = MemberSerializer
 

--- a/households/views.py
+++ b/households/views.py
@@ -139,7 +139,7 @@ class MemberListView(SharedHouseholdScopedView, generics.ListAPIView):
         responses={
             204: None,
             409: OpenApiResponse(
-                description="The last member cannot leave, the household is deleted instead."
+                description="The last member cannot leave, delete the household instead."
             ),
         }
     )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -221,7 +221,7 @@ paths:
         '204':
           description: No response body
         '409':
-          description: The last member cannot leave, the household is deleted instead.
+          description: The last member cannot leave, delete the household instead.
   /api/households/{household_id}/persons/:
     get:
       operationId: households_persons_list

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -36,6 +36,77 @@ paths:
                 items:
                   $ref: '#/components/schemas/Household'
           description: ''
+    post:
+      operationId: households_create
+      tags:
+      - households
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HouseholdCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HouseholdCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HouseholdCreate'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Household'
+          description: ''
+  /api/households/{household_id}/:
+    patch:
+      operationId: households_partial_update
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedHouseholdUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedHouseholdUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedHouseholdUpdate'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Household'
+          description: ''
+    delete:
+      operationId: households_destroy
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
   /api/households/{household_id}/invitations/:
     get:
       operationId: households_invitations_list
@@ -83,15 +154,187 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '204':
+          description: No response body
+  /api/households/{household_id}/invitations/{id}/:
+    delete:
+      operationId: households_invitations_destroy
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/households/{household_id}/members/:
+    get:
+      operationId: households_members_list
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Member'
+          description: ''
+  /api/households/{household_id}/members/{id}/:
+    delete:
+      operationId: households_members_destroy
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+  /api/households/{household_id}/persons/:
+    get:
+      operationId: households_persons_list
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Person'
+          description: ''
+    post:
+      operationId: households_persons_create
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PersonCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PersonCreate'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
         '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/InvitationCreate'
+                $ref: '#/components/schemas/Person'
           description: ''
-  /api/households/{household_id}/invitations/{id}/:
+  /api/households/{household_id}/persons/{id}/:
+    get:
+      operationId: households_persons_retrieve
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Person'
+          description: ''
+    patch:
+      operationId: households_persons_partial_update
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedPersonUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedPersonUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedPersonUpdate'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Person'
+          description: ''
     delete:
-      operationId: households_invitations_destroy
+      operationId: households_persons_destroy
       parameters:
       - in: path
         name: household_id
@@ -162,6 +405,15 @@ components:
       - id
       - name
       - personal
+    HouseholdCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name given by the members, such as their family name.
+          maxLength: 100
+      required:
+      - name
     Invitation:
       type: object
       properties:
@@ -216,6 +468,86 @@ components:
             person in.
       required:
       - email
+    Member:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        user:
+          type: integer
+          readOnly: true
+          description: Account granted access to the household, its people, its catalog
+            and its trips.
+        email:
+          type: string
+          format: email
+          readOnly: true
+        role:
+          allOf:
+          - $ref: '#/components/schemas/RoleEnum'
+          readOnly: true
+          description: |-
+            Reserved for a later differentiation of rights: every member can do everything.
+
+            * `owner` - Owner
+            * `member` - Member
+      required:
+      - email
+      - id
+      - role
+      - user
+    PatchedHouseholdUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name given by the members, such as their family name.
+          maxLength: 100
+    PatchedPersonUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name shown in every picker asking who an item is for.
+          maxLength: 100
+    Person:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          description: Display name shown in every picker asking who an item is for.
+          maxLength: 100
+        user:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: Account of the person when they have one, empty for a child
+            or a guest.
+      required:
+      - id
+      - name
+      - user
+    PersonCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Display name shown in every picker asking who an item is for.
+          maxLength: 100
+      required:
+      - name
+    RoleEnum:
+      enum:
+      - owner
+      - member
+      type: string
+      description: |-
+        * `owner` - Owner
+        * `member` - Member
   securitySchemes:
     cookieAuth:
       type: apiKey

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -220,6 +220,8 @@ paths:
       responses:
         '204':
           description: No response body
+        '409':
+          description: The last member cannot leave, the household is deleted instead.
   /api/households/{household_id}/persons/:
     get:
       operationId: households_persons_list
@@ -353,6 +355,8 @@ paths:
       responses:
         '204':
           description: No response body
+        '409':
+          description: The account of that person is still a member of the household.
   /api/invitations/accept/:
     post:
       operationId: invitations_accept_create

--- a/tests/test_households_api.py
+++ b/tests/test_households_api.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import Client
 
 from accounts.models import User
-from households.models import Household, HouseholdMember
+from households.models import Household, HouseholdMember, Person
 
 pytestmark = pytest.mark.django_db
 
@@ -70,3 +70,100 @@ def test_the_personal_household_comes_first_even_when_the_shared_one_is_older():
         ("sacha", True),
         ("Famille Martin", False),
     ]
+
+
+def household_url(household):
+    return f"{HOUSEHOLDS_URL}{household.pk}/"
+
+
+def test_creating_a_shared_household_makes_its_creator_a_member_and_a_person(camille):
+    response = signed_in(camille).post(
+        HOUSEHOLDS_URL, {"name": "Famille Martin"}, content_type="application/json"
+    )
+
+    assert response.status_code == 201
+    household = Household.objects.get(pk=response.json()["id"])
+    assert response.json() == {"id": household.pk, "name": "Famille Martin", "personal": False}
+    assert household.members.get(user=camille).role == "owner"
+    assert household.persons.get(user=camille).name == "Camille"
+
+
+def test_a_created_household_is_listed_after_the_personal_one(camille):
+    client = signed_in(camille)
+    client.post(HOUSEHOLDS_URL, {"name": "Famille Martin"}, content_type="application/json")
+
+    listed = client.get(HOUSEHOLDS_URL).json()
+
+    assert [entry["name"] for entry in listed] == ["camille", "Famille Martin"]
+
+
+def test_a_shared_household_is_renamed(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille)
+
+    response = signed_in(camille).patch(
+        household_url(shared), {"name": "Les Martin"}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"id": shared.pk, "name": "Les Martin", "personal": False}
+
+
+def test_a_rename_without_a_name_leaves_it_unchanged(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille)
+    client = signed_in(camille)
+
+    empty = client.patch(household_url(shared), {}, content_type="application/json")
+    explicit_null = client.patch(
+        household_url(shared), {"name": None}, content_type="application/json"
+    )
+
+    assert (empty.status_code, explicit_null.status_code) == (200, 200)
+    shared.refresh_from_db()
+    assert shared.name == "Famille Martin"
+
+
+def test_deleting_a_shared_household_takes_its_members_and_persons_with_it(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille)
+    Person.objects.create(household=shared, name="Jeanne")
+
+    response = signed_in(camille).delete(household_url(shared))
+
+    assert response.status_code == 204
+    assert not Household.objects.filter(pk=shared.pk).exists()
+    assert not HouseholdMember.objects.filter(household=shared.pk).exists()
+    assert not Person.objects.filter(household=shared.pk).exists()
+
+
+def test_the_personal_household_is_neither_renamed_nor_deleted(camille):
+    personal = camille.personal_household
+    client = signed_in(camille)
+
+    renamed = client.patch(
+        household_url(personal), {"name": "Chez moi"}, content_type="application/json"
+    )
+
+    assert renamed.status_code == 404
+    assert client.delete(household_url(personal)).status_code == 404
+
+
+def test_the_household_of_another_account_is_out_of_reach(camille):
+    stranger = User.objects.create_user(username="sacha", email="sacha@example.com")
+    theirs = Household.objects.create(name="Chez les autres")
+    HouseholdMember.objects.create(household=theirs, user=stranger)
+    client = signed_in(camille)
+
+    renamed = client.patch(
+        household_url(theirs), {"name": "À moi"}, content_type="application/json"
+    )
+
+    assert renamed.status_code == 404
+    assert client.delete(household_url(theirs)).status_code == 404
+
+
+def test_creating_a_household_refuses_an_unauthenticated_caller():
+    response = Client().post(HOUSEHOLDS_URL, {"name": "Famille Martin"})
+
+    assert response.status_code == 401

--- a/tests/test_households_api.py
+++ b/tests/test_households_api.py
@@ -167,3 +167,12 @@ def test_creating_a_household_refuses_an_unauthenticated_caller():
     response = Client().post(HOUSEHOLDS_URL, {"name": "Famille Martin"})
 
     assert response.status_code == 401
+
+
+def test_a_rename_whose_body_is_not_an_object_is_refused(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille)
+
+    response = signed_in(camille).patch(household_url(shared), [], content_type="application/json")
+
+    assert response.status_code == 400

--- a/tests/test_members_api.py
+++ b/tests/test_members_api.py
@@ -1,0 +1,114 @@
+import pytest
+from django.test import Client
+
+from accounts.models import User
+from households.models import Household, HouseholdMember, Person
+
+pytestmark = pytest.mark.django_db
+
+
+def members_url(household):
+    return f"/api/households/{household.pk}/members/"
+
+
+def member_url(household, member):
+    return f"{members_url(household)}{member.pk}/"
+
+
+def signed_in(user):
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def camille():
+    return User.objects.create_user(
+        username="camille", email="camille@example.com", first_name="Camille"
+    )
+
+
+@pytest.fixture
+def sacha():
+    return User.objects.create_user(username="sacha", email="sacha@example.com", first_name="Sacha")
+
+
+@pytest.fixture
+def household(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille, role="owner")
+    Person.objects.create(household=shared, user=camille, name="Camille")
+    return shared
+
+
+@pytest.fixture
+def joined(household, sacha):
+    Person.objects.create(household=household, user=sacha, name="Sacha")
+    return HouseholdMember.objects.create(household=household, user=sacha)
+
+
+@pytest.fixture
+def client(camille):
+    return signed_in(camille)
+
+
+def test_the_members_of_a_household_are_listed_with_their_address(client, household, joined):
+    listed = client.get(members_url(household)).json()
+
+    assert [(member["email"], member["role"]) for member in listed] == [
+        ("camille@example.com", "owner"),
+        ("sacha@example.com", "member"),
+    ]
+
+
+def test_removing_a_member_keeps_their_person_and_unlinks_their_account(
+    client, household, joined, sacha
+):
+    response = client.delete(member_url(household, joined))
+
+    assert response.status_code == 204
+    assert not HouseholdMember.objects.filter(pk=joined.pk).exists()
+    person = household.persons.get(name="Sacha")
+    assert person.user is None
+
+
+def test_a_member_leaves_the_household_by_removing_their_own_membership(household, joined, sacha):
+    response = signed_in(sacha).delete(member_url(household, joined))
+
+    assert response.status_code == 204
+    assert not Household.objects.filter(pk=household.pk, members__user=sacha).exists()
+
+
+def test_the_last_member_cannot_leave_and_is_told_to_delete_the_household(
+    client, household, camille
+):
+    only = household.members.get()
+
+    response = client.delete(member_url(household, only))
+
+    assert response.status_code == 409
+    assert HouseholdMember.objects.filter(pk=only.pk).exists()
+
+
+def test_the_members_of_another_household_are_out_of_reach(client):
+    stranger = User.objects.create_user(username="alex", email="alex@example.com")
+    other = Household.objects.create(name="Chez les autres")
+    theirs = HouseholdMember.objects.create(household=other, user=stranger)
+
+    assert client.get(members_url(other)).status_code == 404
+    assert client.delete(member_url(other, theirs)).status_code == 404
+
+
+def test_a_personal_household_has_no_members_to_speak_of(client, camille):
+    personal = Household.objects.create(name="camille", personal_of=camille)
+    only = HouseholdMember.objects.create(household=personal, user=camille)
+
+    assert client.get(members_url(personal)).status_code == 404
+    assert client.delete(member_url(personal, only)).status_code == 404
+
+
+def test_the_member_endpoints_refuse_an_unauthenticated_caller(household, joined):
+    anonymous = Client()
+
+    assert anonymous.get(members_url(household)).status_code == 401
+    assert anonymous.delete(member_url(household, joined)).status_code == 401

--- a/tests/test_persons_api.py
+++ b/tests/test_persons_api.py
@@ -148,3 +148,11 @@ def test_the_person_endpoints_refuse_an_unauthenticated_caller(household):
 
     assert anonymous.get(persons_url(household)).status_code == 401
     assert anonymous.post(persons_url(household), {"name": "Jeanne"}).status_code == 401
+
+
+def test_a_rename_whose_body_is_not_an_object_is_refused(client, household):
+    jeanne = Person.objects.create(household=household, name="Jeanne")
+
+    response = client.patch(person_url(household, jeanne), [], content_type="application/json")
+
+    assert response.status_code == 400

--- a/tests/test_persons_api.py
+++ b/tests/test_persons_api.py
@@ -1,0 +1,150 @@
+import pytest
+from django.test import Client
+
+from accounts.models import User
+from households.models import Household, HouseholdMember, Person
+
+pytestmark = pytest.mark.django_db
+
+
+def persons_url(household):
+    return f"/api/households/{household.pk}/persons/"
+
+
+def person_url(household, person):
+    return f"{persons_url(household)}{person.pk}/"
+
+
+@pytest.fixture
+def camille():
+    return User.objects.create_user(
+        username="camille", email="camille@example.com", first_name="Camille"
+    )
+
+
+@pytest.fixture
+def household(camille):
+    shared = Household.objects.create(name="Famille Martin")
+    HouseholdMember.objects.create(household=shared, user=camille)
+    Person.objects.create(household=shared, user=camille, name="Camille")
+    return shared
+
+
+@pytest.fixture
+def client(camille):
+    signed_in = Client()
+    signed_in.force_login(camille)
+    return signed_in
+
+
+@pytest.fixture
+def stranger_household():
+    stranger = User.objects.create_user(username="sacha", email="sacha@example.com")
+    other = Household.objects.create(name="Chez les autres")
+    HouseholdMember.objects.create(household=other, user=stranger)
+    return other
+
+
+def test_the_persons_of_a_household_are_listed(client, household):
+    Person.objects.create(household=household, name="Jeanne")
+
+    listed = client.get(persons_url(household)).json()
+
+    assert [person["name"] for person in listed] == ["Camille", "Jeanne"]
+    assert listed[1]["user"] is None
+
+
+def test_creating_a_person_adds_them_to_the_household(client, household):
+    response = client.post(
+        persons_url(household), {"name": "Jeanne"}, content_type="application/json"
+    )
+
+    assert response.status_code == 201
+    assert response.json()["name"] == "Jeanne"
+    assert household.persons.filter(name="Jeanne", user=None).exists()
+
+
+def test_a_person_is_read_one_by_one(client, household):
+    jeanne = Person.objects.create(household=household, name="Jeanne")
+
+    response = client.get(person_url(household, jeanne))
+
+    assert response.status_code == 200
+    assert response.json() == {"id": jeanne.pk, "name": "Jeanne", "user": None}
+
+
+def test_renaming_a_person_keeps_their_account(client, household, camille):
+    person = household.persons.get(user=camille)
+
+    response = client.patch(
+        person_url(household, person), {"name": "Maman"}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    person.refresh_from_db()
+    assert (person.name, person.user) == ("Maman", camille)
+
+
+def test_a_person_without_an_account_is_deleted(client, household):
+    jeanne = Person.objects.create(household=household, name="Jeanne")
+
+    response = client.delete(person_url(household, jeanne))
+
+    assert response.status_code == 204
+    assert not Person.objects.filter(pk=jeanne.pk).exists()
+
+
+def test_a_person_whose_account_is_still_a_member_is_not_deleted(client, household, camille):
+    person = household.persons.get(user=camille)
+
+    response = client.delete(person_url(household, person))
+
+    assert response.status_code == 409
+    assert Person.objects.filter(pk=person.pk).exists()
+
+
+def test_the_personal_household_has_persons_too(client, camille):
+    personal = Household.objects.create(name="camille", personal_of=camille)
+    HouseholdMember.objects.create(household=personal, user=camille)
+
+    created = client.post(persons_url(personal), {"name": "Moi"}, content_type="application/json")
+
+    assert created.status_code == 201
+    assert [person["name"] for person in client.get(persons_url(personal)).json()] == ["Moi"]
+
+
+def test_the_persons_of_another_household_are_out_of_reach(client, stranger_household):
+    theirs = Person.objects.create(household=stranger_household, name="Inconnu")
+
+    assert client.get(persons_url(stranger_household)).status_code == 404
+    assert (
+        client.post(
+            persons_url(stranger_household), {"name": "Jeanne"}, content_type="application/json"
+        ).status_code
+        == 404
+    )
+    assert client.get(person_url(stranger_household, theirs)).status_code == 404
+    assert (
+        client.patch(
+            person_url(stranger_household, theirs),
+            {"name": "Jeanne"},
+            content_type="application/json",
+        ).status_code
+        == 404
+    )
+    assert client.delete(person_url(stranger_household, theirs)).status_code == 404
+
+
+def test_a_person_of_another_household_is_unreachable_through_our_own(
+    client, household, stranger_household
+):
+    theirs = Person.objects.create(household=stranger_household, name="Inconnu")
+
+    assert client.get(person_url(household, theirs)).status_code == 404
+
+
+def test_the_person_endpoints_refuse_an_unauthenticated_caller(household):
+    anonymous = Client()
+
+    assert anonymous.get(persons_url(household)).status_code == 401
+    assert anonymous.post(persons_url(household), {"name": "Jeanne"}).status_code == 401


### PR DESCRIPTION
Closes #53

## Le blocage

Rien ne créait de foyer partagé : `HouseholdListView` était un `ListAPIView`, et le seul foyer créé automatiquement est le foyer personnel de l'inscription, que les routes d'invitation refusent volontairement. Inviter exigeait donc un foyer que rien ne produisait.

`POST /api/households/` le crée, inscrit son créateur comme membre `owner` et crée la `Person` qui le représente, dans la même transaction — exactement ce que fait l'inscription pour le foyer personnel. Ce trio, écrit jusqu'ici dans le signal d'inscription, part dans `households/memberships.py`, que le signal et la vue partagent.

## Ce qui est ajouté

- `POST /api/households/`, `PATCH` et `DELETE /api/households/{household_id}/`
- CRUD complet des personnes sous `/api/households/{household_id}/persons/`
- `GET` et `DELETE` des membres sous `/api/households/{household_id}/members/`

## Les règles tranchées

- **Retirer un membre conserve sa `Person` et vide son `user`**, comme le fait déjà la suppression d'un compte : sinon un non-membre reste rattaché à une personne du foyer
- **Le dernier membre ne peut pas quitter** un foyer partagé, `409` : un foyer sans membre ne serait lisible ni supprimable par personne, alors que le `DELETE` explicite dit ce qu'il détruit
- **Supprimer une personne dont le compte est encore membre** répond `409` : ça lui retirerait sa représentation alors qu'elle a toujours accès
- **Le foyer personnel** n'est ni renommable, ni supprimable, ni quittable : `PATCH`, `DELETE` et sa collection de membres répondent `404`, comme ses invitations
- Le compte lié d'une personne est en lecture seule dans le schéma : il est rempli par l'inscription ou par l'acceptation d'une invitation, jamais par un client
- Les `PATCH` appliquent la règle déjà écrite dans `docs/api/` — un `null` explicite laisse la valeur inchangée — portée une fois par `PartialWriteSerializer` au lieu d'être réécrite route par route

## Correction annexe

`openapi.yaml` décrivait la création d'invitation comme un `201` renvoyant `InvitationCreate`, alors qu'elle répond `204` sans corps. Le `@extend_schema` était posé sur `create()`, que drf-spectacular n'inspecte jamais — il ne lit que le handler `post()` — donc l'annotation était ignorée en silence. Elle passe par `extend_schema_view` sur la classe, pour cette route comme pour les nouvelles.

## Tests

Cas nominal de chaque route, accès depuis un foyer dont on n'est pas membre (`404` sur chacune), les trois règles ci-dessus, et le foyer personnel protégé. 115 tests, couverture à 100 %, `openapi.yaml` régénéré. Aucun changement de modèle, donc aucune migration ni régénération du diagramme.

## Documentation

`docs/api/README.md` gagne les sections Foyers, Personnes et Membres avec les règles retenues, `docs/model/household.md` le cycle de vie d'un foyer partagé, et le README la liste des nouvelles routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAL56UdsNr32Gd6hc7bSFb)_