### PR TITLE
Add a check_integrity command listing the states the model forbids

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,14 @@ It expects an empty database: run it right after `reset_db` and `migrate`, never
 ### Shell and checks
 
 ```bash
-uv run python manage.py shell_plus   # shell with every model imported (django-extensions)
-uv run python manage.py check        # run the Django system checks
+uv run python manage.py shell_plus         # shell with every model imported (django-extensions)
+uv run python manage.py check              # run the Django system checks
+uv run python manage.py check_integrity    # list the states the model forbids but the schema cannot prevent
 ```
+
+`check_integrity` reads the database and names what should not be there: an account without a personal household, a shared household without a member, a person whose account is not a member of their household. These invariants live in the application code rather than in a constraint — the first would need a foreign key cycle, the other two a count no column can hold — so nothing but this command sees them broken. It says nothing and exits `0` on a healthy database, and lists what it found and exits non-zero otherwise, which is what a scheduled run needs.
+
+It names, it never repairs: a fix applied to a state nobody has explained yet erases the trace of the bug that produced it.
 
 ### Tests, lint and format
 
@@ -189,7 +194,7 @@ The production settings live in `docker-compose.prod.yml`: the database is store
 - `manage.py` — Django entry point
 - `tout_pris/` — project package: `settings.py`, `urls.py` (admin, and the API mounted on `/api/`), `views.py`, `mail.py`, `authentication.py`, `wsgi.py`, `asgi.py`
 - `accounts/` — the custom `User` model, referenced by `AUTH_USER_MODEL` since the initial migration
-- `households/` — the household domain: `Household`, `HouseholdMember`, `Person` and `Invitation`, their admin and API, the personal household created at signup, and the `seed` command
+- `households/` — the household domain: `Household`, `HouseholdMember`, `Person` and `Invitation`, their admin and API, the personal household created at signup, and the `seed` and `check_integrity` commands
 - `.env.example` — every environment variable with a development value
 - `tests/` — pytest-django test suite
 - `docs/api/` — the API conventions: status codes, household scoping, schemas, collections

--- a/docs/model/household.md
+++ b/docs/model/household.md
@@ -18,7 +18,7 @@ Le champ `role` existe pour ne pas avoir à migrer le jour où les droits se dif
 
 ## Le foyer personnel
 
-Tout compte a **toujours** un foyer à lui, créé à l'inscription et qu'il ne partage avec personne. C'est là qu'on prépare le sac de piscine ou le bagage d'un déplacement professionnel : des affaires qui n'ont rien à faire dans la liste familiale, et qu'on ne veut pas voir passer sous les yeux des autres membres.
+Tout compte a **toujours** un foyer à lui, créé à l'inscription et qu'il ne partage avec personne. Tout compte de l'application, s'entend : un compte d'administration créé par `createsuperuser` ne passe pas par l'inscription, donc pas par le signal qui crée le foyer, et n'en a aucun. Il ne se connecte pas au produit, seulement à l'admin. C'est là qu'on prépare le sac de piscine ou le bagage d'un déplacement professionnel : des affaires qui n'ont rien à faire dans la liste familiale, et qu'on ne veut pas voir passer sous les yeux des autres membres.
 
 C'est l'organisation de Notion, de Slack et de la plupart des outils partagés : un espace à soi, et des espaces qu'on rejoint. L'invitation ne convertit donc pas un compte, elle lui ajoute un foyer.
 
@@ -96,7 +96,7 @@ La garantie est donc double, et il vaut mieux le savoir avant d'écrire du SQL �
 
 Trois règles de ce document ne sont pas exprimables en contrainte, et c'est une conséquence du modèle plutôt qu'un oubli.
 
-**Un compte a exactement un foyer personnel.** C'est le foyer qui pointe vers le compte, et l'unicité de `personal_of` garantit qu'il n'y en a pas deux ; exiger qu'il y en ait au moins un demanderait au compte de pointer vers son foyer en retour, donc un cycle de clés étrangères qu'aucune des deux tables ne pourrait plus insérer en premier.
+**Un compte a exactement un foyer personnel.** C'est le foyer qui pointe vers le compte, et l'unicité de `personal_of` garantit qu'il n'y en a pas deux ; exiger qu'il y en ait au moins un demanderait au compte de pointer vers son foyer en retour, donc un cycle de clés étrangères qu'aucune des deux tables ne pourrait plus insérer en premier. L'invariant ne vaut que pour les comptes d'application : `check_integrity` écarte ceux qui portent `is_staff` ou `is_superuser`, faute de quoi le premier `createsuperuser` la rendrait rouge à demeure — et une alerte qui crie toujours finit éteinte, emportant le signalement qu'on attendait. Le filtre nomme les deux drapeaux plutôt que de deviner à l'absence de mot de passe utilisable, qui frapperait un compte de service ordinaire.
 
 **Un foyer partagé a au moins un membre.** Aucune colonne ne porte un compte de lignes d'une autre table, et le foyer doit exister avant l'appartenance qui le référence.
 

--- a/docs/model/household.md
+++ b/docs/model/household.md
@@ -91,3 +91,19 @@ Son foyer personnel part avec lui, en revanche : il n'a d'existence que pour ce 
 Ces règles sont déclarées sur les clés étrangères (`on_delete=CASCADE` et `on_delete=SET_NULL`) et appliquées par l'ORM Django au moment de la suppression. Aucun pragma SQLite n'est à activer : Django active déjà les clés étrangères, et les tests vérifient le comportement en supprimant réellement les lignes plutôt qu'en relisant la déclaration.
 
 La garantie est donc double, et il vaut mieux le savoir avant d'écrire du SQL à la main : la base refuse une suppression qui laisserait des lignes orphelines, et c'est l'ORM qui sait comment l'éviter en supprimant ou en détachant d'abord. Un `DELETE` brut sur un foyer est rejeté par la base plutôt que d'orpheliner ses personnes.
+
+## Les invariants que le schéma ne porte pas
+
+Trois règles de ce document ne sont pas exprimables en contrainte, et c'est une conséquence du modèle plutôt qu'un oubli.
+
+**Un compte a exactement un foyer personnel.** C'est le foyer qui pointe vers le compte, et l'unicité de `personal_of` garantit qu'il n'y en a pas deux ; exiger qu'il y en ait au moins un demanderait au compte de pointer vers son foyer en retour, donc un cycle de clés étrangères qu'aucune des deux tables ne pourrait plus insérer en premier.
+
+**Un foyer partagé a au moins un membre.** Aucune colonne ne porte un compte de lignes d'une autre table, et le foyer doit exister avant l'appartenance qui le référence.
+
+**La personne d'un compte appartient à un foyer dont ce compte est membre.** `Person.user` et `HouseholdMember.user` désignent le même compte sans que rien ne les relie : c'est le retrait d'un membre qui délie la personne, en code.
+
+Ces trois règles vivent donc dans le code applicatif, et un bug, une commande de migration de données ou un `shell_plus` un soir de fatigue peuvent les enfreindre sans que la base bronche. `uv run python manage.py check_integrity` est ce qui les relit : une section par invariant, rien à dire sur une base saine, et un code de sortie non nul quand elle trouve quelque chose.
+
+Elle nomme et ne répare pas. Une réparation automatique sur un état qu'on ne s'explique pas encore ferait disparaître la trace du bug qui l'a produit ; le jour où le cas se présentera, elle aura sa place dans une commande séparée qu'on lance en connaissance de cause, et qui rejouera l'opération d'inscription plutôt que le signal `user_signed_up`, pour ne pas rejouer ce qu'un autre récepteur y aurait accroché.
+
+Un membre sans personne n'en fait pas partie : c'est l'état normal d'un arrivant qui n'a pas encore choisi qui il est.

--- a/households/management/commands/check_integrity.py
+++ b/households/management/commands/check_integrity.py
@@ -8,7 +8,9 @@ from households.models import Household, HouseholdMember, Person
 def accounts_without_a_personal_household():
     return [
         f"#{user.pk} {user.email}"
-        for user in User.objects.filter(personal_household__isnull=True).order_by("pk")
+        for user in User.objects.filter(
+            personal_household__isnull=True, is_staff=False, is_superuser=False
+        ).order_by("pk")
     ]
 
 

--- a/households/management/commands/check_integrity.py
+++ b/households/management/commands/check_integrity.py
@@ -1,0 +1,61 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Exists, OuterRef
+
+from accounts.models import User
+from households.models import Household, HouseholdMember, Person
+
+
+def accounts_without_a_personal_household():
+    return [
+        f"#{user.pk} {user.email}"
+        for user in User.objects.filter(personal_household__isnull=True).order_by("pk")
+    ]
+
+
+def shared_households_without_a_member():
+    return [
+        f"#{household.pk} {household.name}"
+        for household in Household.objects.filter(
+            personal_of__isnull=True, members__isnull=True
+        ).order_by("pk")
+    ]
+
+
+def persons_whose_account_is_not_a_member():
+    membership = HouseholdMember.objects.filter(
+        household=OuterRef("household"), user=OuterRef("user")
+    )
+    return [
+        f"#{person.pk} {person.name} of household #{person.household_id}, {person.user.email}"
+        for person in Person.objects.filter(user__isnull=False)
+        .exclude(Exists(membership))
+        .select_related("user")
+        .order_by("pk")
+    ]
+
+
+INVARIANTS = [
+    ("Accounts without a personal household", accounts_without_a_personal_household),
+    ("Shared households without a member", shared_households_without_a_member),
+    (
+        "Persons whose account is not a member of their household",
+        persons_whose_account_is_not_a_member,
+    ),
+]
+
+
+class Command(BaseCommand):
+    help = "List the states the model forbids but the schema cannot prevent"
+
+    def handle(self, *args, **options):
+        found = 0
+        for title, forbidden_state in INVARIANTS:
+            listed = forbidden_state()
+            if not listed:
+                continue
+            found += len(listed)
+            self.stdout.write(title)
+            for line in listed:
+                self.stdout.write(f"  {line}")
+        if found:
+            raise CommandError(f"{found} forbidden states found")

--- a/tests/test_check_integrity.py
+++ b/tests/test_check_integrity.py
@@ -61,6 +61,8 @@ def test_a_shared_household_without_a_member_is_listed(camille, shared):
 
 
 def test_a_person_whose_account_left_the_household_is_listed(camille, shared):
+    sacha = User.objects.create_user(username="sacha", email="sacha@example.com")
+    HouseholdMember.objects.create(household=shared, user=sacha)
     HouseholdMember.objects.filter(household=shared, user=camille).delete()
     Person.objects.create(household=shared, name="Personne", user=None)
 
@@ -68,6 +70,14 @@ def test_a_person_whose_account_left_the_household_is_listed(camille, shared):
 
     assert "Camille" in report
     assert "Personne" not in report
+    assert "Famille Martin" not in report
+
+
+def test_an_administration_account_is_not_expected_to_have_a_personal_household():
+    User.objects.create_superuser(username="root", email="root@example.com", password="x")
+    User.objects.create_user(username="staff", email="staff@example.com", is_staff=True)
+
+    assert check_integrity() == ""
 
 
 def test_a_member_without_a_person_is_not_a_forbidden_state(camille, shared):

--- a/tests/test_check_integrity.py
+++ b/tests/test_check_integrity.py
@@ -1,0 +1,86 @@
+import io
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from accounts.models import User
+from households.memberships import create_household
+from households.models import Household, HouseholdMember, Person
+
+pytestmark = pytest.mark.django_db
+
+
+def check_integrity():
+    output = io.StringIO()
+    call_command("check_integrity", stdout=output)
+    return output.getvalue()
+
+
+def failing_check_integrity():
+    output = io.StringIO()
+    with pytest.raises(CommandError):
+        call_command("check_integrity", stdout=output)
+    return output.getvalue()
+
+
+@pytest.fixture
+def camille():
+    user = User.objects.create_user(
+        username="camille", email="camille@example.com", first_name="Camille"
+    )
+    create_household("camille", user, personal_of=user)
+    return user
+
+
+@pytest.fixture
+def shared(camille):
+    return create_household("Famille Martin", camille)
+
+
+def test_a_healthy_database_says_nothing(camille, shared):
+    assert check_integrity() == ""
+
+
+def test_an_account_without_a_personal_household_is_listed(camille):
+    camille.personal_household.delete()
+
+    report = failing_check_integrity()
+
+    assert "camille@example.com" in report
+    assert "personal household" in report
+
+
+def test_a_shared_household_without_a_member_is_listed(camille, shared):
+    shared.members.all().delete()
+
+    report = failing_check_integrity()
+
+    assert "Famille Martin" in report
+    assert f"#{shared.pk}" in report
+
+
+def test_a_person_whose_account_left_the_household_is_listed(camille, shared):
+    HouseholdMember.objects.filter(household=shared, user=camille).delete()
+    Person.objects.create(household=shared, name="Personne", user=None)
+
+    report = failing_check_integrity()
+
+    assert "Camille" in report
+    assert "Personne" not in report
+
+
+def test_a_member_without_a_person_is_not_a_forbidden_state(camille, shared):
+    shared.persons.all().delete()
+
+    assert check_integrity() == ""
+
+
+def test_every_forbidden_state_is_reported_in_one_run(camille):
+    orphan = Household.objects.create(name="Chez personne")
+    camille.personal_household.delete()
+
+    report = failing_check_integrity()
+
+    assert "camille@example.com" in report
+    assert f"#{orphan.pk}" in report


### PR DESCRIPTION
Closes #57

## Ce que la commande lit

`uv run python manage.py check_integrity`, une section par invariant, chacune listant l'identifiant et de quoi retrouver la ligne :

- un compte sans foyer personnel — `#12 camille@example.com`
- un foyer partagé sans membre — `#3 Famille Martin`
- une personne dont le compte n'est pas membre de son foyer — `#7 Camille of household #3, camille@example.com`

Silencieuse et code de sortie `0` sur une base saine ; sinon elle liste ce qu'elle a trouvé et sort en non nul, ce qu'attend une tâche planifiée.

Un membre sans personne n'en fait pas partie : c'est l'état normal d'un arrivant qui n'a pas encore choisi qui il est, depuis #55.

## Pourquoi ces trois-là ne sont pas des contraintes

C'est une conséquence de la forme du modèle, pas un oubli, et c'est écrit dans `docs/model/household.md` :

- « un compte a exactement un foyer personnel » demanderait au compte de pointer vers le foyer qui pointe déjà vers lui — un cycle de clés étrangères qu'aucune des deux tables ne pourrait insérer en premier ; l'unicité de `personal_of` garantit qu'il n'y en a pas deux, jamais qu'il y en a un
- « un foyer partagé a au moins un membre » demanderait à une colonne de porter un compte de lignes d'une autre table
- « la personne d'un compte appartient à un foyer dont ce compte est membre » relie `Person.user` et `HouseholdMember.user`, que rien ne relie en base : c'est le retrait d'un membre qui délie la personne, en code

## Elle nomme, elle ne répare pas

Réparer un état qu'on ne s'explique pas encore ferait disparaître la trace du bug qui l'a produit. Le README et `docs/model/household.md` disent aussi où ira la réparation le jour venu : une commande séparée, qui rejouera l'opération d'inscription et non le signal `user_signed_up`.

## Tests

Une base saine ne remonte rien et sort en `0` ; chaque état est fabriqué à la main et détecté ; un membre sans personne ne remonte pas ; et un dernier cas vérifie que deux états différents sortent dans la même exécution plutôt qu'un seul. 130 tests, couverture à 100 %.

Aucun changement de modèle ni de route : ni migration, ni diagramme, ni `openapi.yaml` à régénérer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAL56UdsNr32Gd6hc7bSFb)_