### PR TITLE
Rename the backend to the API

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "tout-pris-back",
+  "name": "tout-pris-api",
   "dockerComposeFile": "../docker-compose.yml",
   "service": "api",
   "workspaceFolder": "/app",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,13 @@ jobs:
     needs: [lint-and-test, build-image]
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    # Both names for the duration of the rename: the front CI and the deployment
+    # repository still pull the tout-pris-back tags. Dropping the old name is a
+    # follow-up, once they both point at tout-pris-api.
     env:
-      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-back
+      IMAGE_NAMES: |
+        ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-api
+        ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-back
     steps:
       - uses: actions/checkout@v4
 
@@ -101,7 +106,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMES }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,8 @@ jobs:
     needs: [lint-and-test, build-image]
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
-    # Both names for the duration of the rename: the front CI and the deployment
-    # repository still pull the tout-pris-back tags. Dropping the old name is a
-    # follow-up, once they both point at tout-pris-api.
     env:
-      IMAGE_NAMES: |
-        ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-api
-        ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-back
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/tout-pris-api
     steps:
       - uses: actions/checkout@v4
 
@@ -106,7 +101,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAMES }}
+          images: ${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# tout-pris-back
+# tout-pris-api
 
-Backend Django du projet Tout Pris. Soit extrêmement concis.
+API Django du projet Tout Pris. Soit extrêmement concis.
 
 ## Langue
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# tout-pris-back
+# tout-pris-api
 
-Backend Django for Tout Pris, with [Django REST Framework](https://www.django-rest-framework.org) for the API, [drf-spectacular](https://drf-spectacular.readthedocs.io) for its OpenAPI schema, [drf-pydantic](https://github.com/georgebv/drf-pydantic) to derive serializers from Pydantic models, and [django-allauth](https://docs.allauth.org) in headless mode for authentication.
+Django API for Tout Pris, with [Django REST Framework](https://www.django-rest-framework.org) for the API, [drf-spectacular](https://drf-spectacular.readthedocs.io) for its OpenAPI schema, [drf-pydantic](https://github.com/georgebv/drf-pydantic) to derive serializers from Pydantic models, and [django-allauth](https://docs.allauth.org) in headless mode for authentication.
 
 There is no Makefile: `manage.py` is the entry point for everything that touches the application or the database, and this README lists every other command.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Tout Pris API
   version: 0.1.0
-  description: Backend API of the Tout Pris project.
+  description: API of the Tout Pris project.
 paths:
   /api/health/:
     get:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "tout-pris-back"
+name = "tout-pris-api"
 version = "0.1.0"
-description = "Tout Pris backend API"
+description = "Tout Pris API"
 requires-python = ">=3.12"
 dependencies = [
     "django>=6.1",

--- a/tout_pris/settings.py
+++ b/tout_pris/settings.py
@@ -164,8 +164,8 @@ REST_FRAMEWORK = {
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "Tout Pris API",
-    "DESCRIPTION": "Backend API of the Tout Pris project.",
-    "VERSION": version("tout-pris-back"),
+    "DESCRIPTION": "API of the Tout Pris project.",
+    "VERSION": version("tout-pris-api"),
     "SERVE_INCLUDE_SCHEMA": False,
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1169,7 +1169,7 @@ wheels = [
 ]
 
 [[package]]
-name = "tout-pris-back"
+name = "tout-pris-api"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
Closes #73

Part de ce dépôt du renommage « back » → « API ». Les deux autres dépôts (AxineTeam/tout-pris-front#35, AxineTeam/tout-pris-docker#5) suivent dans leurs issues.

## Ce qui change

**Le paquet Python** : `tout-pris-back` → `tout-pris-api` dans `pyproject.toml`, et `version("tout-pris-api")` dans `settings.py`. Les deux ensemble : `SPECTACULAR_SETTINGS["VERSION"]` lit les métadonnées de la distribution installée, et renommer l'un sans l'autre lève `PackageNotFoundError` au démarrage. `uv.lock` porte le nom lui aussi, il est régénéré avec `uv lock` — un désaccord se serait vu à l'installation, pas à la relecture. La `description` du projet perd elle aussi son « backend ».

**L'image publiée** : `estb/tout-pris-back` → `estb/tout-pris-api`, bascule directe.

**La prose** : titres de `README.md` et `CLAUDE.md`, nom du devcontainer, et la `DESCRIPTION` OpenAPI (« Backend API of the Tout Pris project. » → « API of the Tout Pris project. »). C'est la seule ligne qui bouge dans `openapi.yaml` régénéré : la version émise reste `0.1.0`, c'est la version du paquet, que le renommage ne touche pas. Les autres occurrences de « back » dans `docs/` désignent le *front* ou les *email backends* de Django et restent en place.

## Pourquoi `tout_pris/` ne bouge pas

Le module racine nomme le produit, pas le service. Le renommer déplacerait `DJANGO_SETTINGS_MODULE`, `wsgi`/`asgi`, l'entrypoint Docker et toutes les migrations qui référencent le label d'app — pour zéro gain de clarté. L'issue le demande explicitement.

## La bascule d'image, et ce qu'elle coûte

**Un seul nom, pas de double publication.** La première version de cette PR publiait sous les deux noms le temps que le front et le dépôt de déploiement basculent. L'arbitrage a été renversé dans l'issue et dans la revue : la double publication achète une transition silencieuse au prix d'un nettoyage que personne ne porte — revenir retirer l'ancien nom une fois les deux autres dépôts passés. Un rouge visible et bref vaut mieux qu'une dette invisible et durable.

**Une nuance sur ce rouge, parce qu'il ne viendra probablement pas.** Cesser de publier sous `estb/tout-pris-back` n'efface pas le tag `dev` existant : rien ne le supprime sur le Docker Hub. La CI du front continuera de le tirer avec succès, **verte mais contre une image gelée** au dernier build de l'ancien nom. Le mode de panne réel n'est donc pas l'échec annoncé mais le silence — des E2E qui passent contre une API qui n'avance plus. La fenêtre est courte, AxineTeam/tout-pris-front#35 étant déjà verte et prête, mais elle mérite d'être surveillée plutôt qu'attendue en rouge.

## Ce qui reste manuel

- **Créer `estb/tout-pris-api` sur le Docker Hub, en public**, avant de merger. Le dépôt d'images répond `404` aujourd'hui. Le job `release-docker` est gardé par `if: github.event_name == 'push'` : il ne tourne jamais sur une pull request, donc la CI verte ici ne prouve rien sur la publication. Un jeton à portée limitée ne couvre pas un dépôt inexistant, et un dépôt créé privé échoue au `pull` d'une façon qui ressemble à une image absente — la CI du front et le déploiement le tirent tous deux sans authentification.
- **Renommer le dépôt GitHub** `tout-pris-back` → `tout-pris-api` : action d'administration du propriétaire. GitHub laisse une redirection sur l'ancien nom, donc les `git remote` existants continuent de marcher.
- **Repointer la pré-production** sur `estb/tout-pris-api:dev` : watchtower compare le digest d'une image au même nom et ne fait pas migrer un conteneur vers un autre dépôt d'images. Tant que ce n'est pas fait, elle reste sur l'ancien nom sans que rien ne le signale — et `/api/health/` répondra fidèlement le ref d'un build qu'on croyait remplacé.

## Vérifié

Docker indisponible dans l'environnement d'exécution, donc tout est passé par uv (repli documenté dans `CLAUDE.md`) : `uv sync`, `ruff check`, `ruff format --check`, `pytest` (188 tests, 100 % de couverture), `manage.py check`, `check --deploy --fail-level WARNING`, `makemigrations --check --dry-run`, régénération d'`openapi.yaml` (seule la ligne `description` bouge), régénération de `docs/model/schema.dot` (`git diff --exit-code` propre, aucun modèle touché), `markdownlint-cli2` (0 issue), et `uv lock --check`.

Le passage au nom unique est une modification de YAML seule, sans code Python touché : elle est vérifiée en parsant le workflow (`images:` reçoit bien une chaîne unique) et par `git grep tout-pris-back`, qui ne trouve plus rien dans les fichiers suivis.