### PR TITLE
Let a member choose which person they are when joining a household

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 - `POST /api/households/` — create a shared household, joined as its owner
 - `/api/households/{household_id}/` — rename or delete a shared household
 - `/api/households/{household_id}/persons/` — the people of a household, created, renamed and deleted
+- `POST /api/households/{household_id}/persons/{id}/claim/` — say which of them you are when joining
 - `/api/households/{household_id}/members/` — who has access to a shared household, and removing one of them
 - `/api/households/{household_id}/invitations/` — invite an address into a shared household, list the pending invitations, cancel one
 - `POST /api/invitations/accept/` — join a household with the token received by email

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -43,6 +43,14 @@ Le corps ne porte que le nom. Le compte lié est en lecture seule dans le schém
 
 Supprimer une personne dont le compte est encore membre du foyer répond `409` : ça retirerait sa représentation à quelqu'un qui a toujours accès, et chaque écran « pour qui » se retrouverait sans lui. Retirer le membre d'abord délie la personne et rend sa suppression possible.
 
+`POST /api/households/{household_id}/persons/{id}/claim/` répond `204` et rattache la personne au compte appelant. C'est l'écran « qui êtes-vous ? » à l'arrivée dans un foyer : l'invité choisit la personne qui l'attendait — « Papa » créé par le foyer avant qu'il ne rejoigne — au lieu qu'une deuxième soit créée à côté d'elle. Rien dans le corps, l'identité vient du chemin et de la session.
+
+Deux refus, tous deux en `409` : une personne qui a déjà un compte, et un appelant qui est déjà quelqu'un dans ce foyer. Le premier protège la représentation d'un autre membre, le second l'invariant « un compte, une personne par foyer » que la base porte déjà — répondre `409` plutôt que laisser passer une violation de contrainte donne à l'appelant une réponse qu'il peut lire.
+
+Un membre peut donc exister sans personne, le temps de choisir : c'est l'état dans lequel l'acceptation d'une invitation le laisse quand elle n'en désigne aucune, et l'écran de choix est ce qui en sort.
+
+Un arrivant que personne n'attendait se crée donc sa personne puis la revendique, en deux appels. Rattacher au passage à la création aurait fait un second chemin d'écriture vers `Person.user` pour épargner une requête, alors que la revendication est déjà la seule porte et qu'elle porte les deux refus.
+
 ## Membres
 
 `GET /api/households/{household_id}/members/` liste qui a accès au foyer, avec l'adresse et le rôle de chaque compte. `DELETE /api/households/{household_id}/members/{id}/` retire un membre ; se retirer soi-même, c'est quitter le foyer, il n'y a pas de route « quitter » distincte pour la même écriture.

--- a/docs/model/household.md
+++ b/docs/model/household.md
@@ -68,6 +68,8 @@ La vérification de l'adresse email est obligatoire et intervient **après** cet
 
 Le second membre d'un foyer partagé arrive par l'invitation. Un foyer personnel, lui, n'en a jamais qu'un.
 
+Ce second membre n'est pas une personne pour autant : rejoindre un foyer n'y crée personne. Il choisit qui il est parmi les personnes déjà là, ou l'invitation l'a choisi pour lui. Une appartenance sans personne est donc un état normal et transitoire, et non un accident à réparer.
+
 ## Cycle de vie d'un foyer partagé
 
 Un foyer partagé se crée à la demande, et son créateur y entre par le même chemin qu'un compte dans son foyer personnel : le foyer, l'appartenance `owner` et la personne qui le représente sont écrits dans la même transaction. C'est la seule création de foyer que l'API expose ; le foyer personnel, lui, n'est créé que par l'inscription.

--- a/docs/model/invitation.md
+++ b/docs/model/invitation.md
@@ -40,7 +40,11 @@ C'est l'inviteur qui choisit, parce que c'est lui qui sait que l'adresse corresp
 
 La personne désignée est cherchée **parmi celles du foyer**, et non validée après coup : une personne d'un autre foyer est alors refusée dans les mêmes termes qu'une personne inexistante. Distinguer les deux permettrait d'énumérer les identifiants des personnes des foyers d'autrui, ce que la règle « `404` et jamais `403` » interdit partout ailleurs.
 
-Le rattachement est vérifié au moment d'accepter, pas seulement au moment d'inviter : entre les deux, la personne a pu être supprimée, changer de foyer ou recevoir un compte. Si l'une de ces conditions n'est plus remplie, l'acceptation crée une `Person` comme si aucune n'avait été désignée, plutôt que d'échouer sur un détail que l'invité ne peut pas corriger.
+Le rattachement est vérifié au moment d'accepter, pas seulement au moment d'inviter : entre les deux, la personne a pu être supprimée, changer de foyer ou recevoir un compte. Si l'une de ces conditions n'est plus remplie, l'acceptation ne rattache rien, plutôt que d'échouer sur un détail que l'invité ne peut pas corriger.
+
+**Accepter ne crée aucune `Person`.** Sans personne désignée — ou avec une désignation devenue caduque — l'invité entre dans le foyer sans y être encore quelqu'un, et c'est l'écran « qui êtes-vous ? » qui tranche, en rattachant une personne existante par `POST /api/households/{household_id}/persons/{id}/claim/`.
+
+Créer d'office une personne à l'arrivée revenait à répondre à sa place. Le cas se voit sur un ex-membre qui revient : son retrait avait vidé le compte de sa personne sans la supprimer, et l'acceptation lui en fabriquait une seconde à côté, l'ancienne restant orpheline. L'unicité `(household, user)` ne l'attrapait pas, celle qu'il avait quittée portant `user = NULL`.
 
 La `Person` que l'inscription crée pour tout nouveau compte n'entre pas en concurrence avec celle-ci : elle vit dans le foyer personnel de l'invité, pas dans le foyer qu'il rejoint.
 

--- a/households/invitations.py
+++ b/households/invitations.py
@@ -66,11 +66,11 @@ def accept(invitation, user):
         return household
 
     HouseholdMember.objects.create(household=household, user=user)
-    claim_person(invitation, user)
+    attach_designated_person(invitation, user)
     return household
 
 
-def claim_person(invitation, user):
+def attach_designated_person(invitation, user):
     person = invitation.person
     if person and person.household_id == invitation.household_id and person.user_id is None:
         person.user = user

--- a/households/invitations.py
+++ b/households/invitations.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 from accounts.models import User
 from households.memberships import display_name_of
-from households.models import HouseholdMember, Invitation, Person
+from households.models import HouseholdMember, Invitation
 
 
 def hashed(token):
@@ -75,5 +75,3 @@ def claim_person(invitation, user):
     if person and person.household_id == invitation.household_id and person.user_id is None:
         person.user = user
         person.save()
-        return
-    Person.objects.create(household=invitation.household, user=user, name=display_name_of(user))

--- a/households/urls.py
+++ b/households/urls.py
@@ -8,6 +8,7 @@ from households.views import (
     InvitationListCreateView,
     MemberDestroyView,
     MemberListView,
+    PersonClaimView,
     PersonDetailView,
     PersonListCreateView,
 )
@@ -20,6 +21,11 @@ urlpatterns = [
         "households/<int:household_id>/persons/<int:pk>/",
         PersonDetailView.as_view(),
         name="person",
+    ),
+    path(
+        "households/<int:household_id>/persons/<int:pk>/claim/",
+        PersonClaimView.as_view(),
+        name="claim-person",
     ),
     path("households/<int:household_id>/members/", MemberListView.as_view(), name="members"),
     path(

--- a/households/views.py
+++ b/households/views.py
@@ -146,12 +146,13 @@ class PersonClaimView(HouseholdScopedView):
 
     def post(self, request, *args, **kwargs):
         person = get_object_or_404(self.household.persons, pk=self.kwargs["pk"])
-        if person.user_id:
-            raise Conflict("That person already has an account.")
         if self.household.persons.filter(user=request.user).exists():
             raise Conflict("The caller already is someone in this household.")
-        person.user = request.user
-        person.save()
+        claimed = self.household.persons.filter(pk=person.pk, user__isnull=True).update(
+            user=request.user
+        )
+        if not claimed:
+            raise Conflict("That person already has an account.")
         return Response(status=204)
 
 

--- a/households/views.py
+++ b/households/views.py
@@ -127,6 +127,34 @@ class PersonDetailView(HouseholdScopedView, generics.RetrieveDestroyAPIView):
         person.delete()
 
 
+@extend_schema_view(
+    post=extend_schema(
+        request=None,
+        responses={
+            204: None,
+            409: OpenApiResponse(
+                description=(
+                    "That person already has an account, "
+                    "or the caller already is someone in this household."
+                )
+            ),
+        },
+    )
+)
+class PersonClaimView(HouseholdScopedView):
+    serializer_class = PersonSerializer
+
+    def post(self, request, *args, **kwargs):
+        person = get_object_or_404(self.household.persons, pk=self.kwargs["pk"])
+        if person.user_id:
+            raise Conflict("That person already has an account.")
+        if self.household.persons.filter(user=request.user).exists():
+            raise Conflict("The caller already is someone in this household.")
+        person.user = request.user
+        person.save()
+        return Response(status=204)
+
+
 class MemberListView(SharedHouseholdScopedView, generics.ListAPIView):
     serializer_class = MemberSerializer
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -357,6 +357,30 @@ paths:
           description: No response body
         '409':
           description: The account of that person is still a member of the household.
+  /api/households/{household_id}/persons/{id}/claim/:
+    post:
+      operationId: households_persons_claim_create
+      parameters:
+      - in: path
+        name: household_id
+        schema:
+          type: integer
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - households
+      security:
+      - cookieAuth: []
+      responses:
+        '204':
+          description: No response body
+        '409':
+          description: That person already has an account, or the caller already is
+            someone in this household.
   /api/invitations/accept/:
     post:
       operationId: invitations_accept_create

--- a/tests/test_invitations.py
+++ b/tests/test_invitations.py
@@ -347,16 +347,14 @@ def test_a_personal_household_has_no_invitations_to_speak_of(member):
 def test_a_returning_member_is_offered_the_person_they_left_behind(
     send_invitation, signed_in, guest
 ):
-    _, household = signed_in
+    client, household = signed_in
     waiting = Person.objects.create(household=household, name="Papa")
     send_invitation(person=waiting.pk)
     signed_in_client(guest).post(
         ACCEPT_URL, {"token": token_from_last_email()}, content_type="application/json"
     )
-    HouseholdMember.objects.get(household=household, user=guest).delete()
-    waiting.refresh_from_db()
-    waiting.user = None
-    waiting.save()
+    membership = HouseholdMember.objects.get(household=household, user=guest)
+    client.delete(f"/api/households/{household.pk}/members/{membership.pk}/")
 
     send_invitation()
     signed_in_client(guest).post(

--- a/tests/test_invitations.py
+++ b/tests/test_invitations.py
@@ -163,7 +163,9 @@ def test_the_invitations_of_another_household_are_out_of_reach(signed_in):
     assert client.post(invitations_url(stranger), {"email": GUEST_EMAIL}).status_code == 404
 
 
-def test_accepting_makes_the_guest_a_member_of_the_household(send_invitation, signed_in, guest):
+def test_accepting_makes_the_guest_a_member_without_choosing_who_they_are(
+    send_invitation, signed_in, guest
+):
     _, household = signed_in
     send_invitation()
     token = token_from_last_email()
@@ -175,7 +177,7 @@ def test_accepting_makes_the_guest_a_member_of_the_household(send_invitation, si
     assert response.status_code == 200
     assert response.json() == {"id": household.pk, "name": household.name, "personal": False}
     assert HouseholdMember.objects.filter(household=household, user=guest).exists()
-    assert household.persons.filter(user=guest).exists()
+    assert not household.persons.filter(user=guest).exists()
 
 
 def test_accepting_spends_the_token(send_invitation, guest):
@@ -340,3 +342,34 @@ def test_a_personal_household_has_no_invitations_to_speak_of(member):
         ).status_code
         == 404
     )
+
+
+def test_a_returning_member_is_offered_the_person_they_left_behind(
+    send_invitation, signed_in, guest
+):
+    _, household = signed_in
+    waiting = Person.objects.create(household=household, name="Papa")
+    send_invitation(person=waiting.pk)
+    signed_in_client(guest).post(
+        ACCEPT_URL, {"token": token_from_last_email()}, content_type="application/json"
+    )
+    HouseholdMember.objects.get(household=household, user=guest).delete()
+    waiting.refresh_from_db()
+    waiting.user = None
+    waiting.save()
+
+    send_invitation()
+    signed_in_client(guest).post(
+        ACCEPT_URL, {"token": token_from_last_email()}, content_type="application/json"
+    )
+
+    assert [person.name for person in household.persons.all()] == ["Camille", "Papa"]
+
+    claimed = signed_in_client(guest).post(
+        f"/api/households/{household.pk}/persons/{waiting.pk}/claim/"
+    )
+
+    assert claimed.status_code == 204
+    waiting.refresh_from_db()
+    assert waiting.user == guest
+    assert household.persons.count() == 2

--- a/tests/test_persons_api.py
+++ b/tests/test_persons_api.py
@@ -30,11 +30,15 @@ def household(camille):
     return shared
 
 
+def signed_in(user):
+    client = Client()
+    client.force_login(user)
+    return client
+
+
 @pytest.fixture
 def client(camille):
-    signed_in = Client()
-    signed_in.force_login(camille)
-    return signed_in
+    return signed_in(camille)
 
 
 @pytest.fixture
@@ -156,3 +160,57 @@ def test_a_rename_whose_body_is_not_an_object_is_refused(client, household):
     response = client.patch(person_url(household, jeanne), [], content_type="application/json")
 
     assert response.status_code == 400
+
+
+def claim_url(household, person):
+    return f"{person_url(household, person)}claim/"
+
+
+@pytest.fixture
+def sacha(household):
+    user = User.objects.create_user(username="sacha", email="sacha@example.com", first_name="Sacha")
+    HouseholdMember.objects.create(household=household, user=user)
+    return user
+
+
+def test_claiming_a_person_makes_them_the_caller(household, sacha):
+    waiting = Person.objects.create(household=household, name="Papa")
+
+    response = signed_in(sacha).post(claim_url(household, waiting))
+
+    assert response.status_code == 204
+    waiting.refresh_from_db()
+    assert waiting.user == sacha
+    assert household.persons.count() == 2
+
+
+def test_a_person_who_already_has_an_account_is_not_claimed(household, sacha, camille):
+    taken = household.persons.get(user=camille)
+
+    response = signed_in(sacha).post(claim_url(household, taken))
+
+    assert response.status_code == 409
+    taken.refresh_from_db()
+    assert taken.user == camille
+
+
+def test_a_caller_who_already_is_someone_claims_nobody_else(client, household, camille):
+    waiting = Person.objects.create(household=household, name="Papa")
+
+    response = client.post(claim_url(household, waiting))
+
+    assert response.status_code == 409
+    waiting.refresh_from_db()
+    assert waiting.user is None
+
+
+def test_claiming_a_person_of_another_household_is_out_of_reach(client, stranger_household):
+    theirs = Person.objects.create(household=stranger_household, name="Inconnu")
+
+    assert client.post(claim_url(stranger_household, theirs)).status_code == 404
+
+
+def test_claiming_refuses_an_unauthenticated_caller(household):
+    waiting = Person.objects.create(household=household, name="Papa")
+
+    assert Client().post(claim_url(household, waiting)).status_code == 401

--- a/tests/test_persons_api.py
+++ b/tests/test_persons_api.py
@@ -210,6 +210,14 @@ def test_claiming_a_person_of_another_household_is_out_of_reach(client, stranger
     assert client.post(claim_url(stranger_household, theirs)).status_code == 404
 
 
+def test_claiming_a_person_of_another_household_through_our_own_is_refused(
+    client, household, stranger_household
+):
+    theirs = Person.objects.create(household=stranger_household, name="Inconnu")
+
+    assert client.post(claim_url(household, theirs)).status_code == 404
+
+
 def test_claiming_refuses_an_unauthenticated_caller(household):
     waiting = Person.objects.create(household=household, name="Papa")
 


### PR DESCRIPTION
Closes #55

## La route de revendication

`POST /api/households/{household_id}/persons/{id}/claim/` rattache une personne libre au compte appelant et répond `204`. Rien dans le corps : le foyer et la personne viennent du chemin, le compte de la session. Une route dédiée plutôt qu'un `PATCH`, `Person.user` restant en lecture seule par design.

Deux refus, tous deux en `409` :

- l'appelant est déjà quelqu'un dans ce foyer — c'est l'unicité `(household, user)` que la base porte, répondue en `409` plutôt qu'en `IntegrityError`
- la personne porte déjà un compte — la représentation d'un autre membre ne se prend pas

Le second refus est porté par l'écriture elle-même : l'`UPDATE` ne s'applique que tant que le compte de la personne est vide, et son nombre de lignes décide de la réponse. Deux arrivants qui ouvrent l'écran « qui êtes-vous ? » en même temps et cliquent le même nom ne peuvent donc pas passer tous les deux — c'est le cas nominal d'un couple qui rejoint ensemble, pas une collision exotique.

Le cloisonnement est celui des autres routes de personnes : `404` pour un foyer dont on n'est pas membre comme pour une personne d'ailleurs.

## `accept()` ne crée plus de personne

C'est la décision qui commande tout : tant que l'acceptation rattachait l'arrivant à une personne toute neuve, l'écran « qui êtes-vous ? » n'avait plus rien à demander. Une appartenance sans personne devient donc un état normal et transitoire. `invitation.person` reste le raccourci — une invitation qui cible une personne évite l'écran de choix — et la fonction qui l'applique s'appelle désormais `attach_designated_person()`, « claim » restant à la route où quelqu'un revendique effectivement quelque chose.

## Le point tranché à l'écriture

L'issue laissait ouvert le cas « se créer sa propre personne » : c'est `POST .../persons/` puis la revendication, en deux appels. Rattacher au passage à la création aurait ouvert un second chemin d'écriture vers `Person.user` pour épargner une requête, alors que la revendication est déjà la seule porte et qu'elle porte les deux refus.

## Tests

Revendication nominale, personne déjà prise, appelant déjà rattaché, foyer et personne d'autrui en `404` — y compris une personne d'un autre foyer présentée via le sien —, appelant anonyme en `401`. Le cas de l'ex-membre parcourt tout le chemin par les routes : rejoindre, être retiré par `DELETE .../members/{id}/`, être réinvité, puis revendiquer la personne laissée derrière au lieu d'en obtenir une seconde. C'est `remove_member()` qui délie la personne dans ce test, pas le test lui-même, sans quoi il resterait vert le jour où le doublon reviendrait.

124 tests, couverture à 100 %, `openapi.yaml` régénéré. Aucun changement de modèle, donc aucune migration ni régénération du diagramme.

## Documentation

`docs/api/README.md` décrit la route, ses deux refus et le chemin création-puis-revendication ; `docs/model/invitation.md` remplace la promesse « l'acceptation crée une `Person` » par ce qui se passe vraiment, avec le cas de l'ex-membre qui l'a motivé ; `docs/model/household.md` note qu'une appartenance sans personne est un état normal ; le README liste la nouvelle route.

Pas d'`UniqueConstraint(household, name)` : l'issue l'écarte pour l'instant, et la revendication rend le doublon évitable sans elle.