### PR TITLE
Let a household reorder its statuses, its kits and the lines of a kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ DJANGO_SECRET_KEY=... docker compose -f docker-compose.prod.yml up -d
 - `/api/households/{household_id}/members/` — who has access to a shared household, their role, handing it over, and removing one of them
 - `/api/households/{household_id}/invitations/` — invite an address into a shared household, list the pending invitations, cancel one
 - `/api/households/{household_id}/item-types/` — the catalog of a household, where creating a name it already holds returns the existing entry and renaming into a name it already holds merges the two
-- `/api/households/{household_id}/item-statuses/` — the preparation statuses of a household, created, reworded, repainted and deleted
-- `/api/households/{household_id}/kits/` — the reusable blocks of a household, always returned with their lines
-- `/api/households/{household_id}/kits/{kit_id}/items/` — the lines of a block, each packing an object of the household for one of its people
+- `/api/households/{household_id}/item-statuses/` — the preparation statuses of a household, created, reworded, repainted, reordered and deleted
+- `/api/households/{household_id}/kits/` — the reusable blocks of a household, reordered within it, each read with its lines
+- `/api/households/{household_id}/kits/{kit_id}/items/` — the lines of a block, each packing an object of the household for one of its people, reordered within the block
 - `/api/households/{household_id}/trips/` — the trips of a household, from the next departure backwards, each read with its participants and its lines
 - `/api/households/{household_id}/trips/{trip_id}/participants/` — who goes on a trip, which is what filters the lines a kit pours in
 - `/api/households/{household_id}/trips/{trip_id}/items/` — the preparation lines of a trip, each tagged with the kits holding its object

--- a/catalog/serializers.py
+++ b/catalog/serializers.py
@@ -1,8 +1,19 @@
+from ordered_model.serializers import OrderedModelSerializer
 from rest_framework import serializers
 
 from catalog.base_catalog import DEFAULT_STATUS_COLOR
 from catalog.models import ItemStatus, ItemType, Kit, KitItem
 from households.serializers import HouseholdScopedRelation, PersonSerializer
+
+
+class ReorderingSerializer(OrderedModelSerializer):
+    """A position moves the entry to that rank, the rest of its group shifting to make room."""
+
+    def validate_position(self, position):
+        last = self.instance.get_ordering_queryset().count() - 1
+        if not 0 <= position <= last:
+            raise serializers.ValidationError(f"Give a position from 0 to {last}.")
+        return position
 
 
 class ItemTypeSerializer(serializers.ModelSerializer):
@@ -36,10 +47,10 @@ class ItemStatusCreateSerializer(serializers.ModelSerializer):
         extra_kwargs = {"color": {"default": DEFAULT_STATUS_COLOR}}
 
 
-class ItemStatusUpdateSerializer(serializers.ModelSerializer):
+class ItemStatusUpdateSerializer(ReorderingSerializer):
     class Meta:
         model = ItemStatus
-        fields = ["name", "color", "progress", "is_default"]
+        fields = ["name", "color", "progress", "position", "is_default"]
 
     def validate_is_default(self, is_default):
         if not is_default:
@@ -67,13 +78,13 @@ class KitItemCreateSerializer(serializers.ModelSerializer):
         fields = ["item_type", "person", "quantity", "note"]
 
 
-class KitItemUpdateSerializer(serializers.ModelSerializer):
+class KitItemUpdateSerializer(ReorderingSerializer):
     item_type = HouseholdScopedRelation("item_types", required=False)
     person = HouseholdScopedRelation("persons", required=False, allow_null=True)
 
     class Meta:
         model = KitItem
-        fields = ["item_type", "person", "quantity", "note"]
+        fields = ["item_type", "person", "quantity", "note", "position"]
 
 
 class KitSerializer(serializers.ModelSerializer):
@@ -96,7 +107,7 @@ class KitCreateSerializer(serializers.ModelSerializer):
         fields = ["name", "description"]
 
 
-class KitUpdateSerializer(serializers.ModelSerializer):
+class KitUpdateSerializer(ReorderingSerializer):
     class Meta:
         model = Kit
-        fields = ["name", "description"]
+        fields = ["name", "description", "position"]

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -175,6 +175,7 @@ class KitDetailView(HouseholdScopedView, generics.RetrieveDestroyAPIView):
     @extend_schema(
         request=KitUpdateSerializer, responses={200: KitDetailSerializer, 403: FORBIDDEN}
     )
+    @transaction.atomic
     def patch(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_object(), data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
@@ -215,6 +216,7 @@ class KitItemDetailView(KitScopedView, generics.RetrieveDestroyAPIView):
     @extend_schema(
         request=KitItemUpdateSerializer, responses={200: KitItemSerializer, 403: FORBIDDEN}
     )
+    @transaction.atomic
     def patch(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.get_object(), data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -148,8 +148,6 @@ La comparaison emploie les mêmes expressions SQL que la contrainte d'unicité, 
 
 **La couleur d'un statut est facultative à la création** et vaut `#7b8189`, un gris neutre, quand le client n'en donne pas. Imposer un hexadécimal pour créer « à acheter sur place » alourdirait la saisie fluide que la création tolérante cherche justement à obtenir, et une couleur est ce qu'on ajuste ensuite, jamais ce qui manque pour reconnaître un statut. Le modèle, lui, garde le champ obligatoire : le défaut est une commodité d'API, l'admin et le catalogue de base continuent de choisir explicitement.
 
-`position` est en lecture seule : elle est attribuée à la fin de la liste à la création, et la déplacer relève d'une route de réordonnancement qui n'existe pas encore.
-
 ## Kits
 
 Un kit est le bloc réutilisable décrit dans [`docs/model/catalog.md`](../model/catalog.md), et ses lignes sont exposées **sous lui** : `GET` et `POST /api/households/{household_id}/kits/`, `GET`, `PATCH` et `DELETE /api/households/{household_id}/kits/{id}/`, puis les mêmes quatre routes sur `kits/{kit_id}/items/`. Comme le reste du référentiel, c'est le quotidien du foyer : seule `IsSomeoneInTheHousehold` s'applique, un `member` en fait autant qu'un `owner`.
@@ -172,7 +170,15 @@ La personne est facultative — une ligne sans personne est pour tout le foyer �
 
 **`quantity` va de 1 à 32767.** Une ligne à zéro n'existe pas : un client qui décrémente jusqu'à zéro envoie un `DELETE`, et demander confirmation avant est son affaire. Les bornes sont posées sur la colonne et non sur le serializer, elles valent donc aussi pour l'admin et pour tout code qui écrira une ligne ; la haute est celle du `smallint`, que PostgreSQL rendrait en `500` sans elle.
 
-`position` est en lecture seule, sur un kit comme sur une ligne : elle est attribuée à la fin de son groupe à la création, et la déplacer relève d'une route de réordonnancement qui n'existe pas encore.
+## L'ordre
+
+Un statut, un kit et une ligne de kit portent une `position` dans leur groupe — le foyer pour les deux premiers, le kit pour la troisième. Elle est attribuée à la fin du groupe à la création, et **l'envoyer dans le `PATCH` de la ressource la déplace à ce rang**, les autres se décalant pour lui faire la place. C'est le glisser-déposer du front, transcrit tel quel : il relâche une entrée à un rang, il envoie ce rang.
+
+**Il n'y a pas de route de réordonnancement séparée.** Déplacer une entrée est une modification comme une autre, et une route dédiée ferait un second chemin d'écriture sur la même ressource, avec son cloisonnement et sa résolution de foyer à réécrire.
+
+**La position va de 0 au dernier rang du groupe**, et hors de ces bornes c'est un `400` : le corps est invalide, et aucun état du foyer ne rendrait la demande acceptable. Les bornes se comptent dans le groupe de l'entrée déplacée et nulle part ailleurs : un kit de trois lignes refuse la position 3, même si le kit d'à côté en a dix.
+
+**Deux membres qui déplacent une entrée du même groupe en même temps obtiennent un ordre qu'aucun des deux n'a demandé** : chacun désigne un rang dans la liste qu'il avait sous les yeux, et rien ne dit au second que la première a bougé. Le déplacement par index achète à ce prix un corps de requête qui ne porte que le rang, là où un `PUT` de la liste entière obligerait le client à renvoyer tous les identifiants pour bouger une ligne.
 
 ## Voyages
 

--- a/docs/model/catalog.md
+++ b/docs/model/catalog.md
@@ -86,11 +86,11 @@ Trois tables portent une `position` : les statuts et les kits dans leur foyer, l
 
 `django-ordered-model` le tient, comme `acts_as_list` en Rails. `order_with_respect_to` limite la numérotation au foyer ou au kit, si bien que deux foyers ont chacun leurs positions à partir de zéro.
 
-Le comportement à connaître avant d'écrire les routes de réordonnancement :
+Le comportement à connaître de la bibliothèque :
 
 - la position est attribuée à la création, à la fin de son groupe, et le champ n'est pas modifiable dans un formulaire (`editable=False`) ;
 - une suppression referme le trou : les positions suivantes descendent d'un cran, y compris quand la ligne part en cascade avec son foyer ou son kit, parce que l'app `ordered_model` branche un récepteur `post_delete` sur chaque modèle ordonné — d'où sa présence dans `INSTALLED_APPS`, qui ne sert pas qu'à l'admin ;
-- `up()`, `down()`, `to()` et `swap()` déplacent une ligne, chacun en plusieurs écritures ; une route de réordonnancement les appelle dans une transaction ;
+- `up()`, `down()`, `to()` et `swap()` déplacent une ligne, chacun en plusieurs écritures ; le `PATCH` qui réordonne les appelle dans une transaction ;
 - `model_bakery` remplit `position` d'une valeur au hasard au lieu de laisser `save()` l'attribuer, malgré `editable=False` : les objets ordonnés se créent avec `objects.create`, comme le fait `seed`, sinon l'ordre est celui du tirage ;
 - changer le foyer d'un statut ou le kit d'une ligne le renumérote dans son nouveau groupe et referme le trou laissé dans l'ancien, ce qui est le bon comportement mais reste une écriture large derrière un `save()` d'apparence anodine.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1879,6 +1879,8 @@ components:
           maxLength: 100
     PatchedItemStatusUpdate:
       type: object
+      description: A position moves the entry to that rank, the rest of its group
+        shifting to make room.
       properties:
         name:
           type: string
@@ -1899,6 +1901,8 @@ components:
             * `not_started` - Not started
             * `in_progress` - In progress
             * `done` - Done
+        position:
+          type: integer
         is_default:
           type: boolean
           description: Whether a new line gets this status, true for one status of
@@ -1915,6 +1919,8 @@ components:
           description: Optional details telling apart two entries that share a name.
     PatchedKitItemUpdate:
       type: object
+      description: A position moves the entry to that rank, the rest of its group
+        shifting to make room.
       properties:
         item_type:
           type: integer
@@ -1930,8 +1936,12 @@ components:
           type: string
           description: Free reminder carried to the trip, such as the warm one.
           maxLength: 200
+        position:
+          type: integer
     PatchedKitUpdate:
       type: object
+      description: A position moves the entry to that rank, the rest of its group
+        shifting to make room.
       properties:
         name:
           type: string
@@ -1940,6 +1950,8 @@ components:
         description:
           type: string
           description: Optional reminder of what the block is meant to cover.
+        position:
+          type: integer
     PatchedMemberUpdate:
       type: object
       properties:

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -498,3 +498,64 @@ def test_a_status_is_deleted_in_a_household_that_started_with_none(client, house
 
     assert response.status_code == 204
     assert not ItemStatus.objects.filter(pk=spare["id"]).exists()
+
+
+def test_a_status_moves_to_the_rank_it_is_given(client, household):
+    make_status(household, "Pas prepare")
+    make_status(household, "Sorti du placard")
+    last = make_status(household, "Dans les sacs", ProgressCategory.DONE)
+
+    response = client.patch(
+        item_status_url(household, last), {"position": 0}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["position"] == 0
+    listed = client.get(item_statuses_url(household)).json()
+    assert [status["name"] for status in listed] == [
+        "Dans les sacs",
+        "Pas prepare",
+        "Sorti du placard",
+    ]
+    assert [status["position"] for status in listed] == [0, 1, 2]
+
+
+def test_a_status_does_not_move_past_the_end_of_the_list(client, household):
+    make_status(household, "Pas prepare")
+    last = make_status(household, "Dans les sacs", ProgressCategory.DONE)
+
+    response = client.patch(
+        item_status_url(household, last), {"position": 2}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    last.refresh_from_db()
+    assert last.position == 1
+
+
+def test_a_status_does_not_move_before_the_head_of_the_list(client, household):
+    make_status(household, "Pas prepare")
+    last = make_status(household, "Dans les sacs", ProgressCategory.DONE)
+
+    response = client.patch(
+        item_status_url(household, last), {"position": -1}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    last.refresh_from_db()
+    assert last.position == 1
+
+
+def test_a_status_moves_within_its_own_household_list(client, household, stranger_household):
+    make_status(stranger_household, "Pas prepare")
+    make_status(stranger_household, "Sorti du placard")
+    make_status(stranger_household, "Dans les sacs", ProgressCategory.DONE)
+    mine = make_status(household, "Pas prepare")
+
+    response = client.patch(
+        item_status_url(household, mine), {"position": 2}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    mine.refresh_from_db()
+    assert mine.position == 0

--- a/tests/test_kits_api.py
+++ b/tests/test_kits_api.py
@@ -145,18 +145,6 @@ def test_deleting_a_kit_takes_its_lines_with_it(client, household, kit, bavoir):
     assert not KitItem.objects.filter(pk=line.pk).exists()
 
 
-def test_the_position_of_a_kit_is_not_written_by_a_client(client, household, kit):
-    later = Kit.objects.create(household=household, name="Affaires de rando")
-
-    response = client.patch(
-        kit_url(household, later), {"position": 0}, content_type="application/json"
-    )
-
-    assert response.status_code == 200
-    later.refresh_from_db()
-    assert later.position == 1
-
-
 def test_the_kits_of_another_household_are_out_of_reach(client, stranger_household):
     theirs = Kit.objects.create(household=stranger_household, name="Le leur")
 
@@ -506,3 +494,89 @@ def test_a_line_of_another_kit_is_unreachable_through_our_own(client, household,
     line = KitItem.objects.create(kit=other, item_type=bavoir)
 
     assert client.get(kit_item_url(household, kit, line)).status_code == 404
+
+
+def test_a_kit_moves_to_the_rank_it_is_given(client, household):
+    Kit.objects.create(household=household, name="Sac a langer")
+    Kit.objects.create(household=household, name="Affaires de rando")
+    last = Kit.objects.create(household=household, name="Plage")
+
+    response = client.patch(
+        kit_url(household, last), {"position": 0}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["position"] == 0
+    listed = client.get(kits_url(household)).json()
+    assert [entry["name"] for entry in listed] == ["Plage", "Sac a langer", "Affaires de rando"]
+    assert [entry["position"] for entry in listed] == [0, 1, 2]
+
+
+def test_a_kit_does_not_move_past_the_end_of_the_household_list(client, household, kit):
+    last = Kit.objects.create(household=household, name="Plage")
+
+    response = client.patch(
+        kit_url(household, last), {"position": 2}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    last.refresh_from_db()
+    assert last.position == 1
+
+
+def test_a_line_moves_to_the_rank_it_is_given(client, household, kit, bavoir):
+    KitItem.objects.create(kit=kit, item_type=bavoir, note="Trousse a pharmacie")
+    KitItem.objects.create(kit=kit, item_type=bavoir, note="Gourde")
+    shoes = KitItem.objects.create(kit=kit, item_type=bavoir, note="Chaussures")
+
+    response = client.patch(
+        kit_item_url(household, kit, shoes), {"position": 0}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["position"] == 0
+    lines = client.get(kit_url(household, kit)).json()["items"]
+    assert [line["note"] for line in lines] == ["Chaussures", "Trousse a pharmacie", "Gourde"]
+    assert [line["position"] for line in lines] == [0, 1, 2]
+
+
+def test_a_line_does_not_move_past_the_end_of_its_kit(client, household, kit, bavoir):
+    KitItem.objects.create(kit=kit, item_type=bavoir)
+    last = KitItem.objects.create(kit=kit, item_type=bavoir)
+
+    response = client.patch(
+        kit_item_url(household, kit, last), {"position": 2}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    last.refresh_from_db()
+    assert last.position == 1
+
+
+def test_a_line_does_not_move_before_the_head_of_its_kit(client, household, kit, bavoir):
+    KitItem.objects.create(kit=kit, item_type=bavoir)
+    last = KitItem.objects.create(kit=kit, item_type=bavoir)
+
+    response = client.patch(
+        kit_item_url(household, kit, last), {"position": -1}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    last.refresh_from_db()
+    assert last.position == 1
+
+
+def test_a_line_moves_within_its_own_kit(client, household, kit, bavoir):
+    elsewhere = Kit.objects.create(household=household, name="Affaires de rando")
+    KitItem.objects.create(kit=elsewhere, item_type=bavoir)
+    KitItem.objects.create(kit=elsewhere, item_type=bavoir)
+    KitItem.objects.create(kit=elsewhere, item_type=bavoir)
+    mine = KitItem.objects.create(kit=kit, item_type=bavoir)
+
+    response = client.patch(
+        kit_item_url(household, kit, mine), {"position": 2}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    mine.refresh_from_db()
+    assert mine.position == 0


### PR DESCRIPTION
Closes #65

Camille a composé « affaires de rando » dans l'ordre où les choses lui venaient : la trousse à pharmacie, les chaussures, la gourde. Elle prépare pourtant dans un autre ordre — les chaussures d'abord, elles sont dans l'entrée — et sa liste ne suivait pas. Elle attrape maintenant « chaussures » et la relâche en tête du bloc : les deux autres descendent d'un cran, l'ordre tient au rechargement, et Léo, qui regarde le même bloc depuis son téléphone, voit la nouvelle liste. Le geste est le même partout : ses statuts de préparation se rangent dans l'ordre où ils se suivent, ses blocs dans l'ordre où elle les parcourt au moment de composer un voyage. Relâcher une entrée hors de la liste ne bouge rien, et l'écran le lui dit.

Les listes d'un voyage ne bougent pas encore, elles gardent l'ordre qu'elles reçoivent du bloc.

## La technique

Aucune route ajoutée : `position` devient écrivable sur les trois `PATCH` de détail qui existent déjà. Les trois sérialiseurs de mise à jour dérivent d'`OrderedModelSerializer` (`django-ordered-model`), qui sort la position des données validées, applique le reste, puis appelle `to()` sur l'instance — les voisins du groupe se décalent, le groupe étant le foyer pour un statut et un kit, le kit pour une ligne.

`editable=False` reste sur la colonne. DRF en fait un champ en lecture seule, et `get_fields()` de la librairie détecte exactement ça et le remplace par un entier écrivable : aucun modèle touché, aucune migration, `schema.dot` et `schema.png` inchangés.

`to()` écrit l'index qu'on lui donne : `999` sur un kit de trois lignes s'écrit tel quel et laisse un trou que rien ne referme. `ReorderingSerializer.validate_position` refuse ce qui sort de 0 au dernier rang, compté dans le `get_ordering_queryset()` de l'entrée déplacée — son foyer ou son kit, jamais un autre. C'est un `400`, au même titre qu'`is_default: false` : le corps est invalide, aucun état du foyer ne rendrait la demande acceptable.

Les trois `patch` passent en `@transaction.atomic`, `to()` déplaçant une ligne en plusieurs écritures ; `ItemStatusDetailView` portait déjà le décorateur pour `make_default`.

**Les déplacements concurrents ne sont pas couverts, et la librairie ne les couvre nulle part** : `to()` lit la position en Python puis émet des `UPDATE` relatifs, sans `SELECT … FOR UPDATE`, et aucune contrainte n'apparie un groupe et un rang. La transaction garde un déplacement entier, elle n'ordonne pas deux déplacements. Sur SQLite les écritures sont sérialisées et la numérotation reste une permutation ; sur PostgreSQL en `READ COMMITTED`, deux `PATCH` simultanés sur le même groupe peuvent laisser deux entrées au même rang, que rien ne répare ensuite. Un `select_for_update()` sur le groupe au début du `PATCH` fermerait le trou — l'issue tranche « pas à ce stade », je n'ai donc pas posé de verrou.

`ReorderingSerializer` porte la seule docstring du dépôt, à contre-courant du style : drf-spectacular la publie comme description des trois schémas `Patched*` d'`openapi.yaml`, et sans elle c'est celle de la librairie — quatre paragraphes sur `order_field_name` — qui y atterrit.

`docs/api/README.md` gagne une section « L'ordre » et perd les deux phrases qui annonçaient la position en lecture seule « en attendant une route de réordonnancement » ; celle des lignes de voyage reste, elle est toujours vraie. `test_the_position_of_a_kit_is_not_written_by_a_client` disparaît, la règle qu'il gardait étant celle que cette PR retire.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AG2d8J5acdEaQ96fs4Vpv5)_