### PR TITLE
Name the household and the inviter before the invitation is accepted

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -116,15 +116,23 @@ Comme pour les invitations, un foyer personnel répond `404` sur ces deux routes
 
 ## Invitations
 
-Un membre invite une adresse dans un foyer partagé, l'invité suit le lien reçu et rejoint. Les routes sont `POST` et `GET /api/households/{household_id}/invitations/`, `DELETE /api/households/{household_id}/invitations/{id}/`, et `POST /api/invitations/accept/`.
+Un membre invite une adresse dans un foyer partagé, l'invité suit le lien reçu et rejoint. Les routes sont `POST` et `GET /api/households/{household_id}/invitations/`, `DELETE /api/households/{household_id}/invitations/{id}/`, `GET /api/invitations/{token}/` et `POST /api/invitations/accept/`.
 
 Le corps de la création ne porte que l'adresse : qui l'invité sera dans le foyer se décide après, et par lui. Le raisonnement est dans [`docs/model/invitation.md`](../model/invitation.md).
 
 Inviter répond `204` sans corps, **y compris quand rien n'est créé**. Une adresse déjà titulaire d'un compte, une adresse inconnue et une adresse déjà membre du foyer donnent la même réponse au bit près : distinguer les cas ferait de la route un oracle d'énumération d'adresses.
 
-Un foyer personnel répond `404` sur ces trois routes, y compris à son propriétaire : la collection n'existe pas, il n'a pas d'autre membre possible que lui.
+Un foyer personnel répond `404` sur les trois routes portées par le foyer, y compris à son propriétaire : la collection n'existe pas, il n'a pas d'autre membre possible que lui.
 
 L'acceptation fait exception au chemin porté par le foyer, l'appelant n'étant justement pas encore membre. C'est le jeton qui porte l'autorisation, et il voyage dans le corps plutôt que dans l'URL — un secret dans un chemin se retrouve dans les journaux du serveur, l'historique du navigateur et l'en-tête `Referer`. allauth fait le même choix pour ses clés de vérification d'email et de réinitialisation.
+
+`GET /api/invitations/{token}/` nomme le foyer, la personne qui invite et la date d'expiration, sans authentification : l'invité voit où il atterrit avant de se connecter ou de créer un compte. Elle ne rend pas l'adresse invitée, que le porteur du lien n'est pas tenu d'être, et c'est pourquoi elle a son propre serializer plutôt que celui de la liste que consulte un membre du foyer. `inviter` est `null` quand le compte qui a invité a disparu depuis.
+
+**La lecture ne dépense pas le jeton** : seul `POST /api/invitations/accept/` écrit `accepted_at`. Un jeton inconnu, expiré ou déjà accepté répond `404` sans les distinguer, comme l'acceptation, et le front n'a qu'un message d'échec à écrire.
+
+Le jeton voyage ici dans le chemin, contrairement à l'acceptation : la page qui appelle cette route est celle du lien reçu, dont l'URL le porte déjà. Il finit donc dans les journaux du serveur, ce que bornent son usage unique et sa semaine de validité.
+
+La route est déclarée **après** `invitations/accept/` dans `households/urls.py` : `<str:token>` capterait `accept` s'il venait avant.
 
 Le raisonnement complet et les décisions du flux sont dans [`docs/model/invitation.md`](../model/invitation.md).
 

--- a/docs/model/invitation.md
+++ b/docs/model/invitation.md
@@ -4,7 +4,9 @@
 
 C'est le seul moment où un foyer **partagé** se peuple. Chaque compte a le sien depuis #52, mais un foyer à soi ne tient aucune des promesses du produit : préparer à plusieurs commence par inviter quelqu'un.
 
-Un membre saisit une adresse, l'invité reçoit un lien, il le suit et rejoint le foyer. S'il a déjà un compte il rejoint directement, sinon il s'inscrit et rejoint dans la foulée : l'invitation n'est jamais un cul-de-sac pour quelqu'un qui n'a pas encore de compte.
+Un membre saisit une adresse, l'invité reçoit un lien, il le suit et lit qui l'invite et dans quel foyer avant de rejoindre. S'il a déjà un compte il rejoint directement, sinon il s'inscrit et rejoint dans la foulée : l'invitation n'est jamais un cul-de-sac pour quelqu'un qui n'a pas encore de compte.
+
+**La page nomme le foyer, l'invitant et la date d'expiration avant toute connexion.** Sans eux, l'invité crée un compte sur la foi d'une URL et découvre après coup où il a atterri, au seul moment où il n'a aucun moyen de vérifier.
 
 ## La table
 
@@ -19,6 +21,8 @@ C'est aussi pour cela que le jeton n'est pas produit par un `default` sur le mod
 SHA-256 sans sel ni étirement suffit, contrairement à un mot de passe : 256 bits tirés au hasard ne s'attaquent ni par dictionnaire ni par force brute, et argon2 est fait pour les secrets à faible entropie. La recherche à l'acceptation reste une égalité exacte sur une colonne indexée.
 
 L'expiration est d'une semaine. Une invitation qui traîne dans une boîte pendant des mois est une porte ouverte que personne ne surveille.
+
+La lecture qui nomme le foyer porte le jeton dans son chemin d'URL, il entre donc dans les journaux du serveur — l'acceptation, elle, le garde dans son corps. La page qui appelle cette lecture est celle du lien reçu, dont l'URL le porte déjà ; son usage unique et sa semaine de validité bornent le reste.
 
 ## Accepter n'enlève rien
 
@@ -40,7 +44,7 @@ Ce que ça coûtait dépassait le confort qu'on croyait offrir. Une colonne à v
 
 **Accepter fait donc une seule chose : ajouter le membre.** Aucune `Person` n'est créée ni rattachée. L'invité entre dans le foyer sans y être encore quelqu'un, voit les personnes qui l'attendent, et revendique la sienne par `POST /api/households/{household_id}/persons/{id}/claim/`. Personne ne l'attendait ? Il crée la sienne puis la revendique, en deux appels, tous deux ouverts à un membre qui n'est encore personne.
 
-Il découvre alors la composition du foyer, ce que la désignation évitait. C'est un foyer qu'il vient de rejoindre sur invitation, pas un inconnu : il en verra les personnes à son premier écran de toute façon.
+Il découvre alors la composition du foyer, ce que la désignation évitait. C'est un foyer dont il a lu le nom et l'invitant avant d'accepter, pas un inconnu : il en verra les personnes à son premier écran de toute façon.
 
 Créer d'office une personne à l'arrivée reste hors de question, et c'est un problème distinct de la désignation. Le cas se voit sur un ex-membre qui revient : son retrait avait vidé le compte de sa personne sans la supprimer, et une création automatique lui en fabriquerait une seconde à côté, l'ancienne restant orpheline. L'unicité `(household, user)` ne l'attraperait pas, celle qu'il a quittée portant `user = NULL`.
 

--- a/households/serializers.py
+++ b/households/serializers.py
@@ -2,6 +2,7 @@ from django.http import Http404
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from households.memberships import display_name_of
 from households.models import Household, HouseholdMember, Invitation, Person
 
 
@@ -81,6 +82,19 @@ class InvitationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Invitation
         fields = ["id", "email", "created_at", "expires_at"]
+
+
+class InvitationPreviewSerializer(serializers.ModelSerializer):
+    household = serializers.CharField(source="household.name", read_only=True)
+    inviter = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Invitation
+        fields = ["household", "inviter", "expires_at"]
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_inviter(self, invitation):
+        return display_name_of(invitation.invited_by) if invitation.invited_by else None
 
 
 class InvitationCreateSerializer(serializers.ModelSerializer):

--- a/households/urls.py
+++ b/households/urls.py
@@ -6,6 +6,7 @@ from households.views import (
     InvitationAcceptView,
     InvitationDestroyView,
     InvitationListCreateView,
+    InvitationPreviewView,
     MemberDetailView,
     MemberListView,
     PersonClaimView,
@@ -44,4 +45,5 @@ urlpatterns = [
         name="invitation",
     ),
     path("invitations/accept/", InvitationAcceptView.as_view(), name="accept-invitation"),
+    path("invitations/<str:token>/", InvitationPreviewView.as_view(), name="preview-invitation"),
 ]

--- a/households/views.py
+++ b/households/views.py
@@ -6,7 +6,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import generics
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
@@ -25,6 +25,7 @@ from households.serializers import (
     HouseholdUpdateSerializer,
     InvitationAcceptSerializer,
     InvitationCreateSerializer,
+    InvitationPreviewSerializer,
     InvitationSerializer,
     MemberSerializer,
     MemberUpdateSerializer,
@@ -280,6 +281,17 @@ class InvitationDestroyView(SharedHouseholdScopedView, generics.DestroyAPIView):
 
     def get_queryset(self):
         return Invitation.objects.filter(household=self.household, accepted_at=None)
+
+
+class InvitationPreviewView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(responses={200: InvitationPreviewSerializer})
+    def get(self, request, token):
+        invitation = pending_invitation(token)
+        if invitation is None:
+            raise Http404
+        return Response(InvitationPreviewSerializer(invitation).data)
 
 
 class InvitationAcceptView(APIView):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1564,6 +1564,27 @@ paths:
         '403':
           description: The caller is a member of this household, but their role does
             not allow that.
+  /api/invitations/{token}/:
+    get:
+      operationId: invitations_retrieve
+      parameters:
+      - in: path
+        name: token
+        schema:
+          type: string
+        required: true
+      tags:
+      - invitations
+      security:
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationPreview'
+          description: ''
   /api/invitations/accept/:
     post:
       operationId: invitations_accept_create
@@ -1705,6 +1726,24 @@ components:
           maxLength: 254
       required:
       - email
+    InvitationPreview:
+      type: object
+      properties:
+        household:
+          type: string
+          readOnly: true
+        inviter:
+          type: string
+          nullable: true
+          readOnly: true
+        expires_at:
+          type: string
+          format: date-time
+          description: When the token stops being accepted, a week after it was created.
+      required:
+      - expires_at
+      - household
+      - inviter
     ItemStatus:
       type: object
       properties:

--- a/tests/test_invitations.py
+++ b/tests/test_invitations.py
@@ -19,6 +19,10 @@ ACCEPT_URL = "/api/invitations/accept/"
 GUEST_EMAIL = "guest@example.com"
 
 
+def preview_url(token):
+    return f"/api/invitations/{token}/"
+
+
 def token_from_last_email():
     prefix = settings.INVITATION_FRONTEND_URL.format(key="")
     return re.findall(rf"{prefix}(\S+)", mail.outbox[-1].body)[-1]
@@ -376,3 +380,81 @@ def test_a_returning_member_is_offered_the_person_they_left_behind(
     waiting.refresh_from_db()
     assert waiting.user == guest
     assert household.persons.count() == 2
+
+
+def test_a_pending_invitation_names_its_household_and_its_inviter_to_anyone_holding_the_token(
+    send_invitation, signed_in
+):
+    _, household = signed_in
+    send_invitation()
+    invitation = Invitation.objects.get()
+
+    response = Client().get(preview_url(token_from_last_email()))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "household": household.name,
+        "inviter": "Camille",
+        "expires_at": invitation.expires_at.isoformat().replace("+00:00", "Z"),
+    }
+
+
+def test_the_preview_never_names_the_invited_address(send_invitation):
+    send_invitation()
+
+    response = Client().get(preview_url(token_from_last_email()))
+
+    assert GUEST_EMAIL not in response.content.decode()
+
+
+def test_the_preview_stands_for_an_invitation_whose_inviter_left(send_invitation, member):
+    user, _ = member
+    send_invitation()
+    token = token_from_last_email()
+    user.delete()
+
+    response = Client().get(preview_url(token))
+
+    assert response.status_code == 200
+    assert response.json()["inviter"] is None
+
+
+def test_reading_an_invitation_does_not_spend_its_token(send_invitation, guest):
+    send_invitation()
+    token = token_from_last_email()
+
+    Client().get(preview_url(token))
+
+    assert Invitation.objects.get().accepted_at is None
+    accepted = signed_in_client(guest).post(
+        ACCEPT_URL, {"token": token}, content_type="application/json"
+    )
+    assert accepted.status_code == 200
+
+
+def test_an_accepted_invitation_is_no_longer_readable(send_invitation, guest):
+    send_invitation()
+    token = token_from_last_email()
+    signed_in_client(guest).post(ACCEPT_URL, {"token": token}, content_type="application/json")
+
+    assert Client().get(preview_url(token)).status_code == 404
+
+
+def test_reading_an_unknown_or_expired_invitation_is_refused(send_invitation):
+    send_invitation()
+    token = token_from_last_email()
+    invitation = Invitation.objects.get()
+    invitation.expires_at = timezone.now() - datetime.timedelta(seconds=1)
+    invitation.save()
+
+    assert Client().get(preview_url("a-token-nobody-issued")).status_code == 404
+    assert Client().get(preview_url(token)).status_code == 404
+
+
+def test_the_preview_route_leaves_the_acceptance_route_alone(guest):
+    client = signed_in_client(guest)
+
+    accepted = client.post(ACCEPT_URL, {"token": "any"}, content_type="application/json")
+
+    assert client.get(preview_url("accept")).status_code == 405
+    assert accepted.status_code == 404


### PR DESCRIPTION
Closes #89

`GET /api/invitations/<token>/`, `AllowAny`, rend le nom du foyer, le nom d'affichage de l'invitant et `expires_at`. Un jeton inconnu, expiré ou déjà accepté répond `404` sans les distinguer, et la lecture n'écrit pas `accepted_at`.

L'issue écrit le chemin `GET /api/households/invitations/<token>/` tout en le plaçant « à côté de `invitations/accept/` ». Les deux ne peuvent pas être vrais : `invitations/accept/` est enregistré sans préfixe `households/`. C'est `/api/invitations/<token>/` qui est livré, déclaré après `invitations/accept/` pour que le chemin littéral gagne sur `<str:token>` — un test tient les deux bouts.

L'issue justifie le jeton dans le chemin « comme les clés d'allauth ». C'est faux, et `docs/api/README.md` disait déjà l'inverse : allauth passe sa clé de vérification dans le corps, ce que l'acceptation a repris. La doc porte donc la vraie raison — l'URL de la page qui appelle cette route porte déjà le jeton — à côté de la règle qu'elle contredit.

Hors périmètre de l'issue : `Invitation.invited_by` est vidé plutôt que cascadé quand l'invitant disparaît, donc `display_name_of` y recevrait `None` et la route rendrait `500` sur un état que le modèle prévoit. `inviter` vaut `null` dans ce cas.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AG2d8J5acdEaQ96fs4Vpv5)_