### PR TITLE
Serve the running version and commit from the health check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,7 @@ EMAIL_PORT=1025
 # Sender of the transactional emails. The address must be validated in Brevo.
 MAIL_FROM_EMAIL=no-reply@tout-pris.app
 MAIL_FROM_NAME=Tout Pris
+
+# Commit the running image was built from, served by /api/health/. Empty outside
+# a CI build, which passes it as a build argument to Dockerfile.prod.
+GIT_COMMIT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
           file: Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=prod

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -43,6 +43,9 @@ RUN mkdir /data && chown nonroot:nonroot /data
 # Put the venv on PATH so the CMD can call gunicorn directly (uv is absent here).
 ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1
 
+ARG GIT_COMMIT=""
+ENV GIT_COMMIT=${GIT_COMMIT}
+
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 
 ## API
 
-- `GET /api/health` — health check
+- `GET /api/health` — health check, with the version and the commit the running image was built from
 - `GET /api/households/` — the households the caller belongs to, their personal one first
 - `POST /api/households/` — create a shared household, joined as its owner
 - `/api/households/{household_id}/` — rename or delete a shared household
@@ -158,6 +158,7 @@ Settings are read from the environment. [`.env.example`](.env.example) lists eve
 | `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
+| `GIT_COMMIT` | empty | Commit the running image was built from, served by `/api/health/`. Passed as a build argument by the release workflow, empty everywhere else. |
 
 The Brevo key and the Django secret key are secrets: never commit them, pass them through the environment.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -477,8 +477,14 @@ components:
       properties:
         status:
           type: string
+        version:
+          type: string
+        commit:
+          type: string
       required:
+      - commit
       - status
+      - version
     Household:
       type: object
       properties:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,8 +1,25 @@
-def test_health_reports_the_service_as_up(client):
+from importlib.metadata import version
+
+from django.test import override_settings
+
+
+@override_settings(GIT_COMMIT="")
+def test_health_reports_the_service_as_up_with_the_version_it_runs(client):
     response = client.get("/api/health/")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json() == {
+        "status": "ok",
+        "version": version("tout-pris-back"),
+        "commit": "",
+    }
+
+
+@override_settings(GIT_COMMIT="d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d")
+def test_health_reports_the_commit_the_image_was_built_from(client):
+    response = client.get("/api/health/")
+
+    assert response.json()["commit"] == "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"
 
 
 def test_the_generated_docs_are_served_under_the_api_prefix(client):

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -157,6 +157,8 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {"invitations": "20/day"},
 }
 
+GIT_COMMIT = os.environ.get("GIT_COMMIT", "")
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "Tout Pris API",
     "DESCRIPTION": "Backend API of the Tout Pris project.",

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from drf_pydantic import BaseModel
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import api_view, permission_classes
@@ -7,6 +8,8 @@ from rest_framework.response import Response
 
 class Health(BaseModel):
     status: str
+    version: str
+    commit: str
 
 
 @extend_schema(
@@ -17,4 +20,10 @@ class Health(BaseModel):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health(request):
-    return Response(Health(status="ok").model_dump())
+    return Response(
+        Health(
+            status="ok",
+            version=settings.SPECTACULAR_SETTINGS["VERSION"],
+            commit=settings.GIT_COMMIT,
+        ).model_dump()
+    )


### PR DESCRIPTION
Le côté back de AxineTeam/tout-pris-front#27. Volontairement pas de `Closes` : cette issue porte aussi le travail front, qui reste à faire — la fermer d'ici laisserait le front sans ticket.

## Ce que ça change

`/api/health/` répondait `{"status": "ok"}`. Il répond maintenant :

```json
{"status": "ok", "version": "0.1.0", "commit": "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"}
```

Pas de nouvelle route : `/api/health/` est déjà en `AllowAny`, c'est un appel que le front peut faire au chargement sans rien négocier.

## La version vient de là où elle est déjà déclarée

`SPECTACULAR_SETTINGS["VERSION"]`, c'est-à-dire la version du paquet. Le numéro que la doc générée affiche et celui que le service annonce ne peuvent donc pas diverger.

## Le commit passe par un argument de build

Pas de `git rev-parse` : `.dockerignore` laisse `.git` dehors, et l'étage d'exécution n'a de toute façon pas git. C'est donc `ARG GIT_COMMIT` dans `Dockerfile.prod`, exposé en `ENV`, lu par `settings.py`.

L'`ARG` est placé **dans l'étage d'exécution, après le venv et les fichiers statiques**. Un nouveau commit ne reconstruit alors que cette dernière couche, au lieu d'invalider toute la chaîne de dépendances : le placement est le seul endroit où ça se joue, d'où ce choix plutôt que le haut du fichier.

Le workflow de release passe `${{ github.sha }}`. Les deux builds qui ne font que vérifier que l'image compile ne passent rien et reçoivent le défaut vide, ce qui est correct — ils ne produisent pas d'image déployée.

Hors image de release, `GIT_COMMIT` est vide : c'est le cas en dev, en test et dans l'image de dev. Le front est censé retomber sur ce vide plutôt que d'afficher un blanc.

## Une décision qui reste à prendre

L'issue la pose et je ne l'ai pas tranchée : **ça publie le commit exact sur un endpoint public**, ce qui dit à un visiteur de quelles vulnérabilités publiées le déploiement est assez vieux pour être porteur. Déplacer le champ derrière l'authentification coûte trois lignes tant que rien ne le consomme ; une fois le footer du front branché dessus, ça coûte les deux côtés. Autant décider maintenant.

## Vérifications

`pytest` (148 tests, couverture 100 %), `ruff check`, `ruff format --check`, `manage.py check`, `makemigrations --check` sans dérive, `spectacular` régénéré (`openapi.yaml` gagne les deux champs), markdownlint sur les 5 fichiers.

Le câblage `ARG` → `ENV` → `settings` est vérifié côté runtime (`GIT_COMMIT=deadbeef` donne bien `"commit": "deadbeef"` dans la réponse), mais **je n'ai pas pu construire l'image** : pas de démon Docker dans cet environnement. C'est le job `build-image` de la CI qui le prouvera, il construit `Dockerfile.prod` à chaque PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uKywEr2PfMmuXgpbXgZgZ)_