### PR TITLE
Open position for writing on a trip line

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -250,7 +250,7 @@ La réponse porte aussi `Cache-Control: no-cache`. Sans en-tête de fraîcheur, 
 
 Le calcul se fait dans la vue, après `get_queryset()`, et non par le décorateur `condition` de Django : sa fonction d'empreinte ne reçoit que les morceaux de l'URL, elle devrait donc retrouver le voyage et réappliquer le cloisonnement par foyer elle-même — c'est-à-dire refaire ce que `get_queryset()` fait déjà, en laissant deux endroits qui doivent rester d'accord sur qui a le droit de voir quoi. Le cloisonnement passe avant l'empreinte : un voyage qui n'est pas celui de l'appelant répond `404`, jamais `304`.
 
-**Le piège à connaître est le réordonnancement.** `position` n'est pas exposée par le `PATCH` d'une ligne, les lignes d'un voyage ne se réordonnent donc pas encore ; le jour où elles le feront, django-ordered-model décalera les rangs par un `update()` de queryset, qui ne déclenche pas `auto_now` et laisserait l'empreinte immobile sur un voyage pourtant réordonné.
+**Le réordonnancement déplace l'empreinte**, et c'est le `to()` de django-ordered-model qui le garantit : il décale les voisins par un `update()` de queryset, qui ne déclenche pas `auto_now`, mais il termine par un `save()` sur la ligne déplacée, donc horodatée. Une empreinte fondée sur `MAX(updated_at)` avance dès qu'une seule ligne est horodatée : que les voisins décalés ne le soient pas est sans conséquence.
 
 **Le sondage multiplie les lectures concurrentes**, d'où les options SQLite de `settings.py` : `journal_mode=WAL` pour qu'une écriture ne bloque plus les lecteurs, et `transaction_mode=IMMEDIATE` pour qu'une transaction qui lit puis écrit prenne son verrou à l'ouverture et fasse la queue au lieu de rendre `database is locked`.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2129,6 +2129,8 @@ components:
           maxLength: 100
     PatchedTripItemUpdate:
       type: object
+      description: A position moves the entry to that rank, the rest of its group
+        shifting to make room.
       properties:
         item_type:
           type: integer
@@ -2141,6 +2143,8 @@ components:
           minimum: 1
           description: How many of the thing to pack, such as five t-shirts.
         status:
+          type: integer
+        position:
           type: integer
     PatchedTripUpdate:
       type: object

--- a/tests/test_trips_api.py
+++ b/tests/test_trips_api.py
@@ -905,6 +905,72 @@ def test_the_tags_of_a_trip_cost_the_same_whatever_the_number_of_lines(
         client.get(items_url(household, trip))
 
 
+def packing_order(household, trip, tshirt, to_pack):
+    for name in ["Creme solaire", "Passeports"]:
+        TripItem.objects.create(
+            trip=trip,
+            item_type=ItemType.objects.create(household=household, name=name),
+            status=to_pack,
+        )
+    return TripItem.objects.create(trip=trip, item_type=tshirt, status=to_pack)
+
+
+def test_a_line_moves_to_the_rank_it_is_given(client, household, trip, tshirt, to_pack):
+    last = packing_order(household, trip, tshirt, to_pack)
+
+    response = client.patch(
+        item_url(household, trip, last), {"position": 0}, content_type="application/json"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["position"] == 0
+    listed = client.get(items_url(household, trip)).json()
+    assert [line["item_type"]["name"] for line in listed] == [
+        "T-shirt",
+        "Creme solaire",
+        "Passeports",
+    ]
+    assert [line["position"] for line in listed] == [0, 1, 2]
+
+
+def test_a_line_does_not_move_past_the_end_of_its_trip(client, household, trip, tshirt, to_pack):
+    last = packing_order(household, trip, tshirt, to_pack)
+
+    response = client.patch(
+        item_url(household, trip, last), {"position": 3}, content_type="application/json"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["position"] == ["Give a position from 0 to 2."]
+    last.refresh_from_db()
+    assert last.position == 2
+
+
+def test_a_line_of_a_trip_of_another_household_does_not_move(client, stranger_household):
+    theirs = Trip.objects.create(household=stranger_household, name="Le leur", date="2026-07-14")
+    status = ItemStatus.objects.create(
+        household=stranger_household, name="Le leur", color="#7b8189"
+    )
+    TripItem.objects.create(
+        trip=theirs,
+        item_type=ItemType.objects.create(household=stranger_household, name="Le premier"),
+        status=status,
+    )
+    line = TripItem.objects.create(
+        trip=theirs,
+        item_type=ItemType.objects.create(household=stranger_household, name="Le second"),
+        status=status,
+    )
+
+    response = client.patch(
+        item_url(stranger_household, theirs, line), {"position": 0}, content_type="application/json"
+    )
+
+    assert response.status_code == 404
+    line.refresh_from_db()
+    assert line.position == 1
+
+
 def fingerprint_of(client, household, trip):
     return client.get(items_url(household, trip)).headers["ETag"]
 
@@ -1013,6 +1079,15 @@ def test_renaming_an_item_type_onto_another_moves_the_fingerprint_of_the_absorbe
     client.patch(
         item_type_url(household, tshirt), {"name": "Maillot"}, content_type="application/json"
     )
+
+    assert fingerprint_of(client, household, trip) != held
+
+
+def test_reordering_a_line_moves_the_fingerprint(client, household, trip, tshirt, to_pack):
+    last = packing_order(household, trip, tshirt, to_pack)
+    held = fingerprint_of(client, household, trip)
+
+    client.patch(item_url(household, trip, last), {"position": 0}, content_type="application/json")
 
     assert fingerprint_of(client, household, trip) != held
 

--- a/trips/serializers.py
+++ b/trips/serializers.py
@@ -3,7 +3,12 @@ from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from catalog.serializers import ItemStatusSerializer, ItemTypeSerializer, KitSerializer
+from catalog.serializers import (
+    ItemStatusSerializer,
+    ItemTypeSerializer,
+    KitSerializer,
+    ReorderingSerializer,
+)
 from households.serializers import HouseholdScopedRelation, PersonSerializer
 from trips.models import Trip, TripItem, TripParticipant
 
@@ -50,14 +55,14 @@ class TripItemCreateSerializer(serializers.ModelSerializer):
         fields = ["item_type", "person", "quantity", "status"]
 
 
-class TripItemUpdateSerializer(serializers.ModelSerializer):
+class TripItemUpdateSerializer(ReorderingSerializer):
     item_type = HouseholdScopedRelation("item_types", required=False)
     person = HouseholdScopedRelation("persons", required=False, allow_null=True)
     status = HouseholdScopedRelation("item_statuses", required=False)
 
     class Meta:
         model = TripItem
-        fields = ["item_type", "person", "quantity", "status"]
+        fields = ["item_type", "person", "quantity", "status", "position"]
 
 
 class TripSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Closes #99

`TripItemUpdateSerializer` dérive de `ReorderingSerializer` et expose `position`, comme `KitItemUpdateSerializer` le fait déjà côté catalogue. Le modèle était prêt — `TripItem` est un `OrderedModelBase` cadré sur son voyage — donc pas de migration.

## Une phrase de la documentation était fausse, et ce changement la rend actuelle

`docs/api/README.md` annonçait, sous le titre « Le piège à connaître est le réordonnancement », que le jour où les lignes se réordonneraient, django-ordered-model décalerait les rangs par un `update()` de queryset et laisserait l'empreinte `ETag` immobile sur un voyage pourtant réordonné.

**C'est faux.** `OrderedModelBase.to()` décale bien les voisins par un `update()`, donc sans `auto_now` — mais il termine par un `save()` sur la ligne déplacée, qui est donc horodatée. Une empreinte fondée sur `MAX(updated_at)` avance dès qu'une seule ligne l'est ; que les voisins ne le soient pas est sans conséquence.

Constaté à l'exécution avant d'être écrit : sur trois lignes, après `lines[2].to(0)`, seule la ligne déplacée voit son `updated_at` changer, les deux voisines passent de 0,1 à 1,2 avec leur horodatage d'origine.

Le paragraphe dit maintenant ce qui est vrai, et un test le tient — `test_reordering_a_line_moves_the_fingerprint`, placé avec les autres tests d'empreinte. C'est lui qui prouve que les autres appareils verront le nouvel ordre quand AxineTeam/tout-pris-front#60 sondera cette route.

## Un détail relevé qui ne change rien ici

`OrderedModelSerializer.update()` appelle `super().update()` avant `instance.to(order)`, et `ModelSerializer.update()` fait un `save()` inconditionnel : un `PATCH` portant la seule `position` horodate donc la ligne deux fois. Sans effet visible, et la documentation s'appuie sur le `save()` de `to()`, qui est le garant côté modèle et vaut aussi hors sérialiseur.

## Ce que le front en fera

Le glisser-déposer de l'écran d'un kit devient possible sur l'écran d'un voyage, avec la mécanique de `KitLines.drop()` : un `PATCH position` par ligne dont le rang change. La position reste portée par la ligne — objet et personne — et le regroupement visuel par objet reste une affaire de front.

AxineTeam/tout-pris-front#63 écrit encore que les lignes d'un voyage ne se réordonnent pas ; son étape 3 est à mettre à jour une fois ceci mergé.

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjjkwzVo7AKMAbQFRbg9f)_