### PR TITLE
Require a branch to be rewritten before it is called ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,12 @@ API Django du projet Tout Pris. Soit extrêmement concis.
 - Ne committe jamais des fichiers que tu n'as ni écrits ni modifiés : c'est peut-être le travail d'un autre agent
 - Titre de commit en anglais, au présent impératif ; le corps doit être assez explicite et détaillé pour comprendre le changement sans contexte
 - Préfère les commits atomiques (un changement logique = un commit)
+- L'historique qui arrive sur `main` est celui de la bonne version, pas celui des allers-retours. Le dépôt merge en rebase-merge : les commits de la branche atterrissent tels quels, donc ils doivent déjà être propres
+- Avant de déclarer la PR prête, réécris **ta** branche pour qu'aucun de ses commits n'en corrige un autre. Pendant l'itération, `git commit --fixup=<sha>` ; à la fin, `git rebase --autosquash origin/main` — `rebase -i` n'est pas disponible en session agent, `GIT_SEQUENCE_EDITOR=true` le remplace
+- Vérifie que la réécriture n'a rien perdu : `git diff <ancienne-tête> HEAD` doit être vide. Un rebase qui traverse un conflit supprime un morceau sans le dire, et c'est la seule preuve qui vaille — ne pousse pas avant de l'avoir lue
+- Pousse la réécriture avec `--force-with-lease`, jamais `--force` : il refuse si la branche a bougé entre-temps
+- Le message décrit le code tel qu'il arrive, pas le chemin parcouru : jamais de « la première version faisait X, corrigé en `abc1234` ». L'hésitation appartient à la PR, pas à `main`
+- Ne réécris qu'une fois les revues abouties : une réécriture en cours de revue fait perdre au relecteur son point de comparaison
 - Résous les conflits de PR par rebase sur `main`, jamais en mergeant `main` dans la branche : le repo merge en rebase-merge, qui jette les commits de merge et leurs résolutions (« Unable to merge » sinon)
 - Quand le dev est fini, `git fetch origin main` et vérifie que la branche est rebasable sans conflit sur `main` ; si `main` a avancé, rebase et re-pousse avant de considérer la PR prête
 - Ouvre toujours une PR une fois le code terminé, sans attendre qu'on te le demande


### PR DESCRIPTION
Six puces dans la section `Git` du `CLAUDE.md`, à la suite de « Préfère les commits atomiques » — c'est la règle qu'elles prolongent. Aucun code touché.

## Le problème

Une branche arrive aujourd'hui sur `main` avec la route qu'elle a parcourue : un commit qui fait A, un qui fait B, un troisième qui défait la moitié de A parce que la première lecture était fausse. Le dépôt merge en **rebase-merge**, donc ces commits atterrissent tels quels — l'hésitation d'une passe de revue devient de l'histoire permanente, et qui lit `git log` dans six mois doit deviner laquelle des trois passes compte.

L'exemple est sous la main : #75 porte un commit dont le message dit « La première version de cette PR ne gardait que la suppression […] Corrigé en `104b91f` ».

## Ce que la règle demande

L'état final plutôt que le trajet : un commit par changement logique, aucun qui en corrige un autre de la même branche, réécrit **une fois les revues abouties**. On itère librement pendant la revue — réécrire en cours de route coûte au relecteur le diff auquel il se comparait.

## Le point qui n'allait pas de soi

Le squash est la bonne façon d'y arriver, mais **le squash ne prouve rien** : il réduit le nombre d'occasions de perdre un morceau, il ne montre pas qu'aucun n'a été perdu. La preuve, c'est que l'arbre n'a pas bougé — `git diff <ancienne-tête> HEAD` vide est la seule chose qui l'établisse.

Un rebase qui traverse un conflit peut supprimer un hunk en silence, et rien d'autre ne l'attrape : ni la CI si le morceau perdu n'était pas testé, ni la relecture du diff final, qui ne montre que ce qui reste. La vérification est donc écrite comme une condition avant de pousser, pas comme un conseil.

`rebase -i` n'existe pas en session agent, donc le chemin non interactif est explicite : `--fixup` pendant l'itération, `--autosquash` à la fin, `GIT_SEQUENCE_EDITOR=true` pour dérouler sans éditeur.

La dernière puce porte sur le message et non sur les commits : ce que le code fait en arrivant est ce que le message décrit.

## Vérifié

`npx markdownlint-cli2 "CLAUDE.md"` : `0 issues`.

Le même changement part sur AxineTeam/tout-pris-front. `tout-pris-docker` n'a pas de `CLAUDE.md` et reste hors périmètre.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjjkwzVo7AKMAbQFRbg9f)_