### PR TITLE
Serve the running build from the health check, to administrators only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,7 @@ EMAIL_PORT=1025
 # Sender of the transactional emails. The address must be validated in Brevo.
 MAIL_FROM_EMAIL=no-reply@tout-pris.app
 MAIL_FROM_NAME=Tout Pris
+
+# Commit the running image was built from, served by /api/health/. The release
+# workflow bakes it into the dev image; leave it empty everywhere else.
+GIT_COMMIT=

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,8 @@ EMAIL_PORT=1025
 MAIL_FROM_EMAIL=no-reply@tout-pris.app
 MAIL_FROM_NAME=Tout Pris
 
-# What /api/health/ answers as the running build, to an administrator only. The
-# release workflow bakes the git ref and the short commit into the published image.
+# What /api/health/ answers as the running build: the git ref to every caller, the
+# short commit to an administrator only. The release workflow bakes both into the
+# published image.
 APP_VERSION=dev
 APP_COMMIT=

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,6 @@ EMAIL_PORT=1025
 MAIL_FROM_EMAIL=no-reply@tout-pris.app
 MAIL_FROM_NAME=Tout Pris
 
-# Commit the running image was built from, served by /api/health/. The release
-# workflow bakes it into the dev image; leave it empty everywhere else.
-GIT_COMMIT=
+# What /api/health/ answers as the running version, to an administrator only. The
+# release workflow bakes the tag, or the short commit, into the published image.
+APP_VERSION=dev

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ EMAIL_PORT=1025
 MAIL_FROM_EMAIL=no-reply@tout-pris.app
 MAIL_FROM_NAME=Tout Pris
 
-# What /api/health/ answers as the running version, to an administrator only. The
-# release workflow bakes the tag, or the short commit, into the published image.
+# What /api/health/ answers as the running build, to an administrator only. The
+# release workflow bakes the git ref and the short commit into the published image.
 APP_VERSION=dev
+APP_COMMIT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,13 @@ jobs:
           file: Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
+          # The dev tag carries the commit it was built from, since its version number
+          # never moves and nothing else says what is deployed. A released image says
+          # its semver instead, and does not publish the commit. The condition is
+          # negated on purpose: an expression of the form `cond && '' || value` always
+          # yields value, the empty string being falsy.
+          build-args: |
+            GIT_COMMIT=${{ !startsWith(github.ref, 'refs/tags/') && github.sha || '' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,19 +109,23 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=dev,enable={{is_default_branch}}
 
+      - name: Version the image answers with
+        id: version
+        run: |
+          if [ "$GITHUB_REF_TYPE" = tag ]; then
+            echo "value=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.prod
           platforms: linux/amd64,linux/arm64
           push: true
-          # The dev tag carries the commit it was built from, since its version number
-          # never moves and nothing else says what is deployed. A released image says
-          # its semver instead, and does not publish the commit. The condition is
-          # negated on purpose: an expression of the form `cond && '' || value` always
-          # yields value, the empty string being falsy.
           build-args: |
-            GIT_COMMIT=${{ !startsWith(github.ref, 'refs/tags/') && github.sha || '' }}
+            APP_VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=prod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,15 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=raw,value=dev,enable={{is_default_branch}}
 
+      # Read from the workflow environment, never from the repository: .git is kept
+      # out of the build context, so the image cannot answer this question itself.
       - name: Version the image answers with
         id: version
         run: |
           if [ "$GITHUB_REF_TYPE" = tag ]; then
             echo "value=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
           else
-            echo "value=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: docker/build-push-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,9 @@ jobs:
 
       # Read from the workflow environment, never from the repository: .git is kept
       # out of the build context, so the image cannot answer this question itself.
-      - name: Version the image answers with
-        id: version
-        run: |
-          if [ "$GITHUB_REF_TYPE" = tag ]; then
-            echo "value=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Short commit the image answers with
+        id: build
+        run: echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/build-push-action@v6
         with:
@@ -127,7 +122,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            APP_VERSION=${{ steps.version.outputs.value }}
+            APP_VERSION=${{ github.ref_name }}
+            APP_COMMIT=${{ steps.build.outputs.commit }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=prod

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Backend Django du projet Tout Pris. Soit extrêmement concis.
 - pytest-django pour les tests, ruff pour lint et format
 - Docker + docker compose, devcontainer basé sur le service `api`
 - Le mailer est choisi dans `settings.py` : clé Brevo, Brevo ; hôte SMTP, ce serveur (Mailpit en dev) ; ni l'un ni l'autre, la console. La branche console garantit que le lien de vérification est lisible sans aucune configuration. Les variables s'appellent `EMAIL_HOST` et `EMAIL_PORT` mais sont stockées en minuscules : Django refuse de démarrer si ces deux *settings* existent à côté de `MAILERS`
+- `.git` est exclu du contexte de build (`.dockerignore`) : aucune image n'en contient, donc **le code ne peut pas et ne doit pas interroger git**. Ce qui vient de git — la version que sert `/api/health/` — est calculé par la CI depuis ses variables d'environnement et passé en `ARG`
 - Deux Dockerfiles (pratiques uv officielles) : `Dockerfile` dev (uv, deps dev, `runserver`, monté sur `/app`), `Dockerfile.prod` multistage (image finale sans uv ni pip, non-root, gunicorn, base dans le volume `/data`)
 
 ## Structure

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -46,11 +46,11 @@ ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Commit the image was built from, served by /api/health/. Declared here, at the very
-# end, so that a new commit rebuilds this layer alone instead of the whole venv chain.
-# Empty unless the release workflow passes it, which it does for the dev tag only.
-ARG GIT_COMMIT=""
-ENV GIT_COMMIT=$GIT_COMMIT
+# What the image answers when an administrator asks which code is running: the tag it
+# was built from, or the short commit outside a release. Declared here, at the very end,
+# so that a new build rebuilds this layer alone instead of the whole venv chain.
+ARG APP_VERSION="dev"
+ENV APP_VERSION=$APP_VERSION
 
 USER nonroot
 WORKDIR /app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -47,8 +47,9 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # What the image answers when an administrator asks which code is running: the tag it
-# was built from, or the short commit outside a release. Declared here, at the very end,
-# so that a new build rebuilds this layer alone instead of the whole venv chain.
+# was built from, or the short commit outside a release. It has to be passed in — .git
+# is excluded from the build context, and nothing in the image can work it out. Declared
+# at the very end so that a new build rebuilds this layer alone, not the venv chain.
 ARG APP_VERSION="dev"
 ENV APP_VERSION=$APP_VERSION
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -46,12 +46,13 @@ ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# What the image answers when an administrator asks which code is running: the tag it
-# was built from, or the short commit outside a release. It has to be passed in — .git
-# is excluded from the build context, and nothing in the image can work it out. Declared
-# at the very end so that a new build rebuilds this layer alone, not the venv chain.
+# What the image answers when an administrator asks which code is running: the git ref
+# it was built from, and the short commit. Both have to be passed in — .git is excluded
+# from the build context, and nothing in the image can work them out. Declared at the
+# very end so that a new build rebuilds this layer alone, not the venv chain.
 ARG APP_VERSION="dev"
-ENV APP_VERSION=$APP_VERSION
+ARG APP_COMMIT=""
+ENV APP_VERSION=$APP_VERSION APP_COMMIT=$APP_COMMIT
 
 USER nonroot
 WORKDIR /app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -46,6 +46,12 @@ ENV PATH="/app/.venv/bin:$PATH" PYTHONUNBUFFERED=1
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+# Commit the image was built from, served by /api/health/. Declared here, at the very
+# end, so that a new commit rebuilds this layer alone instead of the whole venv chain.
+# Empty unless the release workflow passes it, which it does for the dev tag only.
+ARG GIT_COMMIT=""
+ENV GIT_COMMIT=$GIT_COMMIT
+
 USER nonroot
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Settings are read from the environment. [`.env.example`](.env.example) lists eve
 | `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
-| `APP_VERSION` | `dev` | What `/api/health/` answers as the running version, to an administrator only. The release workflow bakes the tag, or the short commit outside a release, into the published image. |
+| `APP_VERSION` | `dev` | Git ref the running image was built from — the tag on a release, the branch otherwise. Served by `/api/health/` to an administrator only, and baked in by the release workflow. |
+| `APP_COMMIT` | empty | Short commit the running image was built from, served alongside `APP_VERSION` and under the same restriction. |
 
 The Brevo key and the Django secret key are secrets: never commit them, pass them through the environment.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Settings are read from the environment. [`.env.example`](.env.example) lists eve
 | `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
-| `GIT_COMMIT` | empty | Commit the running image was built from, served by `/api/health/`. Baked into the `dev` image by the release workflow, empty everywhere else. |
+| `APP_VERSION` | `dev` | What `/api/health/` answers as the running version, to an administrator only. The release workflow bakes the tag, or the short commit outside a release, into the published image. |
 
 The Brevo key and the Django secret key are secrets: never commit them, pass them through the environment.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 
 ## API
 
-- `GET /api/health/` — health check, and the running build for an administrator
+- `GET /api/health/` — health check and running version, with the exact commit for an administrator
 - `GET /api/households/` — the households the caller belongs to, their personal one first
 - `POST /api/households/` — create a shared household, joined as its owner
 - `/api/households/{household_id}/` — rename or delete a shared household
@@ -158,8 +158,8 @@ Settings are read from the environment. [`.env.example`](.env.example) lists eve
 | `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
-| `APP_VERSION` | `dev` | Git ref the running image was built from — the tag on a release, the branch otherwise. Served by `/api/health/` to an administrator only, and baked in by the release workflow. |
-| `APP_COMMIT` | empty | Short commit the running image was built from, served alongside `APP_VERSION` and under the same restriction. |
+| `APP_VERSION` | `dev` | Git ref the running image was built from — the tag on a release, the branch otherwise. Served by `/api/health/` to every caller, and baked in by the release workflow. |
+| `APP_COMMIT` | empty | Short commit the running image was built from, served by `/api/health/` to an administrator only. |
 
 The Brevo key and the Django secret key are secrets: never commit them, pass them through the environment.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 
 ## API
 
-- `GET /api/health` — health check
+- `GET /api/health/` — health check, and the running build for an administrator
 - `GET /api/households/` — the households the caller belongs to, their personal one first
 - `POST /api/households/` — create a shared household, joined as its owner
 - `/api/households/{household_id}/` — rename or delete a shared household

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Settings are read from the environment. [`.env.example`](.env.example) lists eve
 | `EMAIL_PORT` | `1025` | Port of that SMTP host. |
 | `MAIL_FROM_EMAIL` | `no-reply@tout-pris.app` | Sender address, must be a sender validated in Brevo. |
 | `MAIL_FROM_NAME` | `Tout Pris` | Sender display name. |
+| `GIT_COMMIT` | empty | Commit the running image was built from, served by `/api/health/`. Baked into the `dev` image by the release workflow, empty everywhere else. |
 
 The Brevo key and the Django secret key are secrets: never commit them, pass them through the environment.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile.prod
       args:
-        GIT_COMMIT: ${GIT_COMMIT:-}
+        APP_VERSION: ${APP_VERSION:-dev}
+        APP_COMMIT: ${APP_COMMIT:-}
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.prod
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-}
     ports:
       - "8000:8000"
     environment:

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -30,6 +30,22 @@ Les routes du domaine sont donc portées par le chemin du foyer — `/api/househ
 
 Les foyers eux-mêmes échappent à cette imbrication : `/api/households/` est la racine du domaine, et sa collection est cloisonnée par l'appartenance de l'appelant plutôt que par un foyer de chemin.
 
+## État du service
+
+`GET /api/health/` répond `200` sans authentification. C'est la sonde de santé, et c'est aussi le seul appel qu'un client fait au chargement pour savoir quel code lui répond.
+
+```json
+{"status": "ok", "version": "v1.2.0", "commit": "abc1234"}
+```
+
+`version` est le ref git de l'image — le tag sur une release, la branche sinon — et `commit` son SHA court. Les deux valent `null` pour un appelant qui n'est pas administrateur, y compris anonyme, la réponse gardant la même forme dans tous les cas : un client n'a qu'un chemin à écrire, et un champ nul se distingue d'un champ absent.
+
+**Ce n'est pas un `403`, et c'est la seule exception à la règle des rôles.** Ailleurs, un droit refusé sur sa propre ressource répond `403`. Ici la ressource — l'état du service — reste lisible par tous, seuls deux champs de diagnostic sont tus : répondre `403` fermerait la sonde de santé, qui doit rester interrogeable sans session. Un refus ne porte que sur ce qu'il refuse.
+
+**Le garde est `is_staff`, pas un rôle de foyer.** C'est l'accès à l'admin Django, un axe d'autorisation distinct de `owner`/`member`, et c'est le seul endroit de l'API où il décide de quelque chose. Le dépôt étant public, un commit publié dirait à n'importe qui de quels correctifs le déploiement est en retard ; réservé aux administrateurs, il n'apprend rien à personne qui ne puisse déjà tout lire.
+
+Les deux valeurs sont posées au build de l'image et ne peuvent pas être devinées depuis l'intérieur : `.git` est exclu du contexte de build. Le [README](../../README.md) décrit les variables qui les portent.
+
 ## Les refus du domaine
 
 Un refus décidé par le domaine — supprimer le dernier statut « pas préparé », rétrograder le dernier propriétaire — est levé comme une exception DRF, `tout_pris.exceptions.Conflict`, et c'est DRF qui la rend en `409` avec son `detail`. Aucune route n'a à l'attraper, et le message écrit dans le code métier est celui que le client lit.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -38,11 +38,17 @@ Les foyers eux-mêmes échappent à cette imbrication : `/api/households/` est l
 {"status": "ok", "version": "v1.2.0", "commit": "abc1234"}
 ```
 
-`version` est le ref git de l'image — le tag sur une release, la branche sinon — et `commit` son SHA court. Les deux valent `null` pour un appelant qui n'est pas administrateur, y compris anonyme, la réponse gardant la même forme dans tous les cas : un client n'a qu'un chemin à écrire, et un champ nul se distingue d'un champ absent.
+**`version` est public, `commit` ne l'est pas.** Le ref git de l'image — le tag sur une release, la branche sinon — est renvoyé à tout le monde, y compris à un appelant anonyme. Le SHA court n'est renvoyé qu'à un administrateur, et vaut `null` pour les autres ; la réponse garde la même forme dans tous les cas, un client n'a qu'un chemin à écrire et un champ nul se distingue d'un champ absent.
 
-**Ce n'est pas un `403`, et c'est la seule exception à la règle des rôles.** Ailleurs, un droit refusé sur sa propre ressource répond `403`. Ici la ressource — l'état du service — reste lisible par tous, seuls deux champs de diagnostic sont tus : répondre `403` fermerait la sonde de santé, qui doit rester interrogeable sans session. Un refus ne porte que sur ce qu'il refuse.
+Le partage tombe là parce que les deux valeurs ne disent pas la même chose. Un tag existe déjà publiquement dans le dépôt, et sur l'image `dev` le ref vaut `main` : le publier n'apprend rien à personne. Le SHA court, lui, désigne le build exact, et le dépôt étant public il dit de quels correctifs le déploiement est en retard. C'est lui, et lui seul, qu'il y a lieu de protéger.
 
-**Le garde est `is_staff`, pas un rôle de foyer.** C'est l'accès à l'admin Django, un axe d'autorisation distinct de `owner`/`member`, et c'est le seul endroit de l'API où il décide de quelque chose. Le dépôt étant public, un commit publié dirait à n'importe qui de quels correctifs le déploiement est en retard ; réservé aux administrateurs, il n'apprend rien à personne qui ne puisse déjà tout lire.
+Ce que ça donne concrètement : un utilisateur qui signale un bug peut joindre la version, ce qui est le besoin d'origine, sans que l'endpoint devienne un inventaire de ce qui manque au déploiement.
+
+**Ce n'est pas un `403`, et c'est la seule exception à la règle des rôles.** Ailleurs, un droit refusé sur sa propre ressource répond `403`. Ici la ressource — l'état du service — reste lisible par tous, et un seul champ de diagnostic est tu : répondre `403` fermerait la sonde de santé, qui doit rester interrogeable sans session. Un refus ne porte que sur ce qu'il refuse.
+
+**Le garde est `is_staff`, pas un rôle de foyer.** C'est l'accès à l'admin Django, un axe d'autorisation distinct de `owner`/`member`, et c'est le seul endroit de l'API où il décide de quelque chose.
+
+Un angle mort à connaître : sur l'image `dev`, `version` vaut `main` pour tout le monde, ce qui ne distingue pas deux builds de pré-production l'un de l'autre. Un rapport venu de la pré-prod dira donc « main » et rien de plus, et c'est le `commit` — réservé — qui reste le seul moyen d'y voir clair. C'est la conséquence assumée du partage retenu.
 
 Les deux valeurs sont posées au build de l'image et ne peuvent pas être devinées depuis l'intérieur : `.git` est exclu du contexte de build. Le [README](../../README.md) décrit les variables qui les portent.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -479,9 +479,8 @@ components:
           type: string
         version:
           type: string
-          nullable: true
           description: Git ref the running image was built from, the tag on a release
-            and the branch otherwise. Null unless the caller is an administrator.
+            and the branch otherwise.
         commit:
           type: string
           nullable: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -477,8 +477,14 @@ components:
       properties:
         status:
           type: string
+        version:
+          type: string
+        commit:
+          type: string
       required:
+      - commit
       - status
+      - version
     Household:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -480,7 +480,11 @@ components:
         version:
           type: string
           nullable: true
+        commit:
+          type: string
+          nullable: true
       required:
+      - commit
       - status
       - version
     Household:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -480,9 +480,13 @@ components:
         version:
           type: string
           nullable: true
+          description: Git ref the running image was built from, the tag on a release
+            and the branch otherwise. Null unless the caller is an administrator.
         commit:
           type: string
           nullable: true
+          description: Short commit the running image was built from. Null unless
+            the caller is an administrator.
       required:
       - commit
       - status

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -479,10 +479,8 @@ components:
           type: string
         version:
           type: string
-        commit:
-          type: string
+          nullable: true
       required:
-      - commit
       - status
       - version
     Household:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -19,6 +19,12 @@ def ordinary_account(db):
     )
 
 
+@pytest.fixture(autouse=True)
+def a_published_build(settings):
+    settings.APP_VERSION = "v1.2.0"
+    settings.APP_COMMIT = "7e6cfdc"
+
+
 def test_health_reports_the_service_as_up(client):
     response = client.get("/api/health/")
 
@@ -26,9 +32,7 @@ def test_health_reports_the_service_as_up(client):
     assert response.json()["status"] == "ok"
 
 
-def test_health_tells_an_administrator_which_build_is_running(client, administrator, settings):
-    settings.APP_VERSION = "v1.2.0"
-    settings.APP_COMMIT = "7e6cfdc"
+def test_health_tells_an_administrator_the_exact_build(client, administrator):
     client.force_login(administrator)
 
     response = client.get("/api/health/")
@@ -36,33 +40,19 @@ def test_health_tells_an_administrator_which_build_is_running(client, administra
     assert response.json() == {"status": "ok", "version": "v1.2.0", "commit": "7e6cfdc"}
 
 
-def test_health_keeps_the_build_from_an_ordinary_account(client, ordinary_account, settings):
-    settings.APP_VERSION = "v1.2.0"
-    settings.APP_COMMIT = "7e6cfdc"
+def test_health_tells_an_ordinary_account_the_ref_but_not_the_commit(client, ordinary_account):
     client.force_login(ordinary_account)
 
     response = client.get("/api/health/")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": None, "commit": None}
+    assert response.json() == {"status": "ok", "version": "v1.2.0", "commit": None}
 
 
-def test_health_keeps_the_build_from_an_anonymous_caller(client, settings):
-    settings.APP_VERSION = "v1.2.0"
-    settings.APP_COMMIT = "7e6cfdc"
-
+def test_health_tells_an_anonymous_caller_the_ref_but_not_the_commit(client):
     response = client.get("/api/health/")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": None, "commit": None}
-
-
-def test_the_build_falls_back_outside_a_published_image(client, administrator):
-    client.force_login(administrator)
-
-    response = client.get("/api/health/")
-
-    assert response.json() == {"status": "ok", "version": "dev", "commit": ""}
+    assert response.json() == {"status": "ok", "version": "v1.2.0", "commit": None}
 
 
 def test_the_generated_docs_are_served_under_the_api_prefix(client):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,24 @@
+import pytest
+
+from accounts.models import User
+
+ADMIN_PASSWORD = "correct-horse-battery-staple"
+
+
+@pytest.fixture
+def administrator(db):
+    return User.objects.create_superuser(
+        username="root", email="root@example.com", password=ADMIN_PASSWORD
+    )
+
+
+@pytest.fixture
+def ordinary_account(db):
+    return User.objects.create_user(
+        username="camille", email="camille@example.com", password=ADMIN_PASSWORD
+    )
+
+
 def test_health_reports_the_service_as_up(client):
     response = client.get("/api/health/")
 
@@ -5,26 +26,40 @@ def test_health_reports_the_service_as_up(client):
     assert response.json()["status"] == "ok"
 
 
-def test_health_reports_the_version_the_generated_schema_announces(client):
-    schema = client.get("/api/schema/?format=json").json()
+def test_health_tells_an_administrator_which_version_is_running(client, administrator, settings):
+    settings.APP_VERSION = "v1.2.0"
+    client.force_login(administrator)
 
     response = client.get("/api/health/")
 
-    assert response.json()["version"] == schema["info"]["version"]
+    assert response.json()["version"] == "v1.2.0"
 
 
-def test_health_reports_the_commit_the_image_was_built_from(client, settings):
-    settings.GIT_COMMIT = "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"
+def test_health_keeps_the_version_from_an_ordinary_account(client, ordinary_account, settings):
+    settings.APP_VERSION = "v1.2.0"
+    client.force_login(ordinary_account)
 
     response = client.get("/api/health/")
 
-    assert response.json()["commit"] == "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": None}
 
 
-def test_health_reports_an_empty_commit_outside_a_released_image(client):
+def test_health_keeps_the_version_from_an_anonymous_caller(client, settings):
+    settings.APP_VERSION = "v1.2.0"
+
     response = client.get("/api/health/")
 
-    assert response.json()["commit"] == ""
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": None}
+
+
+def test_the_version_falls_back_to_dev_outside_a_published_image(client, administrator):
+    client.force_login(administrator)
+
+    response = client.get("/api/health/")
+
+    assert response.json()["version"] == "dev"
 
 
 def test_the_generated_docs_are_served_under_the_api_prefix(client):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,7 +2,29 @@ def test_health_reports_the_service_as_up(client):
     response = client.get("/api/health/")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json()["status"] == "ok"
+
+
+def test_health_reports_the_version_the_generated_schema_announces(client):
+    schema = client.get("/api/schema/?format=json").json()
+
+    response = client.get("/api/health/")
+
+    assert response.json()["version"] == schema["info"]["version"]
+
+
+def test_health_reports_the_commit_the_image_was_built_from(client, settings):
+    settings.GIT_COMMIT = "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"
+
+    response = client.get("/api/health/")
+
+    assert response.json()["commit"] == "d6a13f0c1e2b4a5978f30c6d2b1e4a7c9f085b3d"
+
+
+def test_health_reports_an_empty_commit_outside_a_released_image(client):
+    response = client.get("/api/health/")
+
+    assert response.json()["commit"] == ""
 
 
 def test_the_generated_docs_are_served_under_the_api_prefix(client):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,20 +2,20 @@ import pytest
 
 from accounts.models import User
 
-ADMIN_PASSWORD = "correct-horse-battery-staple"
+PASSWORD = "correct-horse-battery-staple"
 
 
 @pytest.fixture
 def administrator(db):
     return User.objects.create_superuser(
-        username="root", email="root@example.com", password=ADMIN_PASSWORD
+        username="root", email="root@example.com", password=PASSWORD
     )
 
 
 @pytest.fixture
 def ordinary_account(db):
     return User.objects.create_user(
-        username="camille", email="camille@example.com", password=ADMIN_PASSWORD
+        username="camille", email="camille@example.com", password=PASSWORD
     )
 
 
@@ -26,40 +26,43 @@ def test_health_reports_the_service_as_up(client):
     assert response.json()["status"] == "ok"
 
 
-def test_health_tells_an_administrator_which_version_is_running(client, administrator, settings):
+def test_health_tells_an_administrator_which_build_is_running(client, administrator, settings):
     settings.APP_VERSION = "v1.2.0"
+    settings.APP_COMMIT = "7e6cfdc"
     client.force_login(administrator)
 
     response = client.get("/api/health/")
 
-    assert response.json()["version"] == "v1.2.0"
+    assert response.json() == {"status": "ok", "version": "v1.2.0", "commit": "7e6cfdc"}
 
 
-def test_health_keeps_the_version_from_an_ordinary_account(client, ordinary_account, settings):
+def test_health_keeps_the_build_from_an_ordinary_account(client, ordinary_account, settings):
     settings.APP_VERSION = "v1.2.0"
+    settings.APP_COMMIT = "7e6cfdc"
     client.force_login(ordinary_account)
 
     response = client.get("/api/health/")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": None}
+    assert response.json() == {"status": "ok", "version": None, "commit": None}
 
 
-def test_health_keeps_the_version_from_an_anonymous_caller(client, settings):
+def test_health_keeps_the_build_from_an_anonymous_caller(client, settings):
     settings.APP_VERSION = "v1.2.0"
+    settings.APP_COMMIT = "7e6cfdc"
 
     response = client.get("/api/health/")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": None}
+    assert response.json() == {"status": "ok", "version": None, "commit": None}
 
 
-def test_the_version_falls_back_to_dev_outside_a_published_image(client, administrator):
+def test_the_build_falls_back_outside_a_published_image(client, administrator):
     client.force_login(administrator)
 
     response = client.get("/api/health/")
 
-    assert response.json()["version"] == "dev"
+    assert response.json() == {"status": "ok", "version": "dev", "commit": ""}
 
 
 def test_the_generated_docs_are_served_under_the_api_prefix(client):

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -13,7 +13,7 @@ DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
-GIT_COMMIT = os.environ.get("GIT_COMMIT", "")
+APP_VERSION = os.environ.get("APP_VERSION", "dev")
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -13,6 +13,8 @@ DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
+GIT_COMMIT = os.environ.get("GIT_COMMIT", "")
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -14,6 +14,7 @@ DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
 APP_VERSION = os.environ.get("APP_VERSION", "dev")
+APP_COMMIT = os.environ.get("APP_COMMIT", "")
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -8,8 +8,7 @@ from rest_framework.response import Response
 
 class Health(BaseModel):
     status: str
-    version: str
-    commit: str
+    version: str | None
 
 
 @extend_schema(
@@ -23,7 +22,6 @@ def health(request):
     return Response(
         Health(
             status="ok",
-            version=settings.SPECTACULAR_SETTINGS["VERSION"],
-            commit=settings.GIT_COMMIT,
+            version=settings.APP_VERSION if request.user.is_staff else None,
         ).model_dump()
     )

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 class Health(BaseModel):
     status: str
     version: str | None
+    commit: str | None
 
 
 @extend_schema(
@@ -19,9 +20,11 @@ class Health(BaseModel):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health(request):
+    is_administrator = request.user.is_staff
     return Response(
         Health(
             status="ok",
-            version=settings.APP_VERSION if request.user.is_staff else None,
+            version=settings.APP_VERSION if is_administrator else None,
+            commit=settings.APP_COMMIT if is_administrator else None,
         ).model_dump()
     )

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from drf_pydantic import BaseModel
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import api_view, permission_classes
@@ -7,6 +8,8 @@ from rest_framework.response import Response
 
 class Health(BaseModel):
     status: str
+    version: str
+    commit: str
 
 
 @extend_schema(
@@ -17,4 +20,10 @@ class Health(BaseModel):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health(request):
-    return Response(Health(status="ok").model_dump())
+    return Response(
+        Health(
+            status="ok",
+            version=settings.SPECTACULAR_SETTINGS["VERSION"],
+            commit=settings.GIT_COMMIT,
+        ).model_dump()
+    )

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -9,9 +9,9 @@ from rest_framework.response import Response
 
 class Health(BaseModel):
     status: str
-    version: str | None = Field(
+    version: str = Field(
         description="Git ref the running image was built from, the tag on a release and the "
-        "branch otherwise. Null unless the caller is an administrator."
+        "branch otherwise."
     )
     commit: str | None = Field(
         description="Short commit the running image was built from. Null unless the caller "
@@ -27,11 +27,10 @@ class Health(BaseModel):
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def health(request):
-    is_administrator = request.user.is_staff
     return Response(
         Health(
             status="ok",
-            version=settings.APP_VERSION if is_administrator else None,
-            commit=settings.APP_COMMIT if is_administrator else None,
+            version=settings.APP_VERSION,
+            commit=settings.APP_COMMIT if request.user.is_staff else None,
         ).model_dump()
     )

--- a/tout_pris/views.py
+++ b/tout_pris/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from drf_pydantic import BaseModel
 from drf_spectacular.utils import extend_schema
+from pydantic import Field
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -8,8 +9,14 @@ from rest_framework.response import Response
 
 class Health(BaseModel):
     status: str
-    version: str | None
-    commit: str | None
+    version: str | None = Field(
+        description="Git ref the running image was built from, the tag on a release and the "
+        "branch otherwise. Null unless the caller is an administrator."
+    )
+    commit: str | None = Field(
+        description="Short commit the running image was built from. Null unless the caller "
+        "is an administrator."
+    )
 
 
 @extend_schema(


### PR DESCRIPTION
Closes #67

`/api/health/` répond à un administrateur :

```json
{"status": "ok", "version": "v1.2.0", "commit": "abc1234"}
```

et à tous les autres — compte ordinaire comme anonyme :

```json
{"status": "ok", "version": null, "commit": null}
```

Pas de nouvelle route, toujours en `AllowAny`, un seul appel au chargement.

## Un ref et un commit, pas un numéro de version

`version` est le **ref git** de l'image — le tag sur une release, la branche sinon — et `commit` le **SHA court**. C'est un choix, et c'est celui qui répond à la question posée.

La question n'est pas « quelle version du produit est-ce », c'est « **quel code tourne** ». Un numéro de version ne sait y répondre que sur une release : sur l'image `dev`, que la pré-production suit avec watchtower, il ne bouge pas d'un build au suivant — c'était le cas de `SPECTACULAR_SETTINGS["VERSION"]`, que la première version de cette PR servait, et deux images différentes répondaient `0.1.0`. Un ref plus un commit répondent **toujours**, et sur une release le ref *est* le numéro de version.

Donc oui, sur l'image `dev`, `version` vaut `main`. Ce n'est pas un défaut à rattraper : c'est ce qui rend le champ utile là où la question se pose. Le README le nomme pour ce qu'il est, un ref git, plutôt que de faire passer un nom de branche pour une version.

## Deux champs, toujours remplis

Les deux valeurs sont posées à chaque build, sans que rien n'ait à choisir entre elles.

C'est la restriction aux administrateurs qui rend ça possible. Un endpoint public devait décider ce qu'il ne dirait pas — le dépôt étant public, un SHA publié dit à n'importe qui de quels correctifs le déploiement est en retard —, et décider voulait dire brancher dans le workflow selon l'image construite. À un administrateur on peut tout dire, donc il n'y a plus rien à sélectionner : **plus une seule condition** dans la CI.

```yaml
- name: Short commit the image answers with
  id: build
  run: echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
# ...
build-args: |
  APP_VERSION=${{ github.ref_name }}
  APP_COMMIT=${{ steps.build.outputs.commit }}
```

## La règle est écrite, parce que c'est une exception

`docs/api/README.md` gagne une section « État du service ». Deux points qu'elle fixe, et qui dépassent cet endpoint :

- **ce n'est pas un `403`.** Ailleurs, un droit refusé sur sa propre ressource répond `403` ; ici la ressource — l'état du service — reste lisible par tous, et seuls deux champs de diagnostic sont tus. Répondre `403` fermerait la sonde de santé aux appelants qui en ont le plus besoin. Un refus ne porte que sur ce qu'il refuse ;
- **le garde est `is_staff`**, l'admin Django, un axe d'autorisation distinct des rôles `owner`/`member` du foyer, et le seul endroit de l'API où il décide de quelque chose.

Les deux champs se décrivent aussi dans `openapi.yaml`, qui est ce que lit un client.

## Rien ne lit git

`.git` est exclu du contexte de build : aucune image n'en contient, donc **le code ne peut pas et ne doit pas interroger git**. Tout vient des variables d'environnement du workflow — `github.ref_name`, `GITHUB_SHA` — passées en `ARG` puis en `ENV`. La CI n'invoque plus git non plus.

La règle est écrite là où quelqu'un la lira avant de la casser : dans `CLAUDE.md`, et dans le commentaire des `ARG` de `Dockerfile.prod`.

## Le reste

- les `ARG` sont tout à la fin de l'étage d'exécution : un nouveau build ne reconstruit que cette couche ;
- `docker-compose.prod.yml` passe les deux arguments, sans quoi les variables de `.env.example` n'auraient d'effet nulle part hors CI ;
- hors image publiée — dev, tests, image de dev, builds de vérification — `version` vaut `dev` et `commit` est vide ;
- la liste des routes du README portait `/api/health` sans sa barre oblique finale, à rebours de la convention énoncée trois sections plus bas ;
- `openapi.yaml` régénéré, `README.md` et `.env.example` à jour.

## Chemin parcouru

La première version de cette PR servait le numéro de paquet plus un commit retenu hors des images de production, via une expression GitHub négée — `cond && '' || value` renvoie toujours `value`, la chaîne vide étant *falsy*. Tout ça disparaît : la restriction aux administrateurs a rendu la gymnastique sans objet, et le numéro de paquet ne répondait pas à la question.

Le front suit exactement la même convention, c'est le sujet de AxineTeam/tout-pris-front#27 : c'est la **paire** front/back qui décrit un déploiement, et deux conventions différentes rendraient la comparaison illisible.

## Ce que je n'ai pas pu vérifier ici

Pas de démon Docker dans ce conteneur, donc **l'image n'a pas été construite** : la chaîne `ARG` → `ENV` → `os.environ` n'est pas prouvée de bout en bout. Vérifié côté Django en démarrant avec les variables dans l'environnement. La CI construit l'image de prod à chaque PR, donc une erreur de syntaxe sortirait — pas une valeur qui n'arriverait pas au processus.

## Vérifications

`ruff check`, `ruff format --check`, `manage.py check`, `spectacular` + `git diff`, markdownlint, `pytest` : 189 tests, couverture 100 %.
