### PR TITLE
Write only what changes something for the reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,16 @@ API Django du projet Tout Pris. Soit extrêmement concis.
 - Ces principes s'appliquent à tout code produit : applicatif, scripts, configuration, infrastructure
 - En markdown, pas de retour à la ligne dur — une ligne par paragraphe
 
+## Écriture
+
+Ces règles valent pour les issues, les descriptions de PR, les revues et les commentaires.
+
+- Une phrase qui ne change rien pour le lecteur ne s'écrit pas : pas de résumé de ce qui précède, pas de constat que tout va bien, pas de transition
+- Pas de section « Vérifié » : la CI dit ce qui passe et le relecteur la lit. Recopier ses sorties ne prouve rien de plus et enterre ce que la PR a à dire
+- Ne décris pas ce que couvrent les tests, le fichier de tests est là pour ça
+- Une revue liste des constats actionnables. Ce qui est correct ne se commente pas, le silence suffit à le dire
+- Un constat tient en une affirmation et sa conséquence. Le raisonnement qui y mène ne s'écrit que s'il est contestable
+
 ## Issues
 
 - Une issue se lit à deux : le product owner d'abord, le lead technique ensuite. Elle est donc écrite en deux temps, dans cet ordre, et chacun doit pouvoir répondre à sa question sans lire l'autre moitié


### PR DESCRIPTION
Une section `## Écriture` dans le `CLAUDE.md`, avant `## Issues`. Aucun code touché.

Les issues, descriptions de PR, revues et commentaires ont pris une couche de texte qui ne porte rien : une section « Vérifié » qui recopie ce que la CI vient de faire, l'inventaire de ce que couvrent les tests, une phrase de fin disant que le reste va bien.

Rien de tout ça n'atteint un lecteur qui a la CI, le fichier de tests et le diff sous les yeux, et tout ça enterre les deux ou trois lignes qui demandent une réponse. Un fil qu'on ne finit pas de lire est un fil qu'on ne relit pas.

La section nomme les cas pour que couper soit une règle et non un goût. Elle se place avant `## Issues`, qui n'a alors plus qu'à dire comment les deux moitiés d'un ticket s'agencent.

Le même changement part sur AxineTeam/tout-pris-front.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjjkwzVo7AKMAbQFRbg9f)_