### PR TITLE
Treat PR notifications as a hint, not a source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ API Django du projet Tout Pris. Soit extrêmement concis.
 ## Workflow
 
 - Quand je te demande de traiter une issue ou une PR, souscris par défaut aux notifications de la PR concernée (`subscribe_pr_activity`) et suis-la jusqu'au merge
+- Les notifications sont un déclencheur commode, jamais une source de vérité : leur silence ne prouve rien. Sur une PR suivie, lis les commentaires (`get_comments`) en partant du plus récent — c'est là qu'arrive le retour, et des revues vides (`get_reviews`, fils de revue inline) ne veulent pas dire qu'il n'y a rien de neuf
+- Après tout merge ou fermeture de PR, réabonne-toi aux PR encore ouvertes : le désabonnement automatique peut emporter leurs abonnements sans rien signaler
 - Avant de démarrer le traitement d'une issue, si tu as des objections sur ce qui est demandé, commente-les sur l'issue et attends une réponse avant de commencer
 - Lis toujours le code existant avant de proposer des modifications
 - Utilise les outils dédiés (Read, Edit, Grep, Glob) plutôt que bash quand possible


### PR DESCRIPTION
Deux puces dans la section `## Workflow` du `CLAUDE.md`, juste après celle sur `subscribe_pr_activity`, qui reste telle quelle — elle est vraie, elle était seulement incomplète. Aucun code touché. Texte identique à celui de AxineTeam/tout-pris-front#43.

Cette PR n'a aucun effet visible pour un utilisateur ; conformément à la dernière règle de la section `Issues`, elle le dit et passe directement à la technique.

## Le problème

La formulation actuelle laisse croire que s'abonner aux notifications d'une PR suffit à savoir ce qui s'y passe. Ça a coûté deux fois.

Un retour de revue posté sur une PR suivie n'a déclenché **aucune** notification, et la PR est restée sans réponse jusqu'à ce que le propriétaire du projet le signale lui-même. Le retour arrive le plus souvent en commentaire de PR, pas en revue GitHub au sens strict : chercher dans `get_reviews` et dans les fils de revue inline peut ne rien rendre alors qu'un commentaire attend. Conclure « rien de neuf » sur des revues vides est l'erreur exacte qui a été commise.

Indépendamment, le désabonnement automatique déclenché par le merge d'une PR a par le passé emporté les abonnements des **autres** PR encore ouvertes, coupant leurs notifications sans que rien ne le dise.

## Ce que les règles posent

La première inverse la charge de la preuve : la notification est un déclencheur commode, son silence ne prouve rien, et sur une PR suivie on lit les commentaires (`get_comments`) du plus récent plutôt que de conclure des revues vides.

La seconde nomme l'effet de bord du merge : après tout merge ou fermeture, on se réabonne aux PR encore ouvertes. Elle est écrite comme un geste systématique et non comme une réaction à un symptôme qui, justement, ne se manifeste pas.

Deux puces et non trois : le silence des notifications et la lecture des commentaires sont la même règle prise à deux grains, les séparer aurait fait un principe sans geste et un geste sans raison.

## Vérifié

`npx markdownlint-cli2 "**/*.md"` : `0 issues`. Le diff ne touche que la section `Workflow`.

Les deux textes ont été écrits indépendamment, chaque session ne voyant pas le travail de l'autre, puis comparés et alignés — c'est cette version-ci qui a bougé pour rejoindre celle du front.