### PR TITLE
Create a line at the head of its object rather than at the end

### DIFF
--- a/catalog/ordering.py
+++ b/catalog/ordering.py
@@ -1,0 +1,11 @@
+def move_to_top_of_its_object(line):
+    first_of_its_object = (
+        line.get_ordering_queryset()
+        .filter(item_type_id=line.item_type_id)
+        .exclude(pk=line.pk)
+        .first()
+    )
+    if first_of_its_object is None:
+        line.top()
+    else:
+        line.above(first_of_its_object)

--- a/catalog/views.py
+++ b/catalog/views.py
@@ -6,6 +6,7 @@ from rest_framework import generics
 from rest_framework.response import Response
 
 from catalog.item_types import matching_item_type, rename_item_type
+from catalog.ordering import move_to_top_of_its_object
 from catalog.serializers import (
     ItemStatusCreateSerializer,
     ItemStatusSerializer,
@@ -204,7 +205,9 @@ class KitItemListCreateView(KitScopedView, generics.ListCreateAPIView):
         kit = self.kit
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        line = serializer.save(kit=kit)
+        with transaction.atomic():
+            line = serializer.save(kit=kit)
+            move_to_top_of_its_object(line)
         return Response(KitItemSerializer(line).data, status=201)
 
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -180,7 +180,11 @@ La personne est facultative — une ligne sans personne est pour tout le foyer �
 
 ## L'ordre
 
-Un statut, un kit et une ligne de kit portent une `position` dans leur groupe — le foyer pour les deux premiers, le kit pour la troisième. Elle est attribuée à la fin du groupe à la création, et **l'envoyer dans le `PATCH` de la ressource la déplace à ce rang**, les autres se décalant pour lui faire la place. C'est le glisser-déposer du front, transcrit tel quel : il relâche une entrée à un rang, il envoie ce rang.
+Un statut, un kit, une ligne de kit et une ligne de voyage portent une `position` dans leur groupe — le foyer pour les deux premiers, le kit et le voyage pour les deux autres. **L'envoyer dans le `PATCH` de la ressource la déplace à ce rang**, les autres se décalant pour lui faire la place. C'est le glisser-déposer du front, transcrit tel quel : il relâche une entrée à un rang, il envoie ce rang.
+
+**Un statut et un kit naissent à la fin de leur groupe, une ligne naît en tête de son objet.** Ce qu'on vient d'ajouter est ce qu'on veut relire, et une liste de préparation se lit du haut. La ligne ne prend pas la position 0 mais celle de la première ligne du même objet : le front classe les cartes d'après la première ligne de chaque objet, et ajouter une personne sur un objet déjà présent ferait sinon remonter tout l'objet alors que rien n'est arrivé dans la liste. Un objet qui n'a encore aucune ligne n'en a pas de première, sa ligne part donc en tête de la collection.
+
+**Instancier un kit ne passe pas par là** et écrit ses lignes à la suite : chacune passant devant la précédente, le kit arriverait à l'envers.
 
 **Il n'y a pas de route de réordonnancement séparée.** Déplacer une entrée est une modification comme une autre, et une route dédiée ferait un second chemin d'écriture sur la même ressource, avec son cloisonnement et sa résolution de foyer à réécrire.
 
@@ -228,7 +232,7 @@ La lecture d'une ligne coûte donc le même nombre de requêtes quel qu'en soit 
 
 **`POST /api/households/{household_id}/trips/{trip_id}/duplicate/` crée un voyage à partir d'un autre** et répond `201` avec le voyage complet, participants et lignes développés comme le voyage à l'unité. `name` et `date` sont **obligatoires** : l'API ne suffixe aucun nom et ne devine aucune date, la boîte de dialogue du front préremplit les deux. Les règles de la copie sont dans [`docs/model/trips.md`](../model/trips.md), et elles vivent dans `trips/preparation.py` à côté de l'instanciation d'un kit — la vue reçoit, valide, délègue. Un foyer sans aucun statut répond `409` et ne crée rien, pour la même raison qu'il ne peut pas instancier de kit.
 
-Retirer un participant ne touche pas les lignes préparées pour lui : elles restent, et c'est à l'interface de les montrer. `position` est en lecture seule, attribuée à la fin du voyage à la création et reprise de l'ordre du kit à l'instanciation.
+Retirer un participant ne touche pas les lignes préparées pour lui : elles restent, et c'est à l'interface de les montrer. `position` suit les règles de la section « L'ordre », et une ligne instanciée depuis un kit reprend l'ordre du kit.
 
 ## Requêtes conditionnelles
 

--- a/tests/test_kits_api.py
+++ b/tests/test_kits_api.py
@@ -215,20 +215,53 @@ def test_the_lines_of_a_kit_are_listed_in_preparation_order(client, household, k
     assert [line["position"] for line in listed] == [0, 1]
 
 
-def test_adding_a_line_to_a_kit_appends_it(client, household, kit, bavoir):
-    louis = Person.objects.create(household=household, name="Louis")
+def test_a_new_object_added_to_a_kit_lands_on_top(client, household, kit, bavoir):
+    gourde = ItemType.objects.create(household=household, name="Gourde")
+    chapeau = ItemType.objects.create(household=household, name="Chapeau")
     KitItem.objects.create(kit=kit, item_type=bavoir)
+    KitItem.objects.create(kit=kit, item_type=gourde)
 
     response = client.post(
         kit_items_url(household, kit),
-        {"item_type": bavoir.pk, "person": louis.pk, "quantity": 5},
+        {"item_type": chapeau.pk},
         content_type="application/json",
     )
 
     assert response.status_code == 201
-    assert response.json()["item_type"] == {"id": bavoir.pk, "name": "Bavoir", "description": ""}
+    assert response.json()["position"] == 0
+    listed = client.get(kit_items_url(household, kit)).json()
+    assert [line["item_type"]["name"] for line in listed] == ["Chapeau", "Bavoir", "Gourde"]
+    assert [line["position"] for line in listed] == [0, 1, 2]
+
+
+def test_adding_a_person_on_an_object_of_a_kit_leaves_that_object_where_it_was(
+    client, household, kit, bavoir
+):
+    louis = Person.objects.create(household=household, name="Louis")
+    gourde = ItemType.objects.create(household=household, name="Gourde")
+    chaussures = ItemType.objects.create(household=household, name="Chaussures")
+    KitItem.objects.create(kit=kit, item_type=bavoir)
+    KitItem.objects.create(kit=kit, item_type=gourde)
+    KitItem.objects.create(kit=kit, item_type=chaussures)
+
+    response = client.post(
+        kit_items_url(household, kit),
+        {"item_type": chaussures.pk, "person": louis.pk, "quantity": 5},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201
+    assert response.json()["item_type"] == {
+        "id": chaussures.pk,
+        "name": "Chaussures",
+        "description": "",
+    }
     assert response.json()["person"]["name"] == "Louis"
-    assert response.json()["position"] == 1
+    assert response.json()["position"] == 2
+    listed = client.get(kit_items_url(household, kit)).json()
+    assert [
+        (line["item_type"]["name"], line["person"] and line["person"]["name"]) for line in listed
+    ] == [("Bavoir", None), ("Gourde", None), ("Chaussures", "Louis"), ("Chaussures", None)]
     assert kit.items.filter(quantity=5, person=louis).exists()
 
 

--- a/tests/test_trips_api.py
+++ b/tests/test_trips_api.py
@@ -176,7 +176,9 @@ def test_a_trip_without_a_departure_date_is_refused(client, household):
 def test_creating_a_trip_embarks_its_people_and_its_kits_in_one_call(
     client, household, leo, tshirt, to_pack, rando
 ):
+    creme = ItemType.objects.create(household=household, name="Creme solaire")
     KitItem.objects.create(kit=rando, item_type=tshirt, person=leo, quantity=5)
+    KitItem.objects.create(kit=rando, item_type=creme)
 
     response = client.post(
         trips_url(household),
@@ -192,7 +194,7 @@ def test_creating_a_trip_embarks_its_people_and_its_kits_in_one_call(
     assert response.status_code == 201
     body = response.json()
     assert [entry["person"]["name"] for entry in body["participants"]] == ["Leo"]
-    assert [entry["item_type"]["name"] for entry in body["items"]] == ["T-shirt"]
+    assert [entry["item_type"]["name"] for entry in body["items"]] == ["T-shirt", "Creme solaire"]
     assert body["items"][0]["person"]["name"] == "Leo"
     assert body["items"][0]["quantity"] == 5
 
@@ -593,6 +595,51 @@ def test_a_line_added_by_hand_starts_on_the_default_status_of_the_household(
     assert response.json()["quantity"] == 1
     assert response.json()["person"] is None
     assert response.json()["kits"] == []
+
+
+def test_a_new_object_added_to_a_trip_lands_on_top(client, household, trip, tshirt, to_pack):
+    creme = ItemType.objects.create(household=household, name="Creme solaire")
+    passeports = ItemType.objects.create(household=household, name="Passeports")
+    TripItem.objects.create(trip=trip, item_type=tshirt, status=to_pack)
+    TripItem.objects.create(trip=trip, item_type=creme, status=to_pack)
+
+    response = client.post(
+        items_url(household, trip), {"item_type": passeports.pk}, content_type="application/json"
+    )
+
+    assert response.status_code == 201
+    assert response.json()["position"] == 0
+    listed = client.get(items_url(household, trip)).json()
+    assert [entry["item_type"]["name"] for entry in listed] == [
+        "Passeports",
+        "T-shirt",
+        "Creme solaire",
+    ]
+    assert [entry["position"] for entry in listed] == [0, 1, 2]
+
+
+def test_adding_a_person_on_an_object_of_a_trip_leaves_that_object_where_it_was(
+    client, household, trip, leo, tshirt, to_pack
+):
+    creme = ItemType.objects.create(household=household, name="Creme solaire")
+    duvet = ItemType.objects.create(household=household, name="Duvet")
+    TripItem.objects.create(trip=trip, item_type=tshirt, status=to_pack)
+    TripItem.objects.create(trip=trip, item_type=creme, status=to_pack)
+    TripItem.objects.create(trip=trip, item_type=duvet, status=to_pack)
+
+    response = client.post(
+        items_url(household, trip),
+        {"item_type": duvet.pk, "person": leo.pk},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201
+    assert response.json()["position"] == 2
+    listed = client.get(items_url(household, trip)).json()
+    assert [
+        (entry["item_type"]["name"], entry["person"] and entry["person"]["name"])
+        for entry in listed
+    ] == [("T-shirt", None), ("Creme solaire", None), ("Duvet", "Leo"), ("Duvet", None)]
 
 
 def test_a_line_is_added_on_a_chosen_status_for_a_chosen_person(
@@ -1171,6 +1218,25 @@ def test_choosing_a_kit_copies_its_lines_into_the_trip_in_its_own_order(
         {"id": rando.pk, "name": "Affaires de rando", "description": "", "position": 0}
     ]
     assert [line.position for line in trip.items.all()] == [0, 1]
+
+
+def test_choosing_a_kit_keeps_its_own_order_behind_the_lines_already_there(
+    client, household, trip, tshirt, to_pack, rando
+):
+    masque = ItemType.objects.create(household=household, name="Masque")
+    palmes = ItemType.objects.create(household=household, name="Palmes")
+    KitItem.objects.create(kit=rando, item_type=masque)
+    KitItem.objects.create(kit=rando, item_type=palmes)
+    TripItem.objects.create(trip=trip, item_type=tshirt, status=to_pack)
+
+    response = client.post(
+        kits_url(household, trip), {"kit": rando.pk}, content_type="application/json"
+    )
+
+    assert response.status_code == 201
+    listed = client.get(items_url(household, trip)).json()
+    assert [entry["item_type"]["name"] for entry in listed] == ["T-shirt", "Masque", "Palmes"]
+    assert [entry["position"] for entry in listed] == [0, 1, 2]
 
 
 def test_choosing_a_kit_ignores_the_lines_of_someone_who_does_not_go(

--- a/trips/views.py
+++ b/trips/views.py
@@ -14,6 +14,7 @@ from rest_framework import generics, serializers
 from rest_framework.fields import empty
 from rest_framework.response import Response
 
+from catalog.ordering import move_to_top_of_its_object
 from households.views import FORBIDDEN, HouseholdScopedView
 from tout_pris.exceptions import Conflict
 from trips.models import TripParticipant
@@ -250,6 +251,7 @@ class TripItemListCreateView(TripScopedView, generics.ListCreateAPIView):
         try:
             with transaction.atomic():
                 line = serializer.save(trip=trip, status=status)
+                move_to_top_of_its_object(line)
         except IntegrityError:
             raise Conflict(ALREADY_PACKED) from None
         return Response(TripItemSerializer(self.get_queryset().get(pk=line.pk)).data, status=201)


### PR DESCRIPTION
Closes #102

`KitItem` et `TripItem` sont des `OrderedModelBase` : une ligne créée prenait le rang suivant, donc le bas de la liste, alors que c'est celle qu'on veut relire. Aucun des deux serializers de création n'expose `position`, le client ne pouvait donc pas corriger sans une seconde requête.

Les deux vues de création posent maintenant la ligne juste après l'avoir enregistrée. Si la collection ne porte aucune autre ligne sur cet objet, la ligne va en tête de la collection. Si elle en porte une, la ligne va **au-dessus de la première ligne de cet objet** et non en position absolue 0 : le front classe les cartes d'après la première ligne de chaque objet, et le rang 0 ferait remonter tout l'objet en tête de l'écran alors qu'on a seulement ajouté une personne sur un objet déjà là. `above()` met la ligne en tête de son groupe et laisse le groupe où il est.

La règle reste dans les vues. `instantiate_kit` écrit ses lignes directement par `TripItem.objects.create()` ; les faire passer par le même helper mettrait chaque ligne devant la précédente et livrerait un kit `[Masque, Palmes]` en `[Palmes, Masque]`.

`docs/api/README.md` disait la position d'une ligne de voyage en lecture seule, ce qui n'est plus vrai depuis #100 ; la section « L'ordre » la reprend avec les autres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AG2d8J5acdEaQ96fs4Vpv5