### PR TITLE
Write issues for the two people who have to validate them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,15 @@ API Django du projet Tout Pris. Soit extrêmement concis.
 - Ces principes s'appliquent à tout code produit : applicatif, scripts, configuration, infrastructure
 - En markdown, pas de retour à la ligne dur — une ligne par paragraphe
 
+## Issues
+
+- Une issue se lit à deux : le product owner d'abord, le lead technique ensuite. Elle est donc écrite en deux temps, dans cet ordre, et chacun doit pouvoir répondre à sa question sans lire l'autre moitié
+- **La moitié fonctionnelle répond au product owner : l'équipe a-t-elle compris le besoin ?** Elle commence par ce que quelqu'un cherche à faire et par ce qui l'en empêche aujourd'hui, puis déroule le parcours — qui fait quoi, dans quel ordre, ce qu'il voit — avec des prénoms et des écrans réels. Le test E2E est ce parcours transcrit : écrit assez concrètement, il n'y a pas de troisième texte à produire, et les trois tiennent dans le même bloc de prose plutôt que dans trois sections
+- Elle se valide sans connaître le code. Si comprendre le besoin demande un nom de table, une route ou un composant, elle a manqué son lecteur
+- **La moitié technique répond au lead : est-ce que ça tient dans le cadre existant ?** Elle dit comment, jamais pourquoi, et se rattache à ce qui est déjà là — la convention suivie, le motif repris, l'endroit du code qui résout déjà le même problème. Une solution décrite hors-sol ne se valide pas, elle se croit sur parole
+- Ce qu'elle contient doit se rattacher à une ligne du bloc fonctionnel. Ce qui ne s'y rattache pas est du périmètre qui s'invite
+- Une issue sans effet visible pour un utilisateur — un renommage, une règle d'outillage, une montée de version — le dit en une phrase et passe directement à la technique. Ne lui invente pas un besoin qu'elle n'a pas
+
 ## Git
 
 - Ne committe jamais sans demande explicite


### PR DESCRIPTION
Une section `## Issues` dans le `CLAUDE.md`, entre `Style de code` et `Git` — l'ordre du fichier suit alors celui du travail : comment on écrit le ticket, comment on committe, comment on teste. Aucun code touché.

Cette PR n'a aucun effet visible pour un utilisateur ; conformément à la dernière règle qu'elle ajoute, elle le dit et passe directement à la technique.

## Le problème

Une issue s'ouvre aujourd'hui là où était l'attention de celui qui l'écrit. #63 commence par deux noms de modèles, AxineTeam/tout-pris-front#36 par la palette par défaut de shadcn, AxineTeam/tout-pris-front#33 par ce que l'API n'accepte plus. Chacune est exacte, et aucune ne dit ce que quelqu'un cherchait à faire — donc le seul lecteur capable de les valider est celui qui connaît déjà le code, c'est-à-dire celui qui en a le moins besoin.

## Ce que la règle pose

Deux personnes valident une issue, et elles ne posent pas la même question. **Le product owner** demande si l'équipe a compris le besoin. **Le lead technique** demande si la réponse tient dans le cadre déjà en place. Écrire dans cet ordre donne à chacun une moitié sur laquelle il peut se prononcer, et oblige à trancher le besoin avant qu'une solution ne s'installe comme prémisse.

**La moitié fonctionnelle est un seul bloc de prose**, pas trois sections, parce que besoin, parcours et test E2E sont le même énoncé à trois grains. « Un foyer prépare un voyage à plusieurs » devient « Camille crée le voyage, ajoute le sac de Léo, le marque prêt » devient un test qui rejoue exactement ça. Écrite assez concrètement — de vrais prénoms, de vrais écrans, un vrai ordre —, la transcription ne demande pas de troisième texte. Effet secondaire qui compte : le critère d'acceptation existe avant le code.

Deux contraintes rendent chaque moitié vérifiable par son lecteur :

- **La fonctionnelle doit tenir sans connaître le code.** C'est ce qui en fait un contrôle de compréhension et non une spécification descendante. Si comprendre le besoin demande un nom de table, elle a manqué son lecteur.
- **La technique doit se rattacher à l'existant** — la convention suivie, le motif repris, l'endroit qui résout déjà le même problème. C'est la cohérence que le lead vérifie, et une description hors-sol ne lui offre rien à quoi la comparer. #75 le fait bien : « exposés sous le chemin du foyer, comme les personnes et les membres ».

La dernière règle garde les autres honnêtes : un renommage, une règle d'outillage, une montée de version n'ont pas d'effet visible, et leur réclamer un besoin métier produit du remplissage. Une règle qui produit du remplissage finit ignorée, donc le cas est nommé.

## Vérifié

`npx markdownlint-cli2 "CLAUDE.md"` : `0 issues`.

Le même changement part sur AxineTeam/tout-pris-front. `tout-pris-docker` n'a pas de `CLAUDE.md` et reste hors périmètre.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjjkwzVo7AKMAbQFRbg9f)_